### PR TITLE
Make stripe settings synchronous

### DIFF
--- a/stripe/example/lib/main.dart
+++ b/stripe/example/lib/main.dart
@@ -13,22 +13,18 @@ import 'package:stripe_example/screens/home_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  Stripe.instance.checkApplePaySupport();
+  Stripe.publishableKey = stripePublishableKey;
   runApp(App());
 }
 
 class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return StripeProvider(
-      publishableKey: stripePublishableKey,
-      merchantIdentifier: 'Hello',
-      child: DismissFocusOverlay(
-        child: MaterialApp(
-          //  theme: ThemeData.light(),
-          theme: ThemeData.dark(),
-          home: MyApp(),
-        ),
+    return DismissFocusOverlay(
+      child: MaterialApp(
+        //  theme: ThemeData.light(),
+        theme: ThemeData.dark(),
+        home: MyApp(),
       ),
     );
   }


### PR DESCRIPTION
Stripe settings can be edited as:

```dart
 Stripe.publishableKey = stripePublishableKey;
 Stripe.merchantIdentifier = '';
 Stripe.stripeAccountId = '';
```

And will be updated if needed in native before the next call to another Stripe method