### PR TITLE
Fix intent error according to Stripe RN plugin

### DIFF
--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/StripeSdkModule.kt
@@ -41,7 +41,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext, cardFieldManager: S
   private var confirmPaymentClientSecret: String? = null
 
   private val mActivityEventListener = object : BaseActivityEventListener() {
-    override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent) {
+    override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
       stripe.onSetupResult(requestCode, data, object : ApiResultCallback<SetupIntentResult> {
         override fun onSuccess(result: SetupIntentResult) {
           val setupIntent = result.intent


### PR DESCRIPTION
Fixes https://github.com/flutter-stripe/flutter_stripe/issues/72

According to the latest version Intent is nullable


https://github.com/stripe/stripe-react-native/blob/7b02f143f5d72fcd14d9acd8ab93570f2853afed/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt#L46