### PR TITLE
Add PaymentMethodParams.fpx

### DIFF
--- a/packages/stripe_platform_interface/lib/src/models/payment_methods.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_methods.dart
@@ -326,6 +326,12 @@ class PaymentMethodParams with _$PaymentMethodParams {
     required BillingDetails billingDetails,
   }) = _PaymentMethodParamsP24;
 
+  @JsonSerializable(explicitToJson: true)
+  @FreezedUnionValue('Fpx')
+  const factory PaymentMethodParams.fpx({
+    required bool testOfflineBank,
+  }) = _PaymentMethodParamsFpx;
+
   factory PaymentMethodParams.fromJson(Map<String, dynamic> json) =>
       _$PaymentMethodParamsFromJson(json);
 }

--- a/packages/stripe_platform_interface/lib/src/models/payment_methods.freezed.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_methods.freezed.dart
@@ -2520,6 +2520,8 @@ PaymentMethodParams _$PaymentMethodParamsFromJson(Map<String, dynamic> json) {
       return _PaymentMethodParamsPay.fromJson(json);
     case 'P24':
       return _PaymentMethodParamsP24.fromJson(json);
+    case 'Fpx':
+      return _PaymentMethodParamsFpx.fromJson(json);
 
     default:
       throw FallThroughError();
@@ -2599,6 +2601,12 @@ class _$PaymentMethodParamsTearOff {
     );
   }
 
+  _PaymentMethodParamsFpx fpx({required bool testOfflineBank}) {
+    return _PaymentMethodParamsFpx(
+      testOfflineBank: testOfflineBank,
+    );
+  }
+
   PaymentMethodParams fromJson(Map<String, Object> json) {
     return PaymentMethodParams.fromJson(json);
   }
@@ -2627,6 +2635,7 @@ mixin _$PaymentMethodParams {
     required TResult Function(BillingDetails billingDetails) eps,
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -2644,6 +2653,7 @@ mixin _$PaymentMethodParams {
     TResult Function(BillingDetails billingDetails)? eps,
     TResult Function(BillingDetails billingDetails)? grabPay,
     TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -2662,6 +2672,7 @@ mixin _$PaymentMethodParams {
     required TResult Function(_PaymentMethodParamsEps value) eps,
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -2677,6 +2688,7 @@ mixin _$PaymentMethodParams {
     TResult Function(_PaymentMethodParamsEps value)? eps,
     TResult Function(_PaymentMethodParamsPay value)? grabPay,
     TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -2817,6 +2829,7 @@ class _$_PaymentMethodParamsCard implements _PaymentMethodParamsCard {
     required TResult Function(BillingDetails billingDetails) eps,
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
   }) {
     return card(setupFutureUsage, billingDetails);
   }
@@ -2837,6 +2850,7 @@ class _$_PaymentMethodParamsCard implements _PaymentMethodParamsCard {
     TResult Function(BillingDetails billingDetails)? eps,
     TResult Function(BillingDetails billingDetails)? grabPay,
     TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
     required TResult orElse(),
   }) {
     if (card != null) {
@@ -2861,6 +2875,7 @@ class _$_PaymentMethodParamsCard implements _PaymentMethodParamsCard {
     required TResult Function(_PaymentMethodParamsEps value) eps,
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
   }) {
     return card(this);
   }
@@ -2879,6 +2894,7 @@ class _$_PaymentMethodParamsCard implements _PaymentMethodParamsCard {
     TResult Function(_PaymentMethodParamsEps value)? eps,
     TResult Function(_PaymentMethodParamsPay value)? grabPay,
     TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
     required TResult orElse(),
   }) {
     if (card != null) {
@@ -3014,6 +3030,7 @@ class _$_PaymentMethodParamsCardWithToken
     required TResult Function(BillingDetails billingDetails) eps,
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
   }) {
     return cardFromToken(token, setupFutureUsage);
   }
@@ -3034,6 +3051,7 @@ class _$_PaymentMethodParamsCardWithToken
     TResult Function(BillingDetails billingDetails)? eps,
     TResult Function(BillingDetails billingDetails)? grabPay,
     TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
     required TResult orElse(),
   }) {
     if (cardFromToken != null) {
@@ -3058,6 +3076,7 @@ class _$_PaymentMethodParamsCardWithToken
     required TResult Function(_PaymentMethodParamsEps value) eps,
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
   }) {
     return cardFromToken(this);
   }
@@ -3076,6 +3095,7 @@ class _$_PaymentMethodParamsCardWithToken
     TResult Function(_PaymentMethodParamsEps value)? eps,
     TResult Function(_PaymentMethodParamsPay value)? grabPay,
     TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
     required TResult orElse(),
   }) {
     if (cardFromToken != null) {
@@ -3214,6 +3234,7 @@ class _$_PaymentMethodParamsCardWithMethodId
     required TResult Function(BillingDetails billingDetails) eps,
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
   }) {
     return cardFromMethodId(paymentMethodId, cvc);
   }
@@ -3234,6 +3255,7 @@ class _$_PaymentMethodParamsCardWithMethodId
     TResult Function(BillingDetails billingDetails)? eps,
     TResult Function(BillingDetails billingDetails)? grabPay,
     TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
     required TResult orElse(),
   }) {
     if (cardFromMethodId != null) {
@@ -3258,6 +3280,7 @@ class _$_PaymentMethodParamsCardWithMethodId
     required TResult Function(_PaymentMethodParamsEps value) eps,
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
   }) {
     return cardFromMethodId(this);
   }
@@ -3276,6 +3299,7 @@ class _$_PaymentMethodParamsCardWithMethodId
     TResult Function(_PaymentMethodParamsEps value)? eps,
     TResult Function(_PaymentMethodParamsPay value)? grabPay,
     TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
     required TResult orElse(),
   }) {
     if (cardFromMethodId != null) {
@@ -3370,6 +3394,7 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
     required TResult Function(BillingDetails billingDetails) eps,
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
   }) {
     return aliPay();
   }
@@ -3390,6 +3415,7 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
     TResult Function(BillingDetails billingDetails)? eps,
     TResult Function(BillingDetails billingDetails)? grabPay,
     TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
     required TResult orElse(),
   }) {
     if (aliPay != null) {
@@ -3414,6 +3440,7 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
     required TResult Function(_PaymentMethodParamsEps value) eps,
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
   }) {
     return aliPay(this);
   }
@@ -3432,6 +3459,7 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
     TResult Function(_PaymentMethodParamsEps value)? eps,
     TResult Function(_PaymentMethodParamsPay value)? grabPay,
     TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
     required TResult orElse(),
   }) {
     if (aliPay != null) {
@@ -3567,6 +3595,7 @@ class _$_PaymentMethodParamsIdeal implements _PaymentMethodParamsIdeal {
     required TResult Function(BillingDetails billingDetails) eps,
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
   }) {
     return ideal(billingDetails, bankName);
   }
@@ -3587,6 +3616,7 @@ class _$_PaymentMethodParamsIdeal implements _PaymentMethodParamsIdeal {
     TResult Function(BillingDetails billingDetails)? eps,
     TResult Function(BillingDetails billingDetails)? grabPay,
     TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
     required TResult orElse(),
   }) {
     if (ideal != null) {
@@ -3611,6 +3641,7 @@ class _$_PaymentMethodParamsIdeal implements _PaymentMethodParamsIdeal {
     required TResult Function(_PaymentMethodParamsEps value) eps,
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
   }) {
     return ideal(this);
   }
@@ -3629,6 +3660,7 @@ class _$_PaymentMethodParamsIdeal implements _PaymentMethodParamsIdeal {
     TResult Function(_PaymentMethodParamsEps value)? eps,
     TResult Function(_PaymentMethodParamsPay value)? grabPay,
     TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
     required TResult orElse(),
   }) {
     if (ideal != null) {
@@ -3761,6 +3793,7 @@ class _$_PaymentMethodParamsBankContact
     required TResult Function(BillingDetails billingDetails) eps,
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
   }) {
     return bankContact(billingDetails);
   }
@@ -3781,6 +3814,7 @@ class _$_PaymentMethodParamsBankContact
     TResult Function(BillingDetails billingDetails)? eps,
     TResult Function(BillingDetails billingDetails)? grabPay,
     TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
     required TResult orElse(),
   }) {
     if (bankContact != null) {
@@ -3805,6 +3839,7 @@ class _$_PaymentMethodParamsBankContact
     required TResult Function(_PaymentMethodParamsEps value) eps,
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
   }) {
     return bankContact(this);
   }
@@ -3823,6 +3858,7 @@ class _$_PaymentMethodParamsBankContact
     TResult Function(_PaymentMethodParamsEps value)? eps,
     TResult Function(_PaymentMethodParamsPay value)? grabPay,
     TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
     required TResult orElse(),
   }) {
     if (bankContact != null) {
@@ -3952,6 +3988,7 @@ class _$_PaymentMethodParamsGiroPay implements _PaymentMethodParamsGiroPay {
     required TResult Function(BillingDetails billingDetails) eps,
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
   }) {
     return giroPay(billingDetails);
   }
@@ -3972,6 +4009,7 @@ class _$_PaymentMethodParamsGiroPay implements _PaymentMethodParamsGiroPay {
     TResult Function(BillingDetails billingDetails)? eps,
     TResult Function(BillingDetails billingDetails)? grabPay,
     TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
     required TResult orElse(),
   }) {
     if (giroPay != null) {
@@ -3996,6 +4034,7 @@ class _$_PaymentMethodParamsGiroPay implements _PaymentMethodParamsGiroPay {
     required TResult Function(_PaymentMethodParamsEps value) eps,
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
   }) {
     return giroPay(this);
   }
@@ -4014,6 +4053,7 @@ class _$_PaymentMethodParamsGiroPay implements _PaymentMethodParamsGiroPay {
     TResult Function(_PaymentMethodParamsEps value)? eps,
     TResult Function(_PaymentMethodParamsPay value)? grabPay,
     TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
     required TResult orElse(),
   }) {
     if (giroPay != null) {
@@ -4139,6 +4179,7 @@ class _$_PaymentMethodParamsEps implements _PaymentMethodParamsEps {
     required TResult Function(BillingDetails billingDetails) eps,
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
   }) {
     return eps(billingDetails);
   }
@@ -4159,6 +4200,7 @@ class _$_PaymentMethodParamsEps implements _PaymentMethodParamsEps {
     TResult Function(BillingDetails billingDetails)? eps,
     TResult Function(BillingDetails billingDetails)? grabPay,
     TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
     required TResult orElse(),
   }) {
     if (eps != null) {
@@ -4183,6 +4225,7 @@ class _$_PaymentMethodParamsEps implements _PaymentMethodParamsEps {
     required TResult Function(_PaymentMethodParamsEps value) eps,
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
   }) {
     return eps(this);
   }
@@ -4201,6 +4244,7 @@ class _$_PaymentMethodParamsEps implements _PaymentMethodParamsEps {
     TResult Function(_PaymentMethodParamsEps value)? eps,
     TResult Function(_PaymentMethodParamsPay value)? grabPay,
     TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
     required TResult orElse(),
   }) {
     if (eps != null) {
@@ -4326,6 +4370,7 @@ class _$_PaymentMethodParamsPay implements _PaymentMethodParamsPay {
     required TResult Function(BillingDetails billingDetails) eps,
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
   }) {
     return grabPay(billingDetails);
   }
@@ -4346,6 +4391,7 @@ class _$_PaymentMethodParamsPay implements _PaymentMethodParamsPay {
     TResult Function(BillingDetails billingDetails)? eps,
     TResult Function(BillingDetails billingDetails)? grabPay,
     TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
     required TResult orElse(),
   }) {
     if (grabPay != null) {
@@ -4370,6 +4416,7 @@ class _$_PaymentMethodParamsPay implements _PaymentMethodParamsPay {
     required TResult Function(_PaymentMethodParamsEps value) eps,
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
   }) {
     return grabPay(this);
   }
@@ -4388,6 +4435,7 @@ class _$_PaymentMethodParamsPay implements _PaymentMethodParamsPay {
     TResult Function(_PaymentMethodParamsEps value)? eps,
     TResult Function(_PaymentMethodParamsPay value)? grabPay,
     TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
     required TResult orElse(),
   }) {
     if (grabPay != null) {
@@ -4513,6 +4561,7 @@ class _$_PaymentMethodParamsP24 implements _PaymentMethodParamsP24 {
     required TResult Function(BillingDetails billingDetails) eps,
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
   }) {
     return p24(billingDetails);
   }
@@ -4533,6 +4582,7 @@ class _$_PaymentMethodParamsP24 implements _PaymentMethodParamsP24 {
     TResult Function(BillingDetails billingDetails)? eps,
     TResult Function(BillingDetails billingDetails)? grabPay,
     TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
     required TResult orElse(),
   }) {
     if (p24 != null) {
@@ -4557,6 +4607,7 @@ class _$_PaymentMethodParamsP24 implements _PaymentMethodParamsP24 {
     required TResult Function(_PaymentMethodParamsEps value) eps,
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
   }) {
     return p24(this);
   }
@@ -4575,6 +4626,7 @@ class _$_PaymentMethodParamsP24 implements _PaymentMethodParamsP24 {
     TResult Function(_PaymentMethodParamsEps value)? eps,
     TResult Function(_PaymentMethodParamsPay value)? grabPay,
     TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
     required TResult orElse(),
   }) {
     if (p24 != null) {
@@ -4599,5 +4651,187 @@ abstract class _PaymentMethodParamsP24 implements PaymentMethodParams {
   BillingDetails get billingDetails => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   _$PaymentMethodParamsP24CopyWith<_PaymentMethodParamsP24> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$PaymentMethodParamsFpxCopyWith<$Res> {
+  factory _$PaymentMethodParamsFpxCopyWith(_PaymentMethodParamsFpx value,
+          $Res Function(_PaymentMethodParamsFpx) then) =
+      __$PaymentMethodParamsFpxCopyWithImpl<$Res>;
+  $Res call({bool testOfflineBank});
+}
+
+/// @nodoc
+class __$PaymentMethodParamsFpxCopyWithImpl<$Res>
+    extends _$PaymentMethodParamsCopyWithImpl<$Res>
+    implements _$PaymentMethodParamsFpxCopyWith<$Res> {
+  __$PaymentMethodParamsFpxCopyWithImpl(_PaymentMethodParamsFpx _value,
+      $Res Function(_PaymentMethodParamsFpx) _then)
+      : super(_value, (v) => _then(v as _PaymentMethodParamsFpx));
+
+  @override
+  _PaymentMethodParamsFpx get _value => super._value as _PaymentMethodParamsFpx;
+
+  @override
+  $Res call({
+    Object? testOfflineBank = freezed,
+  }) {
+    return _then(_PaymentMethodParamsFpx(
+      testOfflineBank: testOfflineBank == freezed
+          ? _value.testOfflineBank
+          : testOfflineBank // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+@JsonSerializable(explicitToJson: true)
+@FreezedUnionValue('Fpx')
+
+/// @nodoc
+class _$_PaymentMethodParamsFpx implements _PaymentMethodParamsFpx {
+  const _$_PaymentMethodParamsFpx({required this.testOfflineBank});
+
+  factory _$_PaymentMethodParamsFpx.fromJson(Map<String, dynamic> json) =>
+      _$_$_PaymentMethodParamsFpxFromJson(json);
+
+  @override
+  final bool testOfflineBank;
+
+  @override
+  String toString() {
+    return 'PaymentMethodParams.fpx(testOfflineBank: $testOfflineBank)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _PaymentMethodParamsFpx &&
+            (identical(other.testOfflineBank, testOfflineBank) ||
+                const DeepCollectionEquality()
+                    .equals(other.testOfflineBank, testOfflineBank)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(testOfflineBank);
+
+  @JsonKey(ignore: true)
+  @override
+  _$PaymentMethodParamsFpxCopyWith<_PaymentMethodParamsFpx> get copyWith =>
+      __$PaymentMethodParamsFpxCopyWithImpl<_PaymentMethodParamsFpx>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PaymentIntentsFutureUsage? setupFutureUsage,
+            BillingDetails? billingDetails)
+        card,
+    required TResult Function(
+            String token, PaymentIntentsFutureUsage? setupFutureUsage)
+        cardFromToken,
+    required TResult Function(String paymentMethodId, String? cvc)
+        cardFromMethodId,
+    required TResult Function() aliPay,
+    required TResult Function(BillingDetails? billingDetails, String? bankName)
+        ideal,
+    required TResult Function(BillingDetails billingDetails) bankContact,
+    required TResult Function(BillingDetails billingDetails) giroPay,
+    required TResult Function(BillingDetails billingDetails) eps,
+    required TResult Function(BillingDetails billingDetails) grabPay,
+    required TResult Function(BillingDetails billingDetails) p24,
+    required TResult Function(bool testOfflineBank) fpx,
+  }) {
+    return fpx(testOfflineBank);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PaymentIntentsFutureUsage? setupFutureUsage,
+            BillingDetails? billingDetails)?
+        card,
+    TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
+        cardFromToken,
+    TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
+    TResult Function()? aliPay,
+    TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
+    TResult Function(BillingDetails billingDetails)? bankContact,
+    TResult Function(BillingDetails billingDetails)? giroPay,
+    TResult Function(BillingDetails billingDetails)? eps,
+    TResult Function(BillingDetails billingDetails)? grabPay,
+    TResult Function(BillingDetails billingDetails)? p24,
+    TResult Function(bool testOfflineBank)? fpx,
+    required TResult orElse(),
+  }) {
+    if (fpx != null) {
+      return fpx(testOfflineBank);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_PaymentMethodParamsCard value) card,
+    required TResult Function(_PaymentMethodParamsCardWithToken value)
+        cardFromToken,
+    required TResult Function(_PaymentMethodParamsCardWithMethodId value)
+        cardFromMethodId,
+    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsIdeal value) ideal,
+    required TResult Function(_PaymentMethodParamsBankContact value)
+        bankContact,
+    required TResult Function(_PaymentMethodParamsGiroPay value) giroPay,
+    required TResult Function(_PaymentMethodParamsEps value) eps,
+    required TResult Function(_PaymentMethodParamsPay value) grabPay,
+    required TResult Function(_PaymentMethodParamsP24 value) p24,
+    required TResult Function(_PaymentMethodParamsFpx value) fpx,
+  }) {
+    return fpx(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_PaymentMethodParamsCard value)? card,
+    TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
+    TResult Function(_PaymentMethodParamsCardWithMethodId value)?
+        cardFromMethodId,
+    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsIdeal value)? ideal,
+    TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
+    TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,
+    TResult Function(_PaymentMethodParamsEps value)? eps,
+    TResult Function(_PaymentMethodParamsPay value)? grabPay,
+    TResult Function(_PaymentMethodParamsP24 value)? p24,
+    TResult Function(_PaymentMethodParamsFpx value)? fpx,
+    required TResult orElse(),
+  }) {
+    if (fpx != null) {
+      return fpx(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$_$_PaymentMethodParamsFpxToJson(this)..['type'] = 'Fpx';
+  }
+}
+
+abstract class _PaymentMethodParamsFpx implements PaymentMethodParams {
+  const factory _PaymentMethodParamsFpx({required bool testOfflineBank}) =
+      _$_PaymentMethodParamsFpx;
+
+  factory _PaymentMethodParamsFpx.fromJson(Map<String, dynamic> json) =
+      _$_PaymentMethodParamsFpx.fromJson;
+
+  bool get testOfflineBank => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  _$PaymentMethodParamsFpxCopyWith<_PaymentMethodParamsFpx> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/stripe_platform_interface/lib/src/models/payment_methods.g.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_methods.g.dart
@@ -364,3 +364,16 @@ Map<String, dynamic> _$_$_PaymentMethodParamsP24ToJson(
     <String, dynamic>{
       'billingDetails': instance.billingDetails.toJson(),
     };
+
+_$_PaymentMethodParamsFpx _$_$_PaymentMethodParamsFpxFromJson(
+    Map<String, dynamic> json) {
+  return _$_PaymentMethodParamsFpx(
+    testOfflineBank: json['testOfflineBank'] as bool,
+  );
+}
+
+Map<String, dynamic> _$_$_PaymentMethodParamsFpxToJson(
+        _$_PaymentMethodParamsFpx instance) =>
+    <String, dynamic>{
+      'testOfflineBank': instance.testOfflineBank,
+    };


### PR DESCRIPTION
FPX is a popular payment method in Malaysia.
I was in the middle of testing for FPX payment method and didn't find we have any `PaymentMethodParams` yet for FPX.

I synced the params from the React Native params here: https://github.com/stripe/stripe-react-native/blob/master/src/types/PaymentMethods.ts

Didn't have the time to sync all the Payment Method Params yet since some of the parameters are strongly typed, but I noticed there are several payment methods which are lacking implementation in params as well like:
- `OxxoParams`
- `Sofort`
- `SepaDebit`
- `AfterpayClearpay`
- `Eps`
- `AuBecsDebitParams`

(I opened #106 for the remaining missing payment methods)