### PR TITLE
Rename PaymentMethodParams.aliPay to PaymentMethodParams.alipay for better consistency

### DIFF
--- a/packages/stripe_platform_interface/lib/src/models/payment_methods.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_methods.dart
@@ -305,9 +305,8 @@ class PaymentMethodParams with _$PaymentMethodParams {
   @JsonSerializable(explicitToJson: true)
   @FreezedUnionValue('Alipay')
 
-  /// Config parameters for ali pay card payment method.
-
-  const factory PaymentMethodParams.aliPay() = _PaymentMethodParamsAli;
+  /// Config parameters for Alipay card payment method.
+  const factory PaymentMethodParams.alipay() = _PaymentMethodParamsAlipay;
 
   @JsonSerializable(explicitToJson: true)
   @FreezedUnionValue('Ideal')

--- a/packages/stripe_platform_interface/lib/src/models/payment_methods.freezed.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_methods.freezed.dart
@@ -2507,7 +2507,7 @@ PaymentMethodParams _$PaymentMethodParamsFromJson(Map<String, dynamic> json) {
     case 'CardId':
       return _PaymentMethodParamsCardWithMethodId.fromJson(json);
     case 'Alipay':
-      return _PaymentMethodParamsAli.fromJson(json);
+      return _PaymentMethodParamsAlipay.fromJson(json);
     case 'Ideal':
       return _PaymentMethodParamsIdeal.fromJson(json);
     case 'Bancontact':
@@ -2555,8 +2555,8 @@ class _$PaymentMethodParamsTearOff {
     );
   }
 
-  _PaymentMethodParamsAli aliPay() {
-    return const _PaymentMethodParamsAli();
+  _PaymentMethodParamsAlipay alipay() {
+    return const _PaymentMethodParamsAlipay();
   }
 
   _PaymentMethodParamsIdeal ideal(
@@ -2619,7 +2619,7 @@ mixin _$PaymentMethodParams {
         cardFromToken,
     required TResult Function(String paymentMethodId, String? cvc)
         cardFromMethodId,
-    required TResult Function() aliPay,
+    required TResult Function() alipay,
     required TResult Function(BillingDetails? billingDetails, String? bankName)
         ideal,
     required TResult Function(BillingDetails billingDetails) bankContact,
@@ -2637,7 +2637,7 @@ mixin _$PaymentMethodParams {
     TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
         cardFromToken,
     TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
-    TResult Function()? aliPay,
+    TResult Function()? alipay,
     TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
     TResult Function(BillingDetails billingDetails)? bankContact,
     TResult Function(BillingDetails billingDetails)? giroPay,
@@ -2654,7 +2654,7 @@ mixin _$PaymentMethodParams {
         cardFromToken,
     required TResult Function(_PaymentMethodParamsCardWithMethodId value)
         cardFromMethodId,
-    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsAlipay value) alipay,
     required TResult Function(_PaymentMethodParamsIdeal value) ideal,
     required TResult Function(_PaymentMethodParamsBankContact value)
         bankContact,
@@ -2670,7 +2670,7 @@ mixin _$PaymentMethodParams {
     TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
     TResult Function(_PaymentMethodParamsCardWithMethodId value)?
         cardFromMethodId,
-    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsAlipay value)? alipay,
     TResult Function(_PaymentMethodParamsIdeal value)? ideal,
     TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
     TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,
@@ -2813,7 +2813,7 @@ class _$_PaymentMethodParamsCard implements _PaymentMethodParamsCard {
         cardFromToken,
     required TResult Function(String paymentMethodId, String? cvc)
         cardFromMethodId,
-    required TResult Function() aliPay,
+    required TResult Function() alipay,
     required TResult Function(BillingDetails? billingDetails, String? bankName)
         ideal,
     required TResult Function(BillingDetails billingDetails) bankContact,
@@ -2834,7 +2834,7 @@ class _$_PaymentMethodParamsCard implements _PaymentMethodParamsCard {
     TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
         cardFromToken,
     TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
-    TResult Function()? aliPay,
+    TResult Function()? alipay,
     TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
     TResult Function(BillingDetails billingDetails)? bankContact,
     TResult Function(BillingDetails billingDetails)? giroPay,
@@ -2857,7 +2857,7 @@ class _$_PaymentMethodParamsCard implements _PaymentMethodParamsCard {
         cardFromToken,
     required TResult Function(_PaymentMethodParamsCardWithMethodId value)
         cardFromMethodId,
-    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsAlipay value) alipay,
     required TResult Function(_PaymentMethodParamsIdeal value) ideal,
     required TResult Function(_PaymentMethodParamsBankContact value)
         bankContact,
@@ -2876,7 +2876,7 @@ class _$_PaymentMethodParamsCard implements _PaymentMethodParamsCard {
     TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
     TResult Function(_PaymentMethodParamsCardWithMethodId value)?
         cardFromMethodId,
-    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsAlipay value)? alipay,
     TResult Function(_PaymentMethodParamsIdeal value)? ideal,
     TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
     TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,
@@ -3017,7 +3017,7 @@ class _$_PaymentMethodParamsCardWithToken
         cardFromToken,
     required TResult Function(String paymentMethodId, String? cvc)
         cardFromMethodId,
-    required TResult Function() aliPay,
+    required TResult Function() alipay,
     required TResult Function(BillingDetails? billingDetails, String? bankName)
         ideal,
     required TResult Function(BillingDetails billingDetails) bankContact,
@@ -3038,7 +3038,7 @@ class _$_PaymentMethodParamsCardWithToken
     TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
         cardFromToken,
     TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
-    TResult Function()? aliPay,
+    TResult Function()? alipay,
     TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
     TResult Function(BillingDetails billingDetails)? bankContact,
     TResult Function(BillingDetails billingDetails)? giroPay,
@@ -3061,7 +3061,7 @@ class _$_PaymentMethodParamsCardWithToken
         cardFromToken,
     required TResult Function(_PaymentMethodParamsCardWithMethodId value)
         cardFromMethodId,
-    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsAlipay value) alipay,
     required TResult Function(_PaymentMethodParamsIdeal value) ideal,
     required TResult Function(_PaymentMethodParamsBankContact value)
         bankContact,
@@ -3080,7 +3080,7 @@ class _$_PaymentMethodParamsCardWithToken
     TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
     TResult Function(_PaymentMethodParamsCardWithMethodId value)?
         cardFromMethodId,
-    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsAlipay value)? alipay,
     TResult Function(_PaymentMethodParamsIdeal value)? ideal,
     TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
     TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,
@@ -3222,7 +3222,7 @@ class _$_PaymentMethodParamsCardWithMethodId
         cardFromToken,
     required TResult Function(String paymentMethodId, String? cvc)
         cardFromMethodId,
-    required TResult Function() aliPay,
+    required TResult Function() alipay,
     required TResult Function(BillingDetails? billingDetails, String? bankName)
         ideal,
     required TResult Function(BillingDetails billingDetails) bankContact,
@@ -3243,7 +3243,7 @@ class _$_PaymentMethodParamsCardWithMethodId
     TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
         cardFromToken,
     TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
-    TResult Function()? aliPay,
+    TResult Function()? alipay,
     TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
     TResult Function(BillingDetails billingDetails)? bankContact,
     TResult Function(BillingDetails billingDetails)? giroPay,
@@ -3266,7 +3266,7 @@ class _$_PaymentMethodParamsCardWithMethodId
         cardFromToken,
     required TResult Function(_PaymentMethodParamsCardWithMethodId value)
         cardFromMethodId,
-    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsAlipay value) alipay,
     required TResult Function(_PaymentMethodParamsIdeal value) ideal,
     required TResult Function(_PaymentMethodParamsBankContact value)
         bankContact,
@@ -3285,7 +3285,7 @@ class _$_PaymentMethodParamsCardWithMethodId
     TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
     TResult Function(_PaymentMethodParamsCardWithMethodId value)?
         cardFromMethodId,
-    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsAlipay value)? alipay,
     TResult Function(_PaymentMethodParamsIdeal value)? ideal,
     TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
     TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,
@@ -3328,42 +3328,43 @@ abstract class _PaymentMethodParamsCardWithMethodId
 }
 
 /// @nodoc
-abstract class _$PaymentMethodParamsAliCopyWith<$Res> {
-  factory _$PaymentMethodParamsAliCopyWith(_PaymentMethodParamsAli value,
-          $Res Function(_PaymentMethodParamsAli) then) =
-      __$PaymentMethodParamsAliCopyWithImpl<$Res>;
+abstract class _$PaymentMethodParamsAlipayCopyWith<$Res> {
+  factory _$PaymentMethodParamsAlipayCopyWith(_PaymentMethodParamsAlipay value,
+          $Res Function(_PaymentMethodParamsAlipay) then) =
+      __$PaymentMethodParamsAlipayCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$PaymentMethodParamsAliCopyWithImpl<$Res>
+class __$PaymentMethodParamsAlipayCopyWithImpl<$Res>
     extends _$PaymentMethodParamsCopyWithImpl<$Res>
-    implements _$PaymentMethodParamsAliCopyWith<$Res> {
-  __$PaymentMethodParamsAliCopyWithImpl(_PaymentMethodParamsAli _value,
-      $Res Function(_PaymentMethodParamsAli) _then)
-      : super(_value, (v) => _then(v as _PaymentMethodParamsAli));
+    implements _$PaymentMethodParamsAlipayCopyWith<$Res> {
+  __$PaymentMethodParamsAlipayCopyWithImpl(_PaymentMethodParamsAlipay _value,
+      $Res Function(_PaymentMethodParamsAlipay) _then)
+      : super(_value, (v) => _then(v as _PaymentMethodParamsAlipay));
 
   @override
-  _PaymentMethodParamsAli get _value => super._value as _PaymentMethodParamsAli;
+  _PaymentMethodParamsAlipay get _value =>
+      super._value as _PaymentMethodParamsAlipay;
 }
 
 @JsonSerializable(explicitToJson: true)
 @FreezedUnionValue('Alipay')
 
 /// @nodoc
-class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
-  const _$_PaymentMethodParamsAli();
+class _$_PaymentMethodParamsAlipay implements _PaymentMethodParamsAlipay {
+  const _$_PaymentMethodParamsAlipay();
 
-  factory _$_PaymentMethodParamsAli.fromJson(Map<String, dynamic> json) =>
-      _$_$_PaymentMethodParamsAliFromJson(json);
+  factory _$_PaymentMethodParamsAlipay.fromJson(Map<String, dynamic> json) =>
+      _$_$_PaymentMethodParamsAlipayFromJson(json);
 
   @override
   String toString() {
-    return 'PaymentMethodParams.aliPay()';
+    return 'PaymentMethodParams.alipay()';
   }
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) || (other is _PaymentMethodParamsAli);
+    return identical(this, other) || (other is _PaymentMethodParamsAlipay);
   }
 
   @override
@@ -3380,7 +3381,7 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
         cardFromToken,
     required TResult Function(String paymentMethodId, String? cvc)
         cardFromMethodId,
-    required TResult Function() aliPay,
+    required TResult Function() alipay,
     required TResult Function(BillingDetails? billingDetails, String? bankName)
         ideal,
     required TResult Function(BillingDetails billingDetails) bankContact,
@@ -3389,7 +3390,7 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
     required TResult Function(BillingDetails billingDetails) grabPay,
     required TResult Function(BillingDetails billingDetails) p24,
   }) {
-    return aliPay();
+    return alipay();
   }
 
   @override
@@ -3401,7 +3402,7 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
     TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
         cardFromToken,
     TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
-    TResult Function()? aliPay,
+    TResult Function()? alipay,
     TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
     TResult Function(BillingDetails billingDetails)? bankContact,
     TResult Function(BillingDetails billingDetails)? giroPay,
@@ -3410,8 +3411,8 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
     TResult Function(BillingDetails billingDetails)? p24,
     required TResult orElse(),
   }) {
-    if (aliPay != null) {
-      return aliPay();
+    if (alipay != null) {
+      return alipay();
     }
     return orElse();
   }
@@ -3424,7 +3425,7 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
         cardFromToken,
     required TResult Function(_PaymentMethodParamsCardWithMethodId value)
         cardFromMethodId,
-    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsAlipay value) alipay,
     required TResult Function(_PaymentMethodParamsIdeal value) ideal,
     required TResult Function(_PaymentMethodParamsBankContact value)
         bankContact,
@@ -3433,7 +3434,7 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
     required TResult Function(_PaymentMethodParamsPay value) grabPay,
     required TResult Function(_PaymentMethodParamsP24 value) p24,
   }) {
-    return aliPay(this);
+    return alipay(this);
   }
 
   @override
@@ -3443,7 +3444,7 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
     TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
     TResult Function(_PaymentMethodParamsCardWithMethodId value)?
         cardFromMethodId,
-    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsAlipay value)? alipay,
     TResult Function(_PaymentMethodParamsIdeal value)? ideal,
     TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
     TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,
@@ -3452,23 +3453,23 @@ class _$_PaymentMethodParamsAli implements _PaymentMethodParamsAli {
     TResult Function(_PaymentMethodParamsP24 value)? p24,
     required TResult orElse(),
   }) {
-    if (aliPay != null) {
-      return aliPay(this);
+    if (alipay != null) {
+      return alipay(this);
     }
     return orElse();
   }
 
   @override
   Map<String, dynamic> toJson() {
-    return _$_$_PaymentMethodParamsAliToJson(this)..['type'] = 'Alipay';
+    return _$_$_PaymentMethodParamsAlipayToJson(this)..['type'] = 'Alipay';
   }
 }
 
-abstract class _PaymentMethodParamsAli implements PaymentMethodParams {
-  const factory _PaymentMethodParamsAli() = _$_PaymentMethodParamsAli;
+abstract class _PaymentMethodParamsAlipay implements PaymentMethodParams {
+  const factory _PaymentMethodParamsAlipay() = _$_PaymentMethodParamsAlipay;
 
-  factory _PaymentMethodParamsAli.fromJson(Map<String, dynamic> json) =
-      _$_PaymentMethodParamsAli.fromJson;
+  factory _PaymentMethodParamsAlipay.fromJson(Map<String, dynamic> json) =
+      _$_PaymentMethodParamsAlipay.fromJson;
 }
 
 /// @nodoc
@@ -3581,7 +3582,7 @@ class _$_PaymentMethodParamsIdeal implements _PaymentMethodParamsIdeal {
         cardFromToken,
     required TResult Function(String paymentMethodId, String? cvc)
         cardFromMethodId,
-    required TResult Function() aliPay,
+    required TResult Function() alipay,
     required TResult Function(BillingDetails? billingDetails, String? bankName)
         ideal,
     required TResult Function(BillingDetails billingDetails) bankContact,
@@ -3602,7 +3603,7 @@ class _$_PaymentMethodParamsIdeal implements _PaymentMethodParamsIdeal {
     TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
         cardFromToken,
     TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
-    TResult Function()? aliPay,
+    TResult Function()? alipay,
     TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
     TResult Function(BillingDetails billingDetails)? bankContact,
     TResult Function(BillingDetails billingDetails)? giroPay,
@@ -3625,7 +3626,7 @@ class _$_PaymentMethodParamsIdeal implements _PaymentMethodParamsIdeal {
         cardFromToken,
     required TResult Function(_PaymentMethodParamsCardWithMethodId value)
         cardFromMethodId,
-    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsAlipay value) alipay,
     required TResult Function(_PaymentMethodParamsIdeal value) ideal,
     required TResult Function(_PaymentMethodParamsBankContact value)
         bankContact,
@@ -3644,7 +3645,7 @@ class _$_PaymentMethodParamsIdeal implements _PaymentMethodParamsIdeal {
     TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
     TResult Function(_PaymentMethodParamsCardWithMethodId value)?
         cardFromMethodId,
-    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsAlipay value)? alipay,
     TResult Function(_PaymentMethodParamsIdeal value)? ideal,
     TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
     TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,
@@ -3780,7 +3781,7 @@ class _$_PaymentMethodParamsBankContact
         cardFromToken,
     required TResult Function(String paymentMethodId, String? cvc)
         cardFromMethodId,
-    required TResult Function() aliPay,
+    required TResult Function() alipay,
     required TResult Function(BillingDetails? billingDetails, String? bankName)
         ideal,
     required TResult Function(BillingDetails billingDetails) bankContact,
@@ -3801,7 +3802,7 @@ class _$_PaymentMethodParamsBankContact
     TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
         cardFromToken,
     TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
-    TResult Function()? aliPay,
+    TResult Function()? alipay,
     TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
     TResult Function(BillingDetails billingDetails)? bankContact,
     TResult Function(BillingDetails billingDetails)? giroPay,
@@ -3824,7 +3825,7 @@ class _$_PaymentMethodParamsBankContact
         cardFromToken,
     required TResult Function(_PaymentMethodParamsCardWithMethodId value)
         cardFromMethodId,
-    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsAlipay value) alipay,
     required TResult Function(_PaymentMethodParamsIdeal value) ideal,
     required TResult Function(_PaymentMethodParamsBankContact value)
         bankContact,
@@ -3843,7 +3844,7 @@ class _$_PaymentMethodParamsBankContact
     TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
     TResult Function(_PaymentMethodParamsCardWithMethodId value)?
         cardFromMethodId,
-    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsAlipay value)? alipay,
     TResult Function(_PaymentMethodParamsIdeal value)? ideal,
     TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
     TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,
@@ -3974,7 +3975,7 @@ class _$_PaymentMethodParamsGiroPay implements _PaymentMethodParamsGiroPay {
         cardFromToken,
     required TResult Function(String paymentMethodId, String? cvc)
         cardFromMethodId,
-    required TResult Function() aliPay,
+    required TResult Function() alipay,
     required TResult Function(BillingDetails? billingDetails, String? bankName)
         ideal,
     required TResult Function(BillingDetails billingDetails) bankContact,
@@ -3995,7 +3996,7 @@ class _$_PaymentMethodParamsGiroPay implements _PaymentMethodParamsGiroPay {
     TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
         cardFromToken,
     TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
-    TResult Function()? aliPay,
+    TResult Function()? alipay,
     TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
     TResult Function(BillingDetails billingDetails)? bankContact,
     TResult Function(BillingDetails billingDetails)? giroPay,
@@ -4018,7 +4019,7 @@ class _$_PaymentMethodParamsGiroPay implements _PaymentMethodParamsGiroPay {
         cardFromToken,
     required TResult Function(_PaymentMethodParamsCardWithMethodId value)
         cardFromMethodId,
-    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsAlipay value) alipay,
     required TResult Function(_PaymentMethodParamsIdeal value) ideal,
     required TResult Function(_PaymentMethodParamsBankContact value)
         bankContact,
@@ -4037,7 +4038,7 @@ class _$_PaymentMethodParamsGiroPay implements _PaymentMethodParamsGiroPay {
     TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
     TResult Function(_PaymentMethodParamsCardWithMethodId value)?
         cardFromMethodId,
-    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsAlipay value)? alipay,
     TResult Function(_PaymentMethodParamsIdeal value)? ideal,
     TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
     TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,
@@ -4164,7 +4165,7 @@ class _$_PaymentMethodParamsEps implements _PaymentMethodParamsEps {
         cardFromToken,
     required TResult Function(String paymentMethodId, String? cvc)
         cardFromMethodId,
-    required TResult Function() aliPay,
+    required TResult Function() alipay,
     required TResult Function(BillingDetails? billingDetails, String? bankName)
         ideal,
     required TResult Function(BillingDetails billingDetails) bankContact,
@@ -4185,7 +4186,7 @@ class _$_PaymentMethodParamsEps implements _PaymentMethodParamsEps {
     TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
         cardFromToken,
     TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
-    TResult Function()? aliPay,
+    TResult Function()? alipay,
     TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
     TResult Function(BillingDetails billingDetails)? bankContact,
     TResult Function(BillingDetails billingDetails)? giroPay,
@@ -4208,7 +4209,7 @@ class _$_PaymentMethodParamsEps implements _PaymentMethodParamsEps {
         cardFromToken,
     required TResult Function(_PaymentMethodParamsCardWithMethodId value)
         cardFromMethodId,
-    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsAlipay value) alipay,
     required TResult Function(_PaymentMethodParamsIdeal value) ideal,
     required TResult Function(_PaymentMethodParamsBankContact value)
         bankContact,
@@ -4227,7 +4228,7 @@ class _$_PaymentMethodParamsEps implements _PaymentMethodParamsEps {
     TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
     TResult Function(_PaymentMethodParamsCardWithMethodId value)?
         cardFromMethodId,
-    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsAlipay value)? alipay,
     TResult Function(_PaymentMethodParamsIdeal value)? ideal,
     TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
     TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,
@@ -4354,7 +4355,7 @@ class _$_PaymentMethodParamsPay implements _PaymentMethodParamsPay {
         cardFromToken,
     required TResult Function(String paymentMethodId, String? cvc)
         cardFromMethodId,
-    required TResult Function() aliPay,
+    required TResult Function() alipay,
     required TResult Function(BillingDetails? billingDetails, String? bankName)
         ideal,
     required TResult Function(BillingDetails billingDetails) bankContact,
@@ -4375,7 +4376,7 @@ class _$_PaymentMethodParamsPay implements _PaymentMethodParamsPay {
     TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
         cardFromToken,
     TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
-    TResult Function()? aliPay,
+    TResult Function()? alipay,
     TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
     TResult Function(BillingDetails billingDetails)? bankContact,
     TResult Function(BillingDetails billingDetails)? giroPay,
@@ -4398,7 +4399,7 @@ class _$_PaymentMethodParamsPay implements _PaymentMethodParamsPay {
         cardFromToken,
     required TResult Function(_PaymentMethodParamsCardWithMethodId value)
         cardFromMethodId,
-    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsAlipay value) alipay,
     required TResult Function(_PaymentMethodParamsIdeal value) ideal,
     required TResult Function(_PaymentMethodParamsBankContact value)
         bankContact,
@@ -4417,7 +4418,7 @@ class _$_PaymentMethodParamsPay implements _PaymentMethodParamsPay {
     TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
     TResult Function(_PaymentMethodParamsCardWithMethodId value)?
         cardFromMethodId,
-    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsAlipay value)? alipay,
     TResult Function(_PaymentMethodParamsIdeal value)? ideal,
     TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
     TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,
@@ -4544,7 +4545,7 @@ class _$_PaymentMethodParamsP24 implements _PaymentMethodParamsP24 {
         cardFromToken,
     required TResult Function(String paymentMethodId, String? cvc)
         cardFromMethodId,
-    required TResult Function() aliPay,
+    required TResult Function() alipay,
     required TResult Function(BillingDetails? billingDetails, String? bankName)
         ideal,
     required TResult Function(BillingDetails billingDetails) bankContact,
@@ -4565,7 +4566,7 @@ class _$_PaymentMethodParamsP24 implements _PaymentMethodParamsP24 {
     TResult Function(String token, PaymentIntentsFutureUsage? setupFutureUsage)?
         cardFromToken,
     TResult Function(String paymentMethodId, String? cvc)? cardFromMethodId,
-    TResult Function()? aliPay,
+    TResult Function()? alipay,
     TResult Function(BillingDetails? billingDetails, String? bankName)? ideal,
     TResult Function(BillingDetails billingDetails)? bankContact,
     TResult Function(BillingDetails billingDetails)? giroPay,
@@ -4588,7 +4589,7 @@ class _$_PaymentMethodParamsP24 implements _PaymentMethodParamsP24 {
         cardFromToken,
     required TResult Function(_PaymentMethodParamsCardWithMethodId value)
         cardFromMethodId,
-    required TResult Function(_PaymentMethodParamsAli value) aliPay,
+    required TResult Function(_PaymentMethodParamsAlipay value) alipay,
     required TResult Function(_PaymentMethodParamsIdeal value) ideal,
     required TResult Function(_PaymentMethodParamsBankContact value)
         bankContact,
@@ -4607,7 +4608,7 @@ class _$_PaymentMethodParamsP24 implements _PaymentMethodParamsP24 {
     TResult Function(_PaymentMethodParamsCardWithToken value)? cardFromToken,
     TResult Function(_PaymentMethodParamsCardWithMethodId value)?
         cardFromMethodId,
-    TResult Function(_PaymentMethodParamsAli value)? aliPay,
+    TResult Function(_PaymentMethodParamsAlipay value)? alipay,
     TResult Function(_PaymentMethodParamsIdeal value)? ideal,
     TResult Function(_PaymentMethodParamsBankContact value)? bankContact,
     TResult Function(_PaymentMethodParamsGiroPay value)? giroPay,

--- a/packages/stripe_platform_interface/lib/src/models/payment_methods.g.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_methods.g.dart
@@ -268,13 +268,13 @@ Map<String, dynamic> _$_$_PaymentMethodParamsCardWithMethodIdToJson(
       'cvc': instance.cvc,
     };
 
-_$_PaymentMethodParamsAli _$_$_PaymentMethodParamsAliFromJson(
+_$_PaymentMethodParamsAlipay _$_$_PaymentMethodParamsAlipayFromJson(
     Map<String, dynamic> json) {
-  return _$_PaymentMethodParamsAli();
+  return _$_PaymentMethodParamsAlipay();
 }
 
-Map<String, dynamic> _$_$_PaymentMethodParamsAliToJson(
-        _$_PaymentMethodParamsAli instance) =>
+Map<String, dynamic> _$_$_PaymentMethodParamsAlipayToJson(
+        _$_PaymentMethodParamsAlipay instance) =>
     <String, dynamic>{};
 
 _$_PaymentMethodParamsIdeal _$_$_PaymentMethodParamsIdealFromJson(


### PR DESCRIPTION
Alipay is a digital wallet in China that has more than a billion active users worldwide.

The word Alipay is a single world, so we should not be using `camelCase` in this case.

This is a breaking change but it's much better to do this early in the beta than having the user of this package being confused after the launch.

Nitpick and very small changes :) 