### PR TITLE
remove handlecardcation promise to prevent crash

### DIFF
--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/StripeSdkModule.kt
@@ -94,7 +94,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext, cardFieldManager: S
               }
               StripeIntent.Status.RequiresConfirmation -> {
                 val pi = createResult("paymentIntent", mapFromPaymentIntentResult(paymentIntent))
-                handleCardActionPromise?.resolve(pi)
+                confirmPromise?.resolve(pi)
               }
               StripeIntent.Status.Canceled -> {
                 val error = paymentIntent.lastPaymentError

--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/StripeSdkModule.kt
@@ -94,7 +94,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext, cardFieldManager: S
               }
               StripeIntent.Status.RequiresConfirmation -> {
                 val pi = createResult("paymentIntent", mapFromPaymentIntentResult(paymentIntent))
-                confirmPromise?.reject(ConfirmPaymentErrorType.Failed.toString(), errorMessage)
+                handleCardActionPromise?.resolve(pi)
               }
               StripeIntent.Status.Canceled -> {
                 val error = paymentIntent.lastPaymentError


### PR DESCRIPTION
demo
![crash after pay with credit card then grab pay vice versa](https://user-images.githubusercontent.com/58877825/125891404-fe00ae02-e1aa-4a57-acbc-f9e91e96a586.gif)

crash log:
E/AndroidRuntime(26127): FATAL EXCEPTION: main
E/AndroidRuntime(26127): Process: com.gankglobal.gank, PID: 26127
E/AndroidRuntime(26127): java.lang.IllegalStateException: Reply already submitted
E/AndroidRuntime(26127): 	at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:155)
E/AndroidRuntime(26127): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success(MethodChannel.java:238)
E/AndroidRuntime(26127): 	at com.facebook.react.bridge.Promise$1.run(Promise.java:25)
E/AndroidRuntime(26127): 	at android.os.Handler.handleCallback(Handler.java:938)
E/AndroidRuntime(26127): 	at android.os.Handler.dispatchMessage(Handler.java:99)
E/AndroidRuntime(26127): 	at android.os.Looper.loop(Looper.java:223)
E/AndroidRuntime(26127): 	at android.app.ActivityThread.main(ActivityThread.java:7656)
E/AndroidRuntime(26127): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(26127): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
E/AndroidRuntime(26127): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
I/Process (26127): Sending signal. PID: 26127 SIG: 9

crash happen after we use credit card that have 3d secure, 
then we use other confirm payment method channel(grabpay) or vice versa.