### PR TITLE
Handle payment sheet cancel event, by user

### DIFF
--- a/example/lib/screens/payment_sheet_screen.dart
+++ b/example/lib/screens/payment_sheet_screen.dart
@@ -94,7 +94,7 @@ class _PaymentSheetScreenState extends State<PaymentSheetScreen> {
       ));
 
       final postPaymentIntent = await Stripe.instance
-          .retrievePaymentIntent(paymentSheetData['data']['client_secret']);
+          .retrievePaymentIntent(_paymentSheetData!['paymentIntent']);
 
       
       setState(() {

--- a/example/lib/screens/payment_sheet_screen.dart
+++ b/example/lib/screens/payment_sheet_screen.dart
@@ -101,7 +101,7 @@ class _PaymentSheetScreenState extends State<PaymentSheetScreen> {
         _paymentSheetData = null;
       });
       
-       if (paymentIntentData.status == PaymentIntentsStatus.Succeeded) {
+       if (postPaymentIntent.status == PaymentIntentsStatus.Succeeded) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Payment Succesfully Completed'),

--- a/example/lib/screens/payment_sheet_screen.dart
+++ b/example/lib/screens/payment_sheet_screen.dart
@@ -93,15 +93,29 @@ class _PaymentSheetScreenState extends State<PaymentSheetScreen> {
         confirmPayment: true,
       ));
 
+      final postPaymentIntent = await Stripe.instance
+          .retrievePaymentIntent(paymentSheetData['data']['client_secret']);
+
+      
       setState(() {
         _paymentSheetData = null;
       });
+      
+       if (paymentIntentData.status == PaymentIntentsStatus.Succeeded) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Payment Succesfully Completed'),
+          ),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Payment Cancelled'),
+          ),
+        );
+      }
 
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Payment succesfully completed'),
-        ),
-      );
+      
     } on StripeException catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(


### PR DESCRIPTION
As the return type presentPaymentSheet method is Future<void>, waiting is done without any approval of payment been succeeded or failed (When the user closes or cancels the payment sheet, in spite, the code beneath was executing which was none other than showing payment success). 

At line 96, I've called retrievePaymentIntent to get the post-payment intent which includes the PaymentIntentsStatus and made a decision for both cases accordingly in a brief.