### PR TITLE
stripe_android and stripe_ios: Fix BillingAddress properties being null

### DIFF
--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/Mappers.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/Mappers.kt
@@ -386,7 +386,8 @@ internal fun mapFromSetupIntentLastErrorType(errorType: SetupIntent.Error.Type?)
   }
 }
 
-fun getValOr(map: ReadableMap, key: String, default: String? = ""): String? {
+fun getValOr(map: ReadableMap?, key: String, default: String? = ""): String? {
+  if (map == null) return default
   return if (map.hasKey(key)) map.getString(key) else default
 }
 
@@ -408,13 +409,15 @@ internal fun mapToBillingDetails(billingDetails: ReadableMap?): PaymentMethod.Bi
   if (billingDetails == null) {
     return null
   }
+
+  val addressDetails = getMapOrNull(billingDetails, "address")
   val address = Address.Builder()
-    .setPostalCode(getValOr(billingDetails, "addressPostalCode"))
-    .setCity(getValOr(billingDetails, "addressCity"))
-    .setCountry(getValOr(billingDetails, "addressCountry"))
-    .setLine1(getValOr(billingDetails, "addressLine1"))
-    .setLine2(getValOr(billingDetails, "addressLine2"))
-    .setState(getValOr(billingDetails, "addressState"))
+    .setPostalCode(getValOr(addressDetails, "postalCode"))
+    .setCity(getValOr(addressDetails, "city"))
+    .setCountry(getValOr(addressDetails, "country"))
+    .setLine1(getValOr(addressDetails, "line1"))
+    .setLine2(getValOr(addressDetails, "line2"))
+    .setState(getValOr(addressDetails, "state"))
     .build()
 
   return PaymentMethod.BillingDetails.Builder()

--- a/packages/stripe_ios/ios/Classes/Mappers.swift
+++ b/packages/stripe_ios/ios/Classes/Mappers.swift
@@ -432,13 +432,27 @@ class Mappers {
         
         let billingAddres = STPPaymentMethodAddress()
         
-        billingAddres.city = RCTConvert.nsString(billingDetails["addressCity"])
-        billingAddres.postalCode = RCTConvert.nsString(billingDetails["addressPostalCode"])
-        billingAddres.country = RCTConvert.nsString(billingDetails["addressCountry"])
-        billingAddres.line1 = RCTConvert.nsString(billingDetails["addressLine1"])
-        billingAddres.line2 = RCTConvert.nsString(billingDetails["addressLine2"])
-        billingAddres.state = RCTConvert.nsString(billingDetails["addressState"])
-        
+        if let address = billingDetails["address"] as? NSDictionary {
+            if let city = address["city"] {
+                billingAddres.city = RCTConvert.nsString(city)
+            }
+            if let postalCode = address["postalCode"] {
+                billingAddres.postalCode = RCTConvert.nsString(postalCode)
+            }
+            if let country = address["country"] {
+                billingAddres.country = RCTConvert.nsString(country)
+            }
+            if let line1 = address["line1"] {
+                billingAddres.line1 = RCTConvert.nsString(line1)
+            }
+            if let line2 = address["line2"] {
+                billingAddres.line2 = RCTConvert.nsString(line2)
+            }
+            if let state = address["state"] {
+                billingAddres.state = RCTConvert.nsString(state)
+            }
+        }
+            
         billing.address = billingAddres
         
         return billing


### PR DESCRIPTION
Fixed `BillingAddress`  properties being null while creating a payment method on Android.
This issue has been addressed at #185.