### PR TITLE
iOS Apple Pay token

### DIFF
--- a/example/assets/apple_pay_payment_profile.json
+++ b/example/assets/apple_pay_payment_profile.json
@@ -1,0 +1,33 @@
+{
+  "provider": "apple_pay",
+  "data": {
+    "merchantIdentifier": "merchant.com.stripe.test",
+    "displayName": "Sam's Fish",
+    "merchantCapabilities": ["3DS", "debit", "credit"],
+    "supportedNetworks": ["amex", "visa", "discover", "masterCard"],
+    "countryCode": "US",
+    "currencyCode": "USD",
+    "requiredBillingContactFields": ["emailAddress", "name", "phoneNumber", "postalAddress"],
+    "requiredShippingContactFields": [],
+    "shippingMethods": [
+      {
+        "amount": "0.00",
+        "detail": "Available within an hour",
+        "identifier": "in_store_pickup",
+        "label": "In-Store Pickup"
+      },
+      {
+        "amount": "4.99",
+        "detail": "5-8 Business Days",
+        "identifier": "flat_rate_shipping_id_2",
+        "label": "UPS Ground"
+      },
+      {
+        "amount": "29.99",
+        "detail": "1-3 Business Days",
+        "identifier": "flat_rate_shipping_id_1",
+        "label": "FedEx Priority Mail"
+      }
+    ]
+  }
+}

--- a/example/assets/apple_pay_payment_profile.json
+++ b/example/assets/apple_pay_payment_profile.json
@@ -1,7 +1,7 @@
 {
   "provider": "apple_pay",
   "data": {
-    "merchantIdentifier": "merchant.com.stripe.test",
+    "merchantIdentifier": "merchant.flutter.stripe.test",
     "displayName": "Sam's Fish",
     "merchantCapabilities": ["3DS", "debit", "credit"],
     "supportedNetworks": ["amex", "visa", "discover", "masterCard"],

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C5F7079826DD2C0800AA3E5B /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		FEEC4D1EB43F5F7C33B96096 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -112,6 +113,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				C5F7079826DD2C0800AA3E5B /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -354,15 +356,16 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 8734Y6QF3F;
+				DEVELOPMENT_TEAM = 87RQQPQ85J;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = flutter.stripe.example;
+				PRODUCT_BUNDLE_IDENTIFIER = "flutter.stripe.example-2";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -483,17 +486,18 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 8734Y6QF3F;
+				DEVELOPMENT_TEAM = 87RQQPQ85J;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = flutter.stripe.example;
+				PRODUCT_BUNDLE_IDENTIFIER = "flutter.stripe.example-2";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -509,15 +513,16 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 8734Y6QF3F;
+				DEVELOPMENT_TEAM = 87RQQPQ85J;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = flutter.stripe.example;
+				PRODUCT_BUNDLE_IDENTIFIER = "flutter.stripe.example-2";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -18,16 +18,34 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>safepay</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>flutterstripe</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>FlutterDeepLinkingEnabled</key>
+	<true/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Scan your card to add it automatically</string>
+	<key>NSCameraUsageDescription
+	&lt;string&gt;To scan cards&lt;/string&gt;</key>
+	<string>To scan cards</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>NSCameraUsageDescription</key>
-	<string>Scan your card to add it automatically</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -41,24 +59,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>FlutterDeepLinkingEnabled</key>
-	<true/>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-		<key>CFBundleTypeRole</key>
-		<string>Editor</string>
-		<key>CFBundleURLName</key>
-		<string>safepay</string>
-		<key>CFBundleURLSchemes</key>
-		<array>
-		<string>flutterstripe</string>
-		</array>
-		</dict>
-	</array>
-		<key>NSCameraUsageDescription
-	&lt;string&gt;To scan cards&lt;/string&gt;</key>
-	<string>To scan cards</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/example/ios/Runner/Runner.entitlements
+++ b/example/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.in-app-payments</key>
+	<array>
+		<string>merchant.com.stripe.test</string>
+	</array>
+</dict>
+</plist>

--- a/example/ios/Runner/Runner.entitlements
+++ b/example/ios/Runner/Runner.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
-		<string>merchant.com.stripe.test</string>
+		<string>merchant.flutter.stripe.test</string>
 	</array>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,7 +8,7 @@ import 'widgets/dismiss_focus_overlay.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   Stripe.publishableKey = stripePublishableKey;
-  Stripe.merchantIdentifier = 'merchant.com.stripe.test';
+  Stripe.merchantIdentifier = 'merchant.flutter.stripe.test';
   Stripe.urlScheme = 'flutterstripe';
   await Stripe.instance.applySettings();
   runApp(const App());

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,7 +8,7 @@ import 'widgets/dismiss_focus_overlay.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   Stripe.publishableKey = stripePublishableKey;
-  Stripe.merchantIdentifier = 'MerchantIdentifier';
+  Stripe.merchantIdentifier = 'merchant.com.stripe.test';
   Stripe.urlScheme = 'flutterstripe';
   await Stripe.instance.applySettings();
   runApp(const App());

--- a/example/lib/screens/screens.dart
+++ b/example/lib/screens/screens.dart
@@ -121,6 +121,10 @@ class Example extends StatelessWidget {
           width: 48,
         ),
         builder: (c) => ApplePayScreen(),
+      ), Example(
+        title: 'Apple Pay (iOS) - Pay Plugin',
+        leading: Image.asset('assets/apple_pay.png', width: 48,),
+        builder: (c) => ApplePayExternalPluginScreen(),
       ),
       Example(
         leading: Image.asset(

--- a/example/lib/screens/screens.dart
+++ b/example/lib/screens/screens.dart
@@ -121,10 +121,6 @@ class Example extends StatelessWidget {
           width: 48,
         ),
         builder: (c) => ApplePayScreen(),
-      ), Example(
-        title: 'Apple Pay (iOS) - Pay Plugin',
-        leading: Image.asset('assets/apple_pay.png', width: 48,),
-        builder: (c) => ApplePayExternalPluginScreen(),
       ),
       Example(
         leading: Image.asset(

--- a/example/lib/screens/screens.dart
+++ b/example/lib/screens/screens.dart
@@ -5,6 +5,7 @@ import 'package:stripe_example/screens/regional_payment_methods/ali_pay_screen.d
 import 'package:stripe_example/screens/regional_payment_methods/ideal_screen.dart';
 import 'package:stripe_example/screens/regional_payment_methods/wechat_pay_screen.dart';
 import 'package:stripe_example/screens/wallets/apple_pay_screen.dart';
+import 'package:stripe_example/screens/wallets/apple_pay_screen_plugin.dart';
 import 'package:stripe_example/screens/wallets/google_pay_screen.dart';
 import 'package:stripe_example/screens/wallets/google_pay_stripe_screen.dart';
 
@@ -117,6 +118,10 @@ class Example extends StatelessWidget {
         title: 'Apple Pay (iOS)',
         leading: Image.asset('assets/apple_pay.png', width: 48,),
         builder: (c) => ApplePayScreen(),
+      ), Example(
+        title: 'Apple Pay (iOS) - Pay Plugin',
+        leading: Image.asset('assets/apple_pay.png', width: 48,),
+        builder: (c) => ApplePayExternalPluginScreen(),
       ),
       Example(
         leading: Image.asset('assets/google_play.png', width: 48,),

--- a/example/lib/screens/screens.dart
+++ b/example/lib/screens/screens.dart
@@ -116,39 +116,60 @@ class Example extends StatelessWidget {
     ExampleSection(title: 'Wallets', children: [
       Example(
         title: 'Apple Pay (iOS)',
-        leading: Image.asset('assets/apple_pay.png', width: 48,),
+        leading: Image.asset(
+          'assets/apple_pay.png',
+          width: 48,
+        ),
         builder: (c) => ApplePayScreen(),
-      ), Example(
-        title: 'Apple Pay (iOS) - Pay Plugin',
-        leading: Image.asset('assets/apple_pay.png', width: 48,),
-        builder: (c) => ApplePayExternalPluginScreen(),
       ),
       Example(
-        leading: Image.asset('assets/google_play.png', width: 48,),
+        leading: Image.asset(
+          'assets/google_play.png',
+          width: 48,
+        ),
         title: 'Google Pay (Android)',
         builder: (c) => GooglePayStripeScreen(),
       ),
       Example(
-        leading: Image.asset('assets/google_play.png', width: 48,),
-        title: 'Google Pay - pay plugin (Android)',
+        title: 'Apple Pay (iOS) - Pay Plugin',
+        leading: Image.asset(
+          'assets/apple_pay.png',
+          width: 48,
+        ),
+        builder: (c) => ApplePayExternalPluginScreen(),
+      ),
+      Example(
+        leading: Image.asset(
+          'assets/google_play.png',
+          width: 48,
+        ),
+        title: 'Google Pay (Android) - Pay Plugin',
         builder: (c) => GooglePayScreen(),
       ),
-      
     ]),
     ExampleSection(title: 'Regional Payment Methods', children: [
       Example(
         title: 'Ali Pay',
-        leading: Image.asset('assets/alipay.png', width: 48,),
+        leading: Image.asset(
+          'assets/alipay.png',
+          width: 48,
+        ),
         builder: (context) => AliPayScreen(),
       ),
       Example(
         title: 'Ideal',
-        leading: Image.asset('assets/ideal_pay.png', width: 48,),
+        leading: Image.asset(
+          'assets/ideal_pay.png',
+          width: 48,
+        ),
         builder: (context) => IdealScreen(),
       ),
       Example(
         title: 'WeChat Pay',
-        leading: Image.asset('assets/wechat_pay.png', width: 48,),
+        leading: Image.asset(
+          'assets/wechat_pay.png',
+          width: 48,
+        ),
         builder: (context) => WeChatPayScreen(),
       ),
     ]),

--- a/example/lib/screens/wallets/apple_pay_screen.dart
+++ b/example/lib/screens/wallets/apple_pay_screen.dart
@@ -55,7 +55,7 @@ class _ApplePayScreenState extends State<ApplePayScreen> {
           cartItems: [
             ApplePayCartSummaryItem(
               label: 'Product Test',
-              amount: '20',
+              amount: '0.01',
             ),
           ],
           country: 'Es',

--- a/example/lib/screens/wallets/apple_pay_screen_plugin.dart
+++ b/example/lib/screens/wallets/apple_pay_screen_plugin.dart
@@ -73,7 +73,6 @@ class _ApplePayExternalPluginScreenState
       // 1. Get Stripe token from payment result
       final token = await Stripe.instance.createApplePayToken(paymentResult);
       print(token.id);
-
       // 2. fetch Intent Client Secret from backend
       final response = await fetchPaymentIntentClientSecret();
       final clientSecret = response['clientSecret'];

--- a/example/lib/screens/wallets/apple_pay_screen_plugin.dart
+++ b/example/lib/screens/wallets/apple_pay_screen_plugin.dart
@@ -43,7 +43,7 @@ class _ApplePayExternalPluginScreenState
     return ExampleScaffold(
       title: 'Apple Pay',
       padding: EdgeInsets.all(16),
-      tags: ['Apple', 'Pay plugin'],
+      tags: ['iOS', 'Pay plugin'],
       children: [
         pay.ApplePayButton(
           paymentConfigurationAsset: 'apple_pay_payment_profile.json',
@@ -73,7 +73,7 @@ class _ApplePayExternalPluginScreenState
       // 1. Get Stripe token from payment result
       final token = await Stripe.instance.createApplePayToken(paymentResult);
       print(token.id);
-      
+
       // 2. fetch Intent Client Secret from backend
       final response = await fetchPaymentIntentClientSecret();
       final clientSecret = response['clientSecret'];

--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -117,6 +117,21 @@ class Stripe {
     return isSupported;
   }
 
+  /// Creates a single-use token that represents an Apple Pay credit card’s details.
+  ///
+  /// Tokens are considered legacy, use [PaymentMethod] and [PaymentIntent]
+  /// instead.
+  /// Throws an [StripeError] in case createToken fails.
+  Future<TokenData> createApplePayToken(Map<String, dynamic> payment) async {
+    await _awaitForSettings();
+    try {
+      final tokenData = await _platform.createApplePayToken(payment);
+      return tokenData;
+    } on StripeError catch (error) {
+      throw StripeError(message: error.message, code: error.message);
+    }
+  }
+
   ///Converts payment information defined in [data] into a [PaymentMethod]
   ///object that can be passed to your server.
   ///

--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -118,10 +118,12 @@ class Stripe {
   }
 
   /// Creates a single-use token that represents an Apple Pay credit card’s details.
+  /// 
+  /// The [payment] param should be the data response from the `pay` plugin. It can 
+  /// be used both with the callback `onPaymentResult` from `pay.ApplePayButton` or 
+  /// directly with `Pay.showPaymentSelector`
   ///
-  /// Tokens are considered legacy, use [PaymentMethod] and [PaymentIntent]
-  /// instead.
-  /// Throws an [StripeError] in case createToken fails.
+  /// Throws an [StripeError] in case createApplePayToken fails.
   Future<TokenData> createApplePayToken(Map<String, dynamic> payment) async {
     await _awaitForSettings();
     try {

--- a/packages/stripe_ios/ios/Classes/StripePlugin+PayPlugin.swift
+++ b/packages/stripe_ios/ios/Classes/StripePlugin+PayPlugin.swift
@@ -1,0 +1,122 @@
+import Flutter
+import UIKit
+import Stripe
+import PassKit
+
+
+extension StripePlugin {
+    
+    func createApplePayToken(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let arguments = call.arguments as? FlutterMap,
+        let params = arguments["payment"] as? NSDictionary else {
+            result(FlutterError.invalidParams)
+            return
+        }
+        do {
+            let payment = try PKMapPayment(params:  params)
+        STPAPIClient.shared.createToken(with: payment) { (token, error) in
+            if error != nil || token == nil {
+                result(Errors.createError("Failed", error?.localizedDescription ?? ""))
+            } else {
+                result(Mappers.createResult("token", Mappers.mapFromToken(token: token!)))
+            }
+        }
+            
+        } catch {
+            result(Errors.createError("Failed", error.localizedDescription ))
+        }
+            
+    }
+
+}
+
+
+
+
+class PKMapPayment : PKPayment {
+    
+    enum PKPaymentParamError: Error {
+        case invalidToken
+        case invalidPaymentData
+    }
+  
+    
+    init(params: NSDictionary) throws {
+        guard let token = (params["token"] as? String ?? "").data(using: .utf8),
+              let paymentMethod =  params["paymentMethod"] as? NSDictionary else {
+            throw PKPaymentParamError.invalidToken
+            
+        }
+        self.stp_token = try PaymentToken(token: token, paymentMethod:paymentMethod)
+        
+    }
+    
+    let stp_token : PKPaymentToken
+    override var token : PKPaymentToken{
+        return stp_token
+    }
+    
+    class PaymentToken : PKPaymentToken {
+
+        let stp_transactionIdentifier : String
+        let stp_paymentData : Data
+        let stp_paymentMethod : PaymentMethod
+    
+        
+        override var paymentMethod: PKPaymentMethod {
+            return stp_paymentMethod
+        }
+
+
+        override var transactionIdentifier: String {
+            return stp_transactionIdentifier
+        }
+
+        override var paymentData: Data {
+           return stp_paymentData
+        }
+        
+        init(token: Data, paymentMethod: NSDictionary) throws {
+           
+            if !token.isEmpty,
+                let params = try JSONSerialization.jsonObject(with: token, options: .mutableContainers) as? NSDictionary,
+                let header = params["header"] as? NSDictionary {
+                stp_transactionIdentifier = header["transactionId"] as? String ?? ""
+            } else {
+                assert(
+                    !(STPAPIClient.shared.publishableKey?.hasPrefix("pk_live") ?? false),
+                    "The pk_token is empty. Using Apple Pay with an iOS Simulator while not in Stripe Test Mode will always fail."
+                )
+                stp_transactionIdentifier = "Simulated Identifier"
+            }
+            
+            stp_paymentData = token
+            stp_paymentMethod = try PaymentMethod(paymentMethod: paymentMethod)
+            super.init()
+        }
+      
+        
+        
+    }
+    
+    class PaymentMethod : PKPaymentMethod {
+        let stp_network : PKPaymentNetwork?
+        let stp_displayName : String?
+
+        override var displayName: String? {
+            return stp_displayName
+        }
+
+        override var network: PKPaymentNetwork? {
+            return stp_network
+        }
+        
+        init( paymentMethod: NSDictionary) throws {
+            stp_displayName = paymentMethod["displayName"] as? String
+            stp_network = PKPaymentNetwork(rawValue: paymentMethod["network"] as? String  ?? "")
+            super.init()
+        }
+        
+    }
+}
+

--- a/packages/stripe_ios/ios/Classes/StripePlugin.swift
+++ b/packages/stripe_ios/ios/Classes/StripePlugin.swift
@@ -82,6 +82,8 @@ class StripePlugin: StripeSdk, FlutterPlugin, ViewManagerDelegate {
             return createToken(call, result: result)
         case "dangerouslyUpdateCardDetails":
             return dangerouslyUpdateCardDetails(call, result: result)
+        case "createApplePayToken":
+            return createApplePayToken(call, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -268,6 +268,16 @@ class MethodChannelStripe extends StripePlatform {
       throw ResultParser<void>(parseJson: (json) => {}).parseError(result);
     }
   }
+
+  @override
+  Future<TokenData> createApplePayToken(Map<String, dynamic> payment) async {
+      final result = await _methodChannel.invokeMapMethod<String, dynamic>(
+        'createApplePayToken', {'payment': payment});
+
+    return ResultParser<TokenData>(
+            parseJson: (json) => TokenData.fromJson(json))
+        .parse(result: result!, successResultKey: 'token');
+  }
 }
 
 class MethodChannelStripeFactory {

--- a/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
@@ -60,6 +60,7 @@ abstract class StripePlatform extends PlatformInterface {
 
   Future<void> presentApplePay(ApplePayPresentParams params);
   Future<void> confirmApplePayPayment(String clientSecret);
+  Future<TokenData> createApplePayToken(Map<String, dynamic> payment);
 
   Future<void> initGooglePay(GooglePayInitParams params);
   Future<void> presentGooglePay(PresentGooglePayParams params);


### PR DESCRIPTION
Merge after [/examples](https://github.com/flutter-stripe/flutter_stripe/tree/examples) branch

- Adds `createApplePayToken` method that generates a valid Stripe card token from the result of the Apple Pay button from `pay` plugin.
- Adds Apple Pay example with `pay` plugin