### PR TITLE
Add onFocus param to android platform views

### DIFF
--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -118,9 +118,9 @@ class Stripe {
   }
 
   /// Creates a single-use token that represents an Apple Pay credit card’s details.
-  /// 
-  /// The [payment] param should be the data response from the `pay` plugin. It can 
-  /// be used both with the callback `onPaymentResult` from `pay.ApplePayButton` or 
+  ///
+  /// The [payment] param should be the data response from the `pay` plugin. It can
+  /// be used both with the callback `onPaymentResult` from `pay.ApplePayButton` or
   /// directly with `Pay.showPaymentSelector`
   ///
   /// Throws an [StripeError] in case createApplePayToken fails.

--- a/packages/stripe/lib/src/widgets/card_field.dart
+++ b/packages/stripe/lib/src/widgets/card_field.dart
@@ -240,8 +240,8 @@ class _CardFieldState extends State<CardField> {
     // Flutter fonts need to be loaded in the native framework to work
     // As this is not automatic, default fonts are omitted
     final fontFamily = widget.style?.fontFamily;
-      //  Theme.of(context).textTheme.subtitle1?.fontFamily ??
-      //  kCardFieldDefaultFontFamily;
+    //  Theme.of(context).textTheme.subtitle1?.fontFamily ??
+    //  kCardFieldDefaultFontFamily;
 
     return CardStyle(
       textColor: widget.style?.color,
@@ -616,6 +616,9 @@ class _AndroidCardField extends StatelessWidget {
           layoutDirection: Directionality.of(context),
           creationParams: creationParams,
           creationParamsCodec: const StandardMessageCodec(),
+          onFocus: () {
+            params.onFocusChanged(true);
+          },
         )
           ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
           ..create();

--- a/packages/stripe/lib/src/widgets/card_form_field.dart
+++ b/packages/stripe/lib/src/widgets/card_form_field.dart
@@ -17,7 +17,7 @@ const String _kDebugPCIMessage =
     'set `dangerouslyGetFullCardDetails: true`';
 
 /// Customizable form that collects card information.
-/// 
+///
 /// Notice implementation differs for iOS and Android platforms:
 /// ![Sripe Card Form]
 /// (https://github.com/flutter-stripe/flutter_stripe/tree/main/docs/assets/card_form.png)
@@ -192,24 +192,22 @@ class _CardFormFieldState extends State<CardFormField> {
     final inputDecoration = effectiveDecoration(widget.decoration);
     final style = effectiveCardStyle(inputDecoration);
 
-    return  _MethodChannelCardFormField(
-        focusNode: _node,
-        controller: controller,
-        style: style,
-        placeholder: CardPlaceholder(
-          number: widget.numberHintText,
-          expiration: widget.expirationHintText,
-          cvc: widget.cvcHintText,
-          postalCode: widget.postalCodeHintText,
-        ),
-        dangerouslyGetFullCardDetails: widget.dangerouslyGetFullCardDetails,
-        dangerouslyUpdateFullCardDetails:
-            widget.dangerouslyUpdateFullCardDetails,
-        enablePostalCode: widget.enablePostalCode,
-        onCardChanged: widget.onCardChanged,
-        autofocus: widget.autofocus,
-        onFocus: widget.onFocus,
-      
+    return _MethodChannelCardFormField(
+      focusNode: _node,
+      controller: controller,
+      style: style,
+      placeholder: CardPlaceholder(
+        number: widget.numberHintText,
+        expiration: widget.expirationHintText,
+        cvc: widget.cvcHintText,
+        postalCode: widget.postalCodeHintText,
+      ),
+      dangerouslyGetFullCardDetails: widget.dangerouslyGetFullCardDetails,
+      dangerouslyUpdateFullCardDetails: widget.dangerouslyUpdateFullCardDetails,
+      enablePostalCode: widget.enablePostalCode,
+      onCardChanged: widget.onCardChanged,
+      autofocus: widget.autofocus,
+      onFocus: widget.onFocus,
     );
   }
 
@@ -584,6 +582,9 @@ class _AndroidCardFormField extends StatelessWidget {
           layoutDirection: Directionality.of(context),
           creationParams: creationParams,
           creationParamsCodec: const StandardMessageCodec(),
+          onFocus: () {
+            params.onFocusChanged(true);
+          },
         )
           ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
           ..create();

--- a/packages/stripe/lib/src/widgets/google_pay_button.dart
+++ b/packages/stripe/lib/src/widgets/google_pay_button.dart
@@ -59,6 +59,9 @@ class _GooglePayButtonState extends State<GooglePayButton> {
           layoutDirection: TextDirection.ltr,
           creationParams: _creationParams,
           creationParamsCodec: const StandardMessageCodec(),
+          onFocus: () {
+            params.onFocusChanged(true);
+          },
         )
           ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
           ..create();


### PR DESCRIPTION
The Flutter team came back regarding https://github.com/flutter/flutter/issues/86480 and noted a previously undocumented requirement for Android platform views to call back to Dart when there's a platform focus event.

I've tested this fix but unfortunately it does _not_ resolve the `CardField` focus issues I am experiencing in my application as described in #14. There must be something else going on.