### PR TITLE
Added missing billing name for Future Payments

### DIFF
--- a/example/lib/screens/others/setup_future_payment_screen.dart
+++ b/example/lib/screens/others/setup_future_payment_screen.dart
@@ -112,6 +112,7 @@ class _SetupFuturePaymentScreenState extends State<SetupFuturePaymentScreen> {
 
       // 2. Gather customer billing information (ex. email)
       final billingDetails = BillingDetails(
+        name: "Test User",
         email: 'email@stripe.com',
         phone: '+48888000888',
         address: Address(


### PR DESCRIPTION
Addresses the issue found when calling confirmSetupIntent() showing the following error:
> You passed an empty string for 'payment_method_data[billing_details][name]'.