### PR TITLE
feat: add token & paymentMethodId handling to confirmSetupIntent for Cards

### DIFF
--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -171,14 +171,31 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createCardPaymentSetupParams(): ConfirmSetupIntentParams {
+    val paymentMethodId = getValOr(params, "paymentMethodId", null)
+    val token = getValOr(params, "token", null)
     val cardParams = cardFieldView?.cardParams ?: cardFormView?.cardParams
-    ?: throw PaymentMethodCreateParamsException("Card details not complete")
+
+    if (paymentMethodId != null) {
+      return ConfirmSetupIntentParams.create(
+        paymentMethodId,
+        clientSecret
+      )
+    }
 
     val paymentMethodCreateParams =
-      PaymentMethodCreateParams.create(cardParams, billingDetailsParams)
+      if (token != null)
+        PaymentMethodCreateParams.create(PaymentMethodCreateParams.Card.create(token), billingDetailsParams)
+      else if (cardParams != null)
+        PaymentMethodCreateParams.create(cardParams, billingDetailsParams)
+      else
+        null
 
-    return ConfirmSetupIntentParams
-      .create(paymentMethodCreateParams, clientSecret)
+    if (paymentMethodCreateParams != null) {
+      return ConfirmSetupIntentParams
+        .create(paymentMethodCreateParams, clientSecret)
+    } else {
+      throw PaymentMethodCreateParamsException("Card details not complete")
+    }
   }
 
   @Throws(PaymentMethodCreateParamsException::class)


### PR DESCRIPTION
This is fix for https://github.com/flutter-stripe/flutter_stripe/issues/387 which I've cherry-picked from https://github.com/stripe/stripe-react-native/pull/931.

An a better alternative to merging this PR would be to sync this project with version `0.9.0` of React Native Stripe which was just released and also contains this fix, however there are several breaking changes to accommodate too (I believe we are currently synced with `0.7.0`).

Posting this up anyway for those who may want to reference my fork in the meantime.