### PR TITLE
fix handleCardAction throws MissingPluginException on iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The library offers several methods to handle stripe related actions:
 
 ```dart
 Future<PaymentMethod> createPaymentMethod(...);
-Future<PaymentIntent> handleCardAction(...);
+Future<PaymentIntent> handleNextAction(...);
 Future<PaymentIntent> confirmPayment(...);
 Future<void> configure3dSecure(...);
 Future<bool> isApplePaySupported();

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -85,7 +85,7 @@ To initialize Stripe in your Flutter app, use the `Stripe` base class.
 The library offers several methods to handle stripe related actions:
 ```dart
 Future<PaymentMethod> createPaymentMethod(...);
-Future<PaymentIntent> handleCardAction(...);
+Future<PaymentIntent> handleNextAction(...);
 Future<PaymentIntent> confirmPayment(...);
 Future<void> configure3dSecure(...);
 Future<bool> isApplePaySupported();

--- a/example/lib/screens/card_payments/custom_card_payment_screen.dart
+++ b/example/lib/screens/card_payments/custom_card_payment_screen.dart
@@ -175,9 +175,9 @@ class _CustomCardPaymentScreenState extends State<CustomCardPaymentScreen> {
 
       if (paymentIntentResult['clientSecret'] != null &&
           paymentIntentResult['requiresAction'] == true) {
-        // 4. if payment requires action calling handleCardAction
+        // 4. if payment requires action calling handleNextAction
         final paymentIntent = await Stripe.instance
-            .handleCardAction(paymentIntentResult['clientSecret']);
+            .handleNextAction(paymentIntentResult['clientSecret']);
 
         if (paymentIntent.status == PaymentIntentsStatus.RequiresConfirmation) {
           // 5. Call API to confirm intent

--- a/example/lib/screens/card_payments/no_webhook_payment_cardform_screen.dart
+++ b/example/lib/screens/card_payments/no_webhook_payment_cardform_screen.dart
@@ -137,9 +137,9 @@ class _NoWebhookPaymentCardFormScreenState
 
       if (paymentIntentResult['clientSecret'] != null &&
           paymentIntentResult['requiresAction'] == true) {
-        // 4. if payment requires action calling handleCardAction
+        // 4. if payment requires action calling handleNextAction
         final paymentIntent = await Stripe.instance
-            .handleCardAction(paymentIntentResult['clientSecret']);
+            .handleNextAction(paymentIntentResult['clientSecret']);
 
         // todo handle error
         /*if (cardActionError) {

--- a/example/lib/screens/card_payments/no_webhook_payment_screen.dart
+++ b/example/lib/screens/card_payments/no_webhook_payment_screen.dart
@@ -137,9 +137,9 @@ class _NoWebhookPaymentScreenState extends State<NoWebhookPaymentScreen> {
 
       if (paymentIntentResult['clientSecret'] != null &&
           paymentIntentResult['requiresAction'] == true) {
-        // 4. if payment requires action calling handleCardAction
+        // 4. if payment requires action calling handleNextAction
         final paymentIntent = await Stripe.instance
-            .handleCardAction(paymentIntentResult['clientSecret']);
+            .handleNextAction(paymentIntentResult['clientSecret']);
 
         // todo handle error
         /*if (cardActionError) {

--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -135,7 +135,7 @@ The library offers several methods to handle stripe related actions:
 
 ```dart
 Future<PaymentMethod> createPaymentMethod(...);
-Future<PaymentIntent> handleCardAction(...);
+Future<PaymentIntent> handleNextAction(...);
 Future<PaymentIntent> confirmPayment(...);
 Future<void> configure3dSecure(...);
 Future<bool> isApplePaySupported();

--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -267,13 +267,13 @@ class Stripe {
   /// several seconds and it is important to not resubmit the form.
   ///
   /// Throws a [StripeException] when confirming the handle card action fails.
-  Future<PaymentIntent> handleCardAction(
+  Future<PaymentIntent> handleNextAction(
     String paymentIntentClientSecret,
   ) async {
     await _awaitForSettings();
     try {
       final paymentIntent =
-          await _platform.handleCardAction(paymentIntentClientSecret);
+          await _platform.handleNextAction(paymentIntentClientSecret);
       return paymentIntent;
     } on StripeError {
       //throw StripeError<CardActionError>(error.code, error.message);

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -126,10 +126,10 @@ class MethodChannelStripe extends StripePlatform {
   }
 
   @override
-  Future<PaymentIntent> handleCardAction(
+  Future<PaymentIntent> handleNextAction(
       String paymentIntentClientSecret) async {
     final result = await _methodChannel
-        .invokeMapMethod<String, dynamic>('handleCardAction', {
+        .invokeMapMethod<String, dynamic>('handleNextAction', {
       'paymentIntentClientSecret': paymentIntentClientSecret,
     });
 

--- a/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
@@ -39,7 +39,7 @@ abstract class StripePlatform extends PlatformInterface {
     Map<String, String> options = const {},
   ]);
 
-  Future<PaymentIntent> handleCardAction(String paymentIntentClientSecret);
+  Future<PaymentIntent> handleNextAction(String paymentIntentClientSecret);
   Future<PaymentIntent> confirmPayment(
       String paymentIntentClientSecret, PaymentMethodParams params,
       [Map<String, String> options = const {}]);

--- a/packages/stripe_platform_interface/test/method_channel_stripe_test.dart
+++ b/packages/stripe_platform_interface/test/method_channel_stripe_test.dart
@@ -242,7 +242,7 @@ void main() {
       });
     });
 
-    group('handleCardAction', () {
+    group('handleNextAction', () {
       late PaymentIntent result;
 
       group('When handling card action is successfull', () {
@@ -252,14 +252,14 @@ void main() {
             platformIsAndroid: false,
             methodChannel: MethodChannelMock(
               channelName: methodChannelName,
-              method: 'handleCardAction',
+              method: 'handleNextAction',
               result: {
                 "paymentIntent":
                     PaymentIntentTestInstance.create('id1').toJsonMap()
               },
             ).methodChannel,
           );
-          result = await sut.handleCardAction('paymentIntentId');
+          result = await sut.handleNextAction('paymentIntentId');
         });
 
         test('It returns payment intent', () {
@@ -274,7 +274,7 @@ void main() {
             platformIsAndroid: false,
             methodChannel: MethodChannelMock(
               channelName: methodChannelName,
-              method: 'handleCardAction',
+              method: 'handleNextAction',
               result: createErrorResponse('whoops'),
             ).methodChannel,
           );
@@ -282,7 +282,7 @@ void main() {
 
         test('It returns error', () async {
           expect(
-            () async => await sut.handleCardAction('paymentIntentId'),
+            () async => await sut.handleNextAction('paymentIntentId'),
             throwsA(const TypeMatcher<StripeException>()),
           );
         });

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -196,7 +196,7 @@ class WebStripe extends StripePlatform {
   }
 
   @override
-  Future<PaymentIntent> handleCardAction(
+  Future<PaymentIntent> handleNextAction(
     String paymentIntentClientSecret,
   ) async {
     final s.PaymentIntentResponse response =


### PR DESCRIPTION
**Describe the bug**

throws `MissingPluginException` on iOS and Android when 3D secure action is required.

```
Unhandled Exception: MissingPluginException(No implementation found for method handleCardAction on channel flutter.stripe/payments)
#0      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:165:7)
<asynchronous suspension>
#1      MethodChannel.invokeMapMethod (package:flutter/src/services/platform_channel.dart:367:43)
<asynchronous suspension>
#2      MethodChannelStripe.handleCardAction (package:stripe_platform_interface/src/method_channel_stripe.dart:131:20)
<asynchronous suspension>
#3      Stripe.handleCardAction (package:flutter_stripe/src/stripe.dart:276:11)
<asynchronous suspension>
#4      _NoWebhookPaymentScreenState._handlePayPress (package:stripe_example/screens/card_payments/no_webhook_payment_screen.dart:141:31)
<asynchronous suspension>
#5      _LoadingButtonState._loadFuture (package:stripe_example/widgets/loading_button.dart:50:7)
<asynchronous suspension>
```

**To Reproduce**

* Run example
* Select "Card Payments" - "Without webhooks"
* Use number that requires 3D secure
  * `4000 0027 6000 3184` from https://stripe.com/docs/testing#regulatory-cards

**Expected behavior**

No exceptions.

**Smartphone / tablet**
 - Device: iOS Simulator
 - OS: iOS 15.5
 - Package version: 3.0.0
 - Flutter version: 3.0.0

**Additional context**

CHANGELOG 2.5.0 notes:

```
- Removed handleCardAction in favor of handleNextAction. handleNextAction functions exactly the same, this is just a rename.
```

`handleCardAction` has been renamed in StripePlugin.swift and StripeAndroidPlugin.kt.
However, stripe_platform_interface has not been rnamed.



