### PR TITLE
fix unsafe operation warning from gradle

### DIFF
--- a/packages/stripe_android/android/src/main/kotlin/com/facebook/react/bridge/ReactContextBaseJavaModule.java
+++ b/packages/stripe_android/android/src/main/kotlin/com/facebook/react/bridge/ReactContextBaseJavaModule.java
@@ -38,7 +38,7 @@ public class ReactContextBaseJavaModule implements PluginRegistry.ActivityResult
     }
 
     public Map<String, Object> getConstants() {
-        return new HashMap();
+        return new HashMap<String, Object>();
     }
 
     @Override


### PR DESCRIPTION
since we converted this class ourselves to flutter I thought it won't hurt to fix this small warning. 

fixes #819 