### PR TITLE
Add credit card support to flutter_stripe web

### DIFF
--- a/packages/stripe_web/lib/src/js/models/payment_request.dart
+++ b/packages/stripe_web/lib/src/js/models/payment_request.dart
@@ -223,8 +223,15 @@ abstract class _StripePaymentRequest {
   external Promise<dynamic /*{ applePay?: boolean }|Null*/ > canMakePayment();
 }
 
+@anonymous
+@JS()
+abstract class CanMakePaymentResult {
+  external bool get applePay;
+  external bool get googlePay;
+}
+
 extension StripePaymentRequestExtensions on StripePaymentRequest {
-  Future<dynamic /*{ applePay?: boolean }|Null*/ > canMakePayment() {
+  Future<CanMakePaymentResult> canMakePayment() {
     final _StripePaymentRequest tt = this as _StripePaymentRequest;
     return promiseToFuture(tt.canMakePayment());
   }

--- a/packages/stripe_web/lib/src/parser/card.dart
+++ b/packages/stripe_web/lib/src/parser/card.dart
@@ -1,0 +1,26 @@
+import 'package:stripe_platform_interface/stripe_platform_interface.dart';
+import '../js/js.dart' as s;
+
+extension CardParser on s.Card {
+  CardData parse() {
+    return CardData(
+      id: id,
+      name: name,
+      brand: brand,
+      expYear: exp_year.toInt(),
+      expMonth: exp_month.toInt(),
+      last4: last4,
+      country: country,
+      currency: currency,
+      funding: funding,
+      address: Address(
+        city: address_city,
+        country: address_country,
+        line1: address_line1,
+        line2: address_line2,
+        postalCode: address_zip,
+        state: address_state,
+      ),
+    );
+  }
+}

--- a/packages/stripe_web/lib/src/parser/token.dart
+++ b/packages/stripe_web/lib/src/parser/token.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_stripe_web/flutter_stripe_web.dart';
+import '../js/js.dart' as s;
+import 'card.dart';
+
+extension TokenParser on s.Token {
+  TokenData parse() {
+    final tokenData = TokenData(
+      id: id,
+      type: _parseTokenType(type),
+      card: card.parse(),
+      createdDateTime: created.toString(),
+      livemode: livemode,
+    );
+    return tokenData;
+  }
+}
+
+// Type of the token: "account", "bank_account", "card", or "pii" from Stripe API
+// TODO: add TokenType.Account
+TokenType _parseTokenType(String type) {
+  switch (type) {
+    case 'card':
+      return TokenType.Card;
+    case 'bank_account':
+      return TokenType.BankAccount;
+    case 'pii':
+      return TokenType.Pii;
+  }
+  throw WebUnsupportedError('TokenType $type is not supported');
+}

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -240,7 +240,8 @@ class WebStripe extends StripePlatform {
 
   @override
   Future<void> initGooglePay(GooglePayInitParams params) {
-    throw WebUnsupportedError.method('initGooglePay');
+    // It doesn't look like there is any setup required on web
+    return Future.value();
   }
 
   @override
@@ -259,14 +260,14 @@ class WebStripe extends StripePlatform {
     ));
 
     void paymentRequestOnPaymentMethod(event) async {
-      event.complete('success');
-
       final paymentMethod = event.paymentMethod as s.PaymentMethod;
 
       await js.confirmCardPayment(
         params.clientSecret,
         data: s.ConfirmCardPaymentData(payment_method: paymentMethod.id),
       );
+
+      event.complete('success');
 
       completer.complete();
     }
@@ -292,8 +293,10 @@ class WebStripe extends StripePlatform {
     final paymentRequest = js.paymentRequest(s.StripePaymentRequestOptions(
       country: 'US',
       currency: 'usd',
+      total: s.DisplayItem(amount: 1000, label: 'Total'),
     ));
     final canMakePayment = await paymentRequest.canMakePayment();
+
     return canMakePayment.googlePay;
   }
 

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -252,7 +252,10 @@ class WebStripe extends StripePlatform {
     final paymentRequest = js.paymentRequest(s.StripePaymentRequestOptions(
       country: 'us',
       currency: paymentIntent.currency,
-      total: s.DisplayItem(amount: paymentIntent.amount.toInt()),
+      total: s.DisplayItem(
+        amount: paymentIntent.amount.toInt(),
+        label: paymentIntent.description ?? '',
+      ),
     ));
 
     void paymentRequestOnPaymentMethod(event) async {

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -250,7 +250,7 @@ class WebStripe extends StripePlatform {
     final paymentIntent = await retrievePaymentIntent(params.clientSecret);
 
     final paymentRequest = js.paymentRequest(s.StripePaymentRequestOptions(
-      country: 'us',
+      country: 'US',
       currency: paymentIntent.currency,
       total: s.DisplayItem(
         amount: paymentIntent.amount.toInt(),
@@ -278,10 +278,10 @@ class WebStripe extends StripePlatform {
 
     final canMakePayment = await paymentRequest.canMakePayment();
 
-    if (canMakePayment.googlePay) {
+    if (canMakePayment.googlePay || canMakePayment.applePay) {
       paymentRequest.show();
     } else {
-      completer.completeError('google pay wallet not supported');
+      completer.completeError('pay wallet not supported');
     }
 
     return completer.future;

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -10,6 +10,7 @@ import 'js/js.dart' as s;
 import 'parser/payment_intent.dart';
 import 'parser/payment_methods.dart';
 import 'parser/setup_intent.dart';
+import 'parser/token.dart';
 
 /// An implementation of [StripePlatform] that uses method channels.
 class WebStripe extends StripePlatform {
@@ -205,8 +206,9 @@ class WebStripe extends StripePlatform {
   }
 
   @override
-  Future<TokenData> createToken(CreateTokenParams params) {
-    throw UnimplementedError();
+  Future<TokenData> createToken(CreateTokenParams params) async {
+    final response = await _stripe.createToken(element!);
+    return response.token.parse();
   }
 
   @override


### PR DESCRIPTION
WIP: Proof of concept not yet ready for merge.

Right now the `createToken` method is unimplemented for the web platform. This PR implements it to add credit card support.

I haven't checked yet how to handle `CreateTokenParams`. I suppose I'll need to pass these options along to the javascript `createToken` function. 

Feel free to review, ignore, or use for a future implementation. Whatever is most efficient for you all :)

cc @jonasbark @jamesblasco 

Video of internal prototype:

https://user-images.githubusercontent.com/220686/178574671-9ee35a8a-bae7-4c0c-84de-8eb64fe583ac.mp4

P.S. I was hoping to sponsor a bit of development to get this package working on the web platform, but I was unable to get in touch with folks over email. Not sure on the best person to contact or if the team has their hands full.