### PR TITLE
fix: No payment sheet has been initialized yet on iOS

### DIFF
--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -329,6 +329,7 @@ class Stripe {
   Future<void> initPaymentSheet({
     required SetupPaymentSheetParameters paymentSheetParameters,
   }) async {
+    assert(!(paymentSheetParameters.applePay == true && instance._merchantIdentifier == null), 'merchantIdentifier must be specified if you are using Apple Pay. Please refer to this article to get a merchant identifier: https://support.stripe.com/questions/enable-apple-pay-on-your-stripe-account');
     await _awaitForSettings();
     await _platform.initPaymentSheet(paymentSheetParameters);
   }


### PR DESCRIPTION
Assertion to make sure merchantIdentifier is set if using apple pay. 
At the moment, it just errors saying "No payment sheet has been initialized yet"

#850 & #385 