### PR TITLE
Fix: implemented handleURLCallback method for iOS iDeal payment.

### DIFF
--- a/packages/stripe/CHANGELOG.md
+++ b/packages/stripe/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.1
+ - Fix for #462, added `handleURLCallback` method for iOS to handle `returnUrl` when iDeal payment is successful. This will close the in-app webview of Safari
+ 
 ## 5.0.0
 Breaking changes
 - Your compileSdkVersion (in android/build.gradle) now must be at least 32. Changing your compileSdkVersion does not change runtime behavior.

--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -26,7 +26,7 @@ class Stripe {
 
   /// Retrieves the publishable API key.
   static String get publishableKey {
-    if(instance._publishableKey == null){
+    if (instance._publishableKey == null) {
       throw const StripeConfigException('Publishable key is not set');
     }
     return instance._publishableKey!;
@@ -241,6 +241,15 @@ class Stripe {
     }
   }
 
+  /// Handle URL callback from iDeal payment returnUrl to close iOS in-app webview
+  Future<bool> handleURLCallback(String url) async {
+    try {
+      return await _platform.handleURLCallback(url);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   /// Confirms a payment method, using the provided [paymentIntentClientSecret]
   /// and [data].
   ///
@@ -330,7 +339,10 @@ class Stripe {
   Future<void> initPaymentSheet({
     required SetupPaymentSheetParameters paymentSheetParameters,
   }) async {
-    assert(!(paymentSheetParameters.applePay !=null && instance._merchantIdentifier == null), 'merchantIdentifier must be specified if you are using Apple Pay. Please refer to this article to get a merchant identifier: https://support.stripe.com/questions/enable-apple-pay-on-your-stripe-account');
+    assert(
+        !(paymentSheetParameters.applePay != null &&
+            instance._merchantIdentifier == null),
+        'merchantIdentifier must be specified if you are using Apple Pay. Please refer to this article to get a merchant identifier: https://support.stripe.com/questions/enable-apple-pay-on-your-stripe-account');
     await _awaitForSettings();
     await _platform.initPaymentSheet(paymentSheetParameters);
   }

--- a/packages/stripe/pubspec.yaml
+++ b/packages/stripe/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_stripe
 description: Flutter library for Stripe. Supports PaymentSheets, Apple & Google Pay, SCA, PSD2 and much more.
-version: 5.0.0
+version: 5.0.1
 homepage: https://github.com/flutter-stripe/flutter_stripe
 repository: https://github.com/flutter-stripe/flutter_stripe
 
@@ -22,12 +22,9 @@ dependencies:
   flutter:
     sdk: flutter
   stripe_android: ^5.0.0
-  stripe_ios: ^5.0.0
-  stripe_platform_interface: ^5.0.0
+  stripe_ios: ^5.0.1
+  stripe_platform_interface: ^5.0.1
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.1
-
-
-

--- a/packages/stripe_ios/CHANGELOG.md
+++ b/packages/stripe_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+- Fix for #462, added `handleURLCallback` method for iOS to handle `returnUrl` when iDeal payment is successful. This will close the in-app webview of Safari
+
 ## 5.0.0
 Breaking changes
 - Your compileSdkVersion (in android/build.gradle) now must be at least 32. Changing your compileSdkVersion does not change runtime behavior.

--- a/packages/stripe_ios/ios/Classes/Stripe Sdk/StripeSdk.swift
+++ b/packages/stripe_ios/ios/Classes/Stripe Sdk/StripeSdk.swift
@@ -454,7 +454,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
     }
 
     @objc(handleURLCallback:resolver:rejecter:)
-    func handleURLCallback(url: String?, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    func handleURLCallback(url: String?, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {    
       guard let url = url else {
         resolve(false)
         return;

--- a/packages/stripe_ios/ios/Classes/StripePlugin.swift
+++ b/packages/stripe_ios/ios/Classes/StripePlugin.swift
@@ -21,7 +21,6 @@ class StripePlugin: StripeSdk, FlutterPlugin, ViewManagerDelegate {
         
         let instance = StripePlugin(channel: channel)
         registrar.addMethodCallDelegate(instance, channel: channel)
-        registrar.addApplicationDelegate(instance)
         
         // Card Field
         let cardFieldFactory = CardFieldViewFactory(messenger: registrar.messenger(), delegate:instance)
@@ -131,19 +130,6 @@ class StripePlugin: StripeSdk, FlutterPlugin, ViewManagerDelegate {
     override
     func sendEvent(withName name: String, body: [String:  Any]) {
         channel.invokeMethod(name, arguments: body)
-    }
-    
-    public func application( _ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:] ) -> Bool {
-        return StripeAPI.handleURLCallback(with: url)
-    }
-
-    public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool  {
-        if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
-            if let url = userActivity.webpageURL {
-                return StripeAPI.handleURLCallback(with: url)
-            }
-        }
-        return false
     }
 }
 

--- a/packages/stripe_ios/pubspec.yaml
+++ b/packages/stripe_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stripe_ios
 description: Stripe platform implementation for iOS
-version: 5.0.0
+version: 5.0.1
 repository: https://github.com/flutter-stripe/flutter_stripe
 homepage: https://pub.dev/packages/flutter_stripe
 
@@ -18,7 +18,7 @@ dev_dependencies:
   flutter_lints: ^1.0.3
 
 flutter:
-   plugin:
+  plugin:
     platforms:
       ios:
         pluginClass: StripeIosPlugin

--- a/packages/stripe_platform_interface/CHANGELOG.md
+++ b/packages/stripe_platform_interface/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.0.1
+ - Fix for #462, added `handleURLCallback` method for iOS to handle `returnUrl` when iDeal payment is successful. This will close the in-app webview of Safari
 ## 5.0.0
 Breaking changes
 - Your compileSdkVersion (in android/build.gradle) now must be at least 32. Changing your compileSdkVersion does not change runtime behavior.

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -412,6 +412,14 @@ class MethodChannelStripe extends StripePlatform {
 
     return FinancialConnectionSessionResult.fromJson(result);
   }
+
+  @override
+  Future<bool> handleURLCallback(String url) async {
+    final result = await _methodChannel.invokeMethod('handleURLCallback', {
+      'url': url,
+    });
+    return result ?? false;
+  }
 }
 
 class MethodChannelStripeFactory {

--- a/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
@@ -63,6 +63,8 @@ abstract class StripePlatform extends PlatformInterface {
     List<ApplePayErrorAddressField>? errorAddressFields,
   });
 
+  Future<bool> handleURLCallback(String url);
+
   Future<void> initGooglePay(GooglePayInitParams params);
   Future<void> presentGooglePay(PresentGooglePayParams params);
   Future<bool> googlePayIsSupported(IsGooglePaySupportedParams params);

--- a/packages/stripe_platform_interface/pubspec.yaml
+++ b/packages/stripe_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stripe_platform_interface
 description: Platform interface for stripe sdk
-version: 5.0.0
+version: 5.0.1
 repository: https://github.com/flutter-stripe/flutter_stripe
 homepage: https://pub.dev/packages/flutter_stripe
 

--- a/packages/stripe_web/CHANGELOG.md
+++ b/packages/stripe_web/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.1
+- Fix for #462, added `handleURLCallback` method for iOS to handle `returnUrl` when iDeal payment is successful. This will close the in-app webview of Safari. On web not implemented, as not needed.
 ## 1.2.0
 - Several fixes by the Stripe sdk [v.0.15.0](https://github.com/stripe/stripe-react-native/releases/tag/v0.15.0).
 

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -358,6 +358,12 @@ class WebStripe extends StripePlatform {
       {required String clientSecret}) {
     throw WebUnsupportedError.method('collectFinancialConnectionsAccounts');
   }
+
+  @override
+  Future<bool> handleURLCallback(String url) {
+    // TODO: implement handleURLCallback
+    throw UnimplementedError();
+  }
 }
 
 class WebUnsupportedError extends Error implements UnsupportedError {

--- a/packages/stripe_web/pubspec.yaml
+++ b/packages/stripe_web/pubspec.yaml
@@ -1,12 +1,11 @@
 name: flutter_stripe_web
 description: Stripe sdk for Flutter web platform.
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/flutter-stripe/flutter_stripe
 
 environment:
   sdk: ">=2.16.0 <3.0.0"
   flutter: ">=2.0.0"
-
 
 dependencies:
   flutter:
@@ -16,7 +15,6 @@ dependencies:
   freezed_annotation: ^2.0.3
   stripe_platform_interface: ^5.0.0
   js: ^0.6.3
-
 
 dev_dependencies:
   flutter_test:
@@ -29,4 +27,3 @@ flutter:
       web:
         pluginClass: WebStripe
         fileName: flutter_stripe_web.dart
-

--- a/packages/stripe_web/pubspec.yaml
+++ b/packages/stripe_web/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   freezed_annotation: ^2.0.3
-  stripe_platform_interface: ^5.0.0
+  stripe_platform_interface: ^5.0.1
   js: ^0.6.3
 
 dev_dependencies:


### PR DESCRIPTION
`handleURLCallback` method was needed for iOS iDeal payment to close the safari in-app webview. Currently, it happens from `swift` side which doesn't provide the `returnUrl` deep-link in flutter side. So we can not navigate the user from the deep link to the iDeal payment success screen. 