### PR TITLE
[WIP] Support intent:// in webview

### DIFF
--- a/packages/stripe_checkout/lib/src/platforms/stripe_checkout.dart
+++ b/packages/stripe_checkout/lib/src/platforms/stripe_checkout.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 import 'checkout.dart';
@@ -87,7 +88,7 @@ class CheckoutPage extends StatefulWidget {
   /// The URL to which Stripe should send customers when payment is complete.
   ///
   /// Only needed when using on a non web app. If the webview url matches
-  /// this one, [onCompleted] will return as succesfull
+  /// this one, [onCompleted] will return as successful
   final String successUrl;
 
   /// The URL to which Stripe should send customers when payment is canceled.
@@ -133,11 +134,20 @@ class _CheckoutPageState extends State<CheckoutPage> {
               final successUrl = widget.successUrl;
               final canceledUrl = widget.canceledUrl;
 
+              const testUrl =
+                  "intent://ideal.ing.nl/ideal/static/detect/detect_mob?trxid=0140000710955039&random=z05d7b5bbfb700bb";
+              _launchURL(testUrl);
+              return NavigationDecision.prevent;
+
+              print("@@@@@@@@@@@@@@@@@@ request.url: ${request.url}");
               if (request.url.startsWith(successUrl)) {
                 widget.onCompleted?.call(const CheckoutResponse.success());
                 return NavigationDecision.prevent;
               } else if (request.url.startsWith(canceledUrl)) {
                 widget.onCompleted?.call(const CheckoutResponse.canceled());
+                return NavigationDecision.prevent;
+              } else if (request.url.contains(RegExp('^intent://.*\$'))) {
+                _launchURL(request.url);
                 return NavigationDecision.prevent;
               }
               return NavigationDecision.navigate;
@@ -177,6 +187,21 @@ class _CheckoutPageState extends State<CheckoutPage> {
     } catch (e) {
       widget.onCompleted?.call(CheckoutResponse.error(error: e));
     }
+  }
+
+  Future<void> _launchURL(String url) async {
+    final uri = Uri.parse(url);
+
+    await launchUrl(
+      uri,
+      mode: LaunchMode.externalApplication,
+    );
+
+    // if (await canLaunchUrl(uri)) {
+    //
+    // } else {
+    //   throw 'Could not launch $url';
+    // }
   }
 }
 

--- a/packages/stripe_checkout/pubspec.yaml
+++ b/packages/stripe_checkout/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   webview_flutter: ^3.0.4
+  url_launcher: ^6.1.6
   js: ^0.6.3
   json_annotation: ^4.5.0
   freezed_annotation: ^2.0.3


### PR DESCRIPTION
- Sync with React Native 0.17.0 (#874)
- update changelog
- prepare release as 5.0.0
- remove package log from example server (#905)
- throw exception when publishable key is not set (#907)
- add dark launch theme to dark theme to provide better example (#906)
- Bump minimist from 0.0.8 to 1.2.6 in /example/server (#908)
- move google pay gms metadata one level up in manifest (#916)
- Fix mastercard to masterCard (#814)
- add support for connected accounts in checkout session (#894)
- chore: use melos override new option (#924)
- Fix: implemented handleURLCallback method for iOS iDeal payment. (#939)
- Sync with Stripe React Native 0.19.0 (#929)
- wip
