### PR TITLE
fix incorrect parsing resetpaymentsheetcustomer result

### DIFF
--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -249,17 +249,10 @@ class MethodChannelStripe extends StripePlatform {
 
   @override
   Future<void> resetPaymentSheetCustomer() async {
-    final result = await _methodChannel.invokeMethod<dynamic>(
+    await _methodChannel.invokeMethod<dynamic>(
       'resetPaymentSheetCustomer',
       {'params': {}},
     );
-
-    // iOS returns empty list on success
-    if (result is List) {
-      return;
-    } else {
-      return _parsePaymentSheetResult(result);
-    }
   }
 
   @override


### PR DESCRIPTION
do not parse result of resetpaymentsheetcustomer since methodchannel returns nothing

Fix #1036 