### PR TITLE
feat: scroll to keep card field visible

### DIFF
--- a/packages/stripe/lib/src/widgets/card_field.dart
+++ b/packages/stripe/lib/src/widgets/card_field.dart
@@ -298,7 +298,7 @@ class _MethodChannelCardField extends StatefulWidget {
   // time.
   // A unique key is used to throw an expection before multiple platform
   // views are created
-  static final _key = GlobalKey();
+  static final _key = UniqueKey();
 
   @override
   _MethodChannelCardFieldState createState() => _MethodChannelCardFieldState();

--- a/packages/stripe/lib/src/widgets/card_field.dart
+++ b/packages/stripe/lib/src/widgets/card_field.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_stripe/flutter_stripe.dart';
 
 import '../utils.dart';
+import 'keep_visible_on_focus.dart';
 
 /// Customizable form that collects card information.
 class CardField extends StatefulWidget {
@@ -188,9 +189,12 @@ class _CardFieldState extends State<CardField> {
       isFocused: _node.hasFocus,
       decoration: inputDecoration,
       baseStyle: widget.style,
-      child: SizedBox(
-        height: cardHeight,
-        child: platform,
+      child: KeepVisibleOnFocus(
+        focusNode: _node,
+        child: SizedBox(
+          height: cardHeight,
+          child: platform,
+        ),
       ),
     );
   }
@@ -263,7 +267,7 @@ class _MethodChannelCardField extends StatefulWidget {
     double? width,
     double? height = kCardFieldDefaultHeight,
     BoxConstraints? constraints,
-    this.focusNode,
+    required this.focusNode,
     this.dangerouslyGetFullCardDetails = false,
     this.dangerouslyUpdateFullCardDetails = false,
     this.autofocus = false,
@@ -281,7 +285,7 @@ class _MethodChannelCardField extends StatefulWidget {
   final CardPlaceholder? placeholder;
   final bool enablePostalCode;
   final String? countryCode;
-  final FocusNode? focusNode;
+  final FocusNode focusNode;
   final bool autofocus;
   final CardEditController controller;
   final bool dangerouslyGetFullCardDetails;
@@ -294,7 +298,7 @@ class _MethodChannelCardField extends StatefulWidget {
   // time.
   // A unique key is used to throw an expection before multiple platform
   // views are created
-  static final _key = UniqueKey();
+  static final _key = GlobalKey();
 
   @override
   _MethodChannelCardFieldState createState() => _MethodChannelCardFieldState();
@@ -303,10 +307,6 @@ class _MethodChannelCardField extends StatefulWidget {
 class _MethodChannelCardFieldState extends State<_MethodChannelCardField>
     with CardFieldContext {
   MethodChannel? _methodChannel;
-
-  final _focusNode =
-      FocusNode(debugLabel: 'CardField', descendantsAreFocusable: false);
-  FocusNode get _effectiveNode => widget.focusNode ?? _focusNode;
 
   CardStyle? _lastStyle;
   CardStyle resolveStyle(CardStyle? style) {
@@ -365,7 +365,6 @@ class _MethodChannelCardFieldState extends State<_MethodChannelCardField>
   void dispose() {
     detachController(controller);
 
-    _focusNode.dispose();
     super.dispose();
   }
 
@@ -397,14 +396,14 @@ class _MethodChannelCardFieldState extends State<_MethodChannelCardField>
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       platform = Listener(
         onPointerDown: (_) {
-          if (!_effectiveNode.hasFocus) {
-            _effectiveNode.requestFocus();
+          if (!widget.focusNode.hasFocus) {
+            widget.focusNode.requestFocus();
           }
         },
         child: Focus(
           autofocus: widget.autofocus,
           descendantsAreFocusable: true,
-          focusNode: _effectiveNode,
+          focusNode: widget.focusNode,
           onFocusChange: _handleFrameworkFocusChanged,
           child: _UiKitCardField(
             key: _MethodChannelCardField._key,
@@ -483,7 +482,7 @@ class _MethodChannelCardFieldState extends State<_MethodChannelCardField>
   }
 
   void onPlatformViewCreated(int viewId) {
-    _focusNode.debugLabel = 'CardField(id: $viewId)';
+    widget.focusNode.debugLabel = 'CardField(id: $viewId)';
     _methodChannel = MethodChannel('flutter.stripe/card_field/$viewId');
     _methodChannel?.setMethodCallHandler((call) async {
       if (call.method == 'topFocusChange') {
@@ -515,10 +514,12 @@ class _MethodChannelCardFieldState extends State<_MethodChannelCardField>
       final field = CardFieldFocusName.fromJson(map);
       if (field.focusedField != null &&
           ambiguate(WidgetsBinding.instance)?.focusManager.primaryFocus !=
-              _effectiveNode) {
-        _effectiveNode.requestFocus();
+              widget.focusNode) {
+        widget.focusNode.requestFocus();
       }
+
       widget.onFocus?.call(field.focusedField);
+
       // ignore: avoid_catches_without_on_clauses
     } catch (e) {
       dev.log(
@@ -529,7 +530,7 @@ class _MethodChannelCardFieldState extends State<_MethodChannelCardField>
 
   /// Handler called when the focus changes in the node attached to the platform
   /// view. This updates the correspondant platform view to keep it in sync.
-  void _handleFrameworkFocusChanged(bool isFocused) {
+  void _handleFrameworkFocusChanged(bool isFocused) async {
     final methodChannel = _methodChannel;
     if (methodChannel == null) {
       return;
@@ -539,6 +540,7 @@ class _MethodChannelCardFieldState extends State<_MethodChannelCardField>
     }
     if (!isFocused) {
       blur();
+
       return;
     }
 

--- a/packages/stripe/lib/src/widgets/card_form_field.dart
+++ b/packages/stripe/lib/src/widgets/card_form_field.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_stripe/flutter_stripe.dart';
 
 import '../utils.dart';
+import 'keep_visible_on_focus.dart';
 
 /// Customizable form that collects card information.
 ///
@@ -204,7 +205,7 @@ class _MethodChannelCardFormField extends StatefulWidget {
     double? width,
     double? height,
     BoxConstraints? constraints,
-    this.focusNode,
+    required this.focusNode,
     this.dangerouslyGetFullCardDetails = false,
     this.dangerouslyUpdateFullCardDetails = false,
     this.autofocus = false,
@@ -221,7 +222,7 @@ class _MethodChannelCardFormField extends StatefulWidget {
   final CardChangedCallback? onCardChanged;
   final CardFormStyle? style;
   final bool enablePostalCode;
-  final FocusNode? focusNode;
+  final FocusNode focusNode;
   final bool autofocus;
   final CardFormEditController controller;
   final bool dangerouslyGetFullCardDetails;
@@ -245,10 +246,6 @@ class _MethodChannelCardFormField extends StatefulWidget {
 class _MethodChannelCardFormFieldState
     extends State<_MethodChannelCardFormField> with CardFormFieldContext {
   MethodChannel? _methodChannel;
-
-  final _focusNode =
-      FocusNode(debugLabel: 'CardFormField', descendantsAreFocusable: false);
-  FocusNode get _effectiveNode => widget.focusNode ?? _focusNode;
 
   CardFormStyle? _lastStyle;
 
@@ -283,7 +280,7 @@ class _MethodChannelCardFormFieldState
     if (controller._context == this) {
       controller._context = null;
     }
-    _focusNode.dispose();
+
     super.dispose();
   }
 
@@ -315,20 +312,23 @@ class _MethodChannelCardFormFieldState
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       platform = Listener(
         onPointerDown: (_) {
-          if (!_effectiveNode.hasFocus) {
-            _effectiveNode.requestFocus();
+          if (!widget.focusNode.hasFocus) {
+            widget.focusNode.requestFocus();
           }
         },
         child: Focus(
           autofocus: widget.autofocus,
           descendantsAreFocusable: true,
-          focusNode: _effectiveNode,
+          focusNode: widget.focusNode,
           onFocusChange: _handleFrameworkFocusChanged,
-          child: _UiKitCardFormField(
-            key: _MethodChannelCardFormField._key,
-            viewType: _MethodChannelCardFormField._viewType,
-            creationParams: creationParams,
-            onPlatformViewCreated: onPlatformViewCreated,
+          child: KeepVisibleOnFocus(
+            focusNode: widget.focusNode,
+            child: _UiKitCardFormField(
+              key: _MethodChannelCardFormField._key,
+              viewType: _MethodChannelCardFormField._viewType,
+              creationParams: creationParams,
+              onPlatformViewCreated: onPlatformViewCreated,
+            ),
           ),
         ),
       );
@@ -402,7 +402,7 @@ class _MethodChannelCardFormFieldState
   }
 
   void onPlatformViewCreated(int viewId) {
-    _focusNode.debugLabel = 'CardFormField(id: $viewId)';
+    widget.focusNode.debugLabel = 'CardFormField(id: $viewId)';
     _methodChannel = MethodChannel('flutter.stripe/card_form_field/$viewId');
     _methodChannel?.setMethodCallHandler((call) async {
       if (call.method == 'topFocusChange') {
@@ -439,8 +439,8 @@ class _MethodChannelCardFormFieldState
       final field = CardFieldFocusName.fromJson(map);
       if (field.focusedField != null &&
           ambiguate(WidgetsBinding.instance)?.focusManager.primaryFocus !=
-              _effectiveNode) {
-        _effectiveNode.requestFocus();
+              widget.focusNode) {
+        widget.focusNode.requestFocus();
       }
       widget.onFocus?.call(field.focusedField);
       // ignore: avoid_catches_without_on_clauses

--- a/packages/stripe/lib/src/widgets/keep_visible_on_focus.dart
+++ b/packages/stripe/lib/src/widgets/keep_visible_on_focus.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+class KeepVisibleOnFocus extends StatefulWidget {
+  const KeepVisibleOnFocus({
+    Key? key,
+    required this.focusNode,
+    required this.child,
+  }) : super(key: key);
+
+  final FocusNode focusNode;
+
+  final Widget child;
+
+  @override
+  State<KeepVisibleOnFocus> createState() => _KeepVisibleOnFocusState();
+}
+
+class _KeepVisibleOnFocusState extends State<KeepVisibleOnFocus>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    widget.focusNode.addListener(onFocusChanged);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+
+  void onFocusChanged() {
+    if (widget.focusNode.hasFocus) {
+      WidgetsBinding.instance.addObserver(this);
+      _lastBottomViewInset = WidgetsBinding.instance.window.viewInsets.bottom;
+    } else {
+      WidgetsBinding.instance.removeObserver(this);
+    }
+  }
+
+  late double _lastBottomViewInset;
+
+  bool _showOnScreenScheduled = false;
+
+  void _showOnScreen() {
+    if (_showOnScreenScheduled) {
+      return;
+    }
+    _showOnScreenScheduled = true;
+    SchedulerBinding.instance.addPostFrameCallback((Duration _) {
+      _showOnScreenScheduled = false;
+      if (!mounted) return;
+      final renderObject = context.findRenderObject()! as RenderBox;
+
+      renderObject.showOnScreen(
+        // Inflate ensures that caret is not positioned directly at the edge.
+        rect: renderObject.paintBounds.inflate(20.0),
+      );
+    });
+  }
+
+  @override
+  void didChangeMetrics() {
+    if (_lastBottomViewInset !=
+        WidgetsBinding.instance.window.viewInsets.bottom) {
+      if (_lastBottomViewInset <
+          WidgetsBinding.instance.window.viewInsets.bottom) {
+        // Because the metrics change signal from engine will come here every frame
+        // (on both iOS and Android). So we don't need to show caret with animation.
+        _showOnScreen();
+      }
+    }
+    _lastBottomViewInset = WidgetsBinding.instance.window.viewInsets.bottom;
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    widget.focusNode.removeListener(onFocusChanged);
+    super.dispose();
+  }
+}


### PR DESCRIPTION
- CardField and CardFormField now trigger scroll to keep themselves visible on the screen.
- Similar approach than EditableText, the base for TextField