### PR TITLE
Enable automatic webview closing by demand

### DIFF
--- a/example/lib/screens/card_payments/no_webhook_payment_screen.dart
+++ b/example/lib/screens/card_payments/no_webhook_payment_screen.dart
@@ -135,8 +135,10 @@ class _NoWebhookPaymentScreenState extends State<NoWebhookPaymentScreen> {
       if (paymentIntentResult['clientSecret'] != null &&
           paymentIntentResult['requiresAction'] == true) {
         // 4. if payment requires action calling handleNextAction
-        final paymentIntent = await Stripe.instance
-            .handleNextAction(paymentIntentResult['clientSecret']);
+        final paymentIntent = await Stripe.instance.handleNextAction(
+          paymentIntentResult['clientSecret'],
+          returnURL: 'flutterstripe://redirect',
+        );
 
         // todo handle error
         /*if (cardActionError) {

--- a/example/server/src/index.ts
+++ b/example/server/src/index.ts
@@ -288,6 +288,7 @@ app.post(
         const params: Stripe.PaymentIntentCreateParams = {
           amount: orderAmount,
           confirm: true,
+          return_url: 'flutterstripe://redirect',
           confirmation_method: 'manual',
           currency,
           payment_method: paymentMethods.data[0].id,
@@ -306,6 +307,7 @@ app.post(
         const params: Stripe.PaymentIntentCreateParams = {
           amount: orderAmount,
           confirm: true,
+          return_url: 'flutterstripe://redirect',
           confirmation_method: 'manual',
           currency,
           payment_method: paymentMethodId,

--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -287,13 +287,12 @@ class Stripe {
   /// several seconds and it is important to not resubmit the form.
   ///
   /// Throws a [StripeException] when confirming the handle card action fails.
-  Future<PaymentIntent> handleNextAction(
-    String paymentIntentClientSecret,
-  ) async {
+  Future<PaymentIntent> handleNextAction(String paymentIntentClientSecret,
+      {String? returnURL}) async {
     await _awaitForSettings();
     try {
-      final paymentIntent =
-          await _platform.handleNextAction(paymentIntentClientSecret);
+      final paymentIntent = await _platform
+          .handleNextAction(paymentIntentClientSecret, returnURL: returnURL);
       return paymentIntent;
     } on StripeError {
       //throw StripeError<CardActionError>(error.code, error.message);

--- a/packages/stripe_ios/ios/Classes/StripePlugin.swift
+++ b/packages/stripe_ios/ios/Classes/StripePlugin.swift
@@ -21,6 +21,7 @@ class StripePlugin: StripeSdk, FlutterPlugin, ViewManagerDelegate {
         
         let instance = StripePlugin(channel: channel)
         registrar.addMethodCallDelegate(instance, channel: channel)
+        registrar.addApplicationDelegate(instance)
         
         // Card Field
         let cardFieldFactory = CardFieldViewFactory(messenger: registrar.messenger(), delegate:instance)
@@ -132,6 +133,20 @@ class StripePlugin: StripeSdk, FlutterPlugin, ViewManagerDelegate {
     override
     func sendEvent(withName name: String, body: [String:  Any]) {
         channel.invokeMethod(name, arguments: body)
+    }
+    
+    func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        return StripeAPI.handleURLCallback(with: url)
+    }
+    
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]) -> Void) -> Bool {
+        
+        if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
+            if let url = userActivity.webpageURL {
+                return StripeAPI.handleURLCallback(with: url)
+            }
+        }
+        return false
     }
 }
 


### PR DESCRIPTION
fixes #1081 and #955

- reintroduces handling of the return URL that was removed in https://github.com/flutter-stripe/flutter_stripe/pull/939/files
- exposes missing returnURL paramter in handleNextAction method
- adds adjustments in the example app and server to show how it needs to be implemented