### PR TITLE
Update stripe_platform_interface for stripe_web

### DIFF
--- a/packages/stripe_web/pubspec.yaml
+++ b/packages/stripe_web/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   freezed_annotation: ^2.0.3
-  stripe_platform_interface: ^8.0.0
+  stripe_platform_interface: ^9.0.0
   js: ^0.6.3
   stripe_js: ^2.0.1
 


### PR DESCRIPTION
With the latest release v9, dependencies are not resolving anymore if you depend on `stripe_web`. Because `stripe_web` is still depending on `stripe_platform_interface ^8.0.0`.

Error:
```
Running "flutter pub get" in app...
Resolving dependencies...
Because flutter_stripe_web >=3.0.0 depends on stripe_platform_interface ^8.0.0 and flutter_stripe >=9.0.0 depends on stripe_platform_interface ^9.0.0, flutter_stripe_web >=3.0.0 is incompatible with flutter_stripe >=9.0.0.
And because every version of payment_stripe from path depends on flutter_stripe 9.0.0+1, flutter_stripe_web >=3.0.0 is incompatible with payment_stripe from path.
So, because app depends on payment_stripe from path which depends on flutter_stripe_web 3.0.0, version solving failed.
```