### PR TITLE
Update platform view for card element

### DIFF
--- a/packages/stripe/lib/src/widgets/card_field.dart
+++ b/packages/stripe/lib/src/widgets/card_field.dart
@@ -602,7 +602,7 @@ class _AndroidCardField extends StatelessWidget {
       ),
       onCreatePlatformView: (params) {
         onPlatformViewCreated(params.id);
-        return PlatformViewsService.initExpensiveAndroidView(
+        return PlatformViewsService.initAndroidView(
           id: params.id,
           viewType: viewType,
           layoutDirection: Directionality.of(context),


### PR DESCRIPTION
Hi,
our app suffered from really bad performance when the `CardField` was used (60fps dropped to 14 fps as soon as the Card field was shown). Scrolling the view became very laggy.

While looking into it i found that `PlatformViewsService.initExpensiveAndroidView` is called. I changed to `initAndroidView` and the performance got a lot better (+10fps) and the functionality was still working. I am not really sure, if that makes problems in certain scenarios, but according to the documentation, androids picks the platform best supported platform view.

If u guys think it might become a problem, i can add like a `flag` or something similar, so the developer can choose between the two modes.

Regards