### PR TITLE
Upgrade Kotlin version and remove JitPack from repositories

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()

--- a/packages/stripe_android/android/build.gradle
+++ b/packages/stripe_android/android/build.gradle
@@ -20,7 +20,6 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/packages/stripe_android/android/build.gradle
+++ b/packages/stripe_android/android/build.gradle
@@ -2,7 +2,9 @@ group 'com.flutter.stripe'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.8.0'
+    ext.stripe_version = '[20.19.2, 20.20.0['
+
     repositories {
         google()
         mavenCentral()
@@ -40,14 +42,13 @@ android {
 dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.1"
-    implementation 'com.stripe:stripe-android:[20.19.2, 20.20.0['
-    implementation "com.stripe:financial-connections:20.16.+"
+    implementation "com.stripe:stripe-android:$stripe_version"
+    implementation "com.stripe:financial-connections:$stripe_version"
     implementation 'com.google.android.material:material:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
 
     // play-services-wallet is already included in stripe-android
     compileOnly "com.google.android.gms:play-services-wallet:19.1.0"


### PR DESCRIPTION
- stripe-react-native is already using Kotlin 1.8.0, so this PR updates this repo as well 
- flutter_stripe was depending on JitPack what was causing issues from time to time (as the one attached). However, JitPack is not required at all. All dependencies are available on google or mavenCentral repositories. So this PR removes JitPack.

```
* What went wrong:
Execution failed for task ':stripe_android:mapReleaseSourceSetPaths'.
> Could not resolve all files for configuration ':stripe_android:releaseRuntimeClasspath'.
   > Could not resolve com.stripe:stripe-android:[20.19.2, 20.20.0[.
     Required by:
         project :stripe_android
      > Failed to list versions for com.stripe:stripe-android.
         > Unable to load Maven meta-data from https://jitpack.io/com/stripe/stripe-android/maven-metadata.xml.
            > Could not GET 'https://jitpack.io/com/stripe/stripe-android/maven-metadata.xml'.
               > Read timed out
```