### PR TITLE
fix: confirmation redirect and stripeAccountId

### DIFF
--- a/packages/stripe_js/lib/src/api/payment_intents/confirm_payment_options.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/confirm_payment_options.dart
@@ -50,5 +50,6 @@ class ConfirmPaymentParams with _$ConfirmPaymentParams {
 /// will only redirect if your user chooses a redirect-based payment method.
 enum PaymentConfirmationRedirect {
   always,
+  @JsonKey(name: 'if_required')
   ifRequired,
 }

--- a/packages/stripe_js/lib/src/api/setup_intents/setup_intent.freezed.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/setup_intent.freezed.dart
@@ -60,14 +60,7 @@ mixin _$SetupIntent {
   /// Unix epoch.
   int? get created => throw _privateConstructorUsedError;
 
-  /// The client secret of this SetupIntent.
-  /// Used for client-side retrieval using a publishable key.
-  /// The client secret can be used to complete payment setup from your
-  /// frontend.
-  /// It should not be stored, logged, or exposed to anyone other
-  /// than the customer.
-  /// Make sure that you have TLS enabled on any page that includes the
-  /// client secret.
+  /// The ID of the Customer this SetupIntent belongs to.
   String? get customer => throw _privateConstructorUsedError;
 
   /// An arbitrary string attached to the object.
@@ -601,14 +594,7 @@ class _$_SetupIntent implements _SetupIntent {
   @override
   final int? created;
 
-  /// The client secret of this SetupIntent.
-  /// Used for client-side retrieval using a publishable key.
-  /// The client secret can be used to complete payment setup from your
-  /// frontend.
-  /// It should not be stored, logged, or exposed to anyone other
-  /// than the customer.
-  /// Make sure that you have TLS enabled on any page that includes the
-  /// client secret.
+  /// The ID of the Customer this SetupIntent belongs to.
   @override
   final String? customer;
 
@@ -921,14 +907,7 @@ abstract class _SetupIntent implements SetupIntent {
   int? get created;
   @override
 
-  /// The client secret of this SetupIntent.
-  /// Used for client-side retrieval using a publishable key.
-  /// The client secret can be used to complete payment setup from your
-  /// frontend.
-  /// It should not be stored, logged, or exposed to anyone other
-  /// than the customer.
-  /// Make sure that you have TLS enabled on any page that includes the
-  /// client secret.
+  /// The ID of the Customer this SetupIntent belongs to.
   String? get customer;
   @override
 

--- a/packages/stripe_js/lib/src/js/stripe.dart
+++ b/packages/stripe_js/lib/src/js/stripe.dart
@@ -19,6 +19,9 @@ class Stripe {
   external static num get version;
 
   external StripeElements elements([ElementsCreateOptions options]);
+
+  external String? get stripeAccount;
+  external set stripeAccount(String? stripeAccount);
 }
 
 @anonymous

--- a/packages/stripe_web/lib/src/parser/token.dart
+++ b/packages/stripe_web/lib/src/parser/token.dart
@@ -5,7 +5,7 @@ extension Token on js.Token {
   TokenData parse() {
     return TokenData(
       id: id,
-      createdDateTime: created.toString(),
+      createdDateTime: created ?? 0,
       livemode: livemode,
       type: type.parse(),
       card: card?.parse(),

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -42,14 +42,18 @@ class WebStripe extends StripePlatform {
     String? urlScheme,
     bool? setReturnUrlSchemeOnAndroid,
   }) async {
+    this.urlScheme = urlScheme;
+    if (__stripe != null) {
+      __stripe!.stripeAccount = stripeAccountId;
+      return;
+    }
+
     await stripe_js.loadStripe();
-    if (__stripe != null) return;
     final stripeOption = stripe_js.StripeOptions();
     if (stripeAccountId != null) {
       stripeOption.stripeAccount = stripeAccountId;
     }
     __stripe = stripe_js.Stripe(publishableKey, stripeOption);
-    this.urlScheme = urlScheme;
   }
 
   static stripe_js.StripeElement? element;


### PR DESCRIPTION
- Fix analyser warning 
- Fix payment confirmation redirect enum parsing wrongly
- Adds possibility to change stripeAccountId for stripe web

Closes #1181 & #1042