### PR TITLE
fix: apple pay

### DIFF
--- a/example/lib/screens/wallets/apple_pay_create_payment_method.dart
+++ b/example/lib/screens/wallets/apple_pay_create_payment_method.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_stripe/flutter_stripe.dart';
 import 'package:stripe_example/widgets/example_scaffold.dart';
 
-
 class ApplePayCreatePaymentMethodScreen extends StatefulWidget {
   @override
   _ApplePayScreenState createState() => _ApplePayScreenState();
@@ -74,7 +73,6 @@ class _ApplePayScreenState extends State<ApplePayCreatePaymentMethodScreen> {
           merchantCountryCode: 'Es',
           currencyCode: 'EUR',
         ),
-        applePayPaymentMethodParams: ApplePayPaymentMethodParams(),
       ),
     );
 

--- a/example/lib/screens/wallets/apple_pay_screen.dart
+++ b/example/lib/screens/wallets/apple_pay_screen.dart
@@ -71,11 +71,21 @@ class _ApplePayScreenState extends State<ApplePayScreen> {
                   errors: [],
                 ),
               );
-              print(Stripe.instance.debugUpdatePlatformSheetCalled);
+
               return;
             },
-            onShippingMethodSelected: (method) {
+            onShippingMethodSelected: (method) async {
               debugPrint('Shipping method updated $method');
+              // Mandatory after entering a shipping contact
+              await Stripe.instance.updatePlatformSheet(
+                params: PlatformPaySheetUpdateParams.applePay(
+                  summaryItems: items,
+                  shippingMethods: shippingMethods,
+                  errors: [],
+                ),
+              );
+
+              return;
             },
             onCouponCodeEntered: (couponCode) {
               debugPrint('set coupon $couponCode');

--- a/example/lib/screens/wallets/apple_pay_screen.dart
+++ b/example/lib/screens/wallets/apple_pay_screen.dart
@@ -60,28 +60,38 @@ class _ApplePayScreenState extends State<ApplePayScreen> {
       children: [
         if (Stripe.instance.isPlatformPaySupportedListenable.value)
           PlatformPayButton(
-            onDidSetShippingContact: (contact) {
+            onShippingContactSelected: (contact) async {
               debugPrint('Shipping contact updated $contact');
 
               // Mandatory after entering a shipping contact
-              Stripe.instance.updatePlatformSheet(
+              await Stripe.instance.updatePlatformSheet(
                 params: PlatformPaySheetUpdateParams.applePay(
                   summaryItems: items,
                   shippingMethods: shippingMethods,
                   errors: [],
                 ),
               );
+              print(Stripe.instance.debugUpdatePlatformSheetCalled);
+              return;
             },
             onShippingMethodSelected: (method) {
-              debugPrint('Shipping contact updated $method');
+              debugPrint('Shipping method updated $method');
+            },
+            onCouponCodeEntered: (couponCode) {
+              debugPrint('set coupon $couponCode');
+            },
+            onOrderTracking: () async {
+              debugPrint('set order tracking');
 
-              Stripe.instance.updatePlatformSheet(
-                params: PlatformPaySheetUpdateParams.applePay(
-                  summaryItems: items,
-                  shippingMethods: shippingMethods,
-                  errors: [],
-                ),
-              );
+              /// Provide a URL to your web service that will provide the order details
+              ///
+              await Stripe.instance.configurePlatformOrderTracking(
+                  orderDetails: PlatformPayOrderDetails.applePay(
+                orderTypeIdentifier: 'orderTypeIdentifier',
+                orderIdentifier: 'https://your-web-service.com/v1/orders/',
+                webServiceUrl: 'webServiceURL',
+                authenticationToken: 'token',
+              ));
             },
             type: PlatformButtonType.buy,
             appearance: PlatformButtonStyle.whiteOutline,
@@ -110,17 +120,18 @@ class _ApplePayScreenState extends State<ApplePayScreen> {
         clientSecret: clientSecret,
         confirmParams: PlatformPayConfirmParams.applePay(
           applePay: ApplePayParams(
-            cartItems: items,
-            requiredShippingAddressFields: [
-              ApplePayContactFieldsType.name,
-              ApplePayContactFieldsType.postalAddress,
-              ApplePayContactFieldsType.emailAddress,
-              ApplePayContactFieldsType.phoneNumber,
-            ],
-            shippingMethods: shippingMethods,
-            merchantCountryCode: 'Es',
-            currencyCode: 'EUR',
-          ),
+              cartItems: items,
+              requiredShippingAddressFields: [
+                ApplePayContactFieldsType.name,
+                ApplePayContactFieldsType.postalAddress,
+                ApplePayContactFieldsType.emailAddress,
+                ApplePayContactFieldsType.phoneNumber,
+              ],
+              shippingMethods: shippingMethods,
+              merchantCountryCode: 'Es',
+              currencyCode: 'EUR',
+              supportsCouponCode: true,
+              couponCode: 'Coupon'),
         ),
       );
       ScaffoldMessenger.of(context).showSnackBar(

--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:stripe_platform_interface/stripe_platform_interface.dart';
 
 /// [Stripe] is the facade of the library and exposes the operations that can be
@@ -226,6 +227,9 @@ class Stripe {
     }
   }
 
+  @internal
+  bool debugUpdatePlatformSheetCalled = false;
+
   /// Updates the native payment sheet with new data **iOS-only.
   ///
   /// For example this method is required to call when the user updates shippingmethod, shippingAddress and couponcode.
@@ -233,7 +237,31 @@ class Stripe {
     required PlatformPaySheetUpdateParams params,
   }) async {
     await _awaitForSettings();
+    assert(() {
+      debugUpdatePlatformSheetCalled = true;
+      return true;
+    }());
+    debugUpdatePlatformSheetCalled = true;
     return _platform.updatePlatformSheet(params: params);
+  }
+
+  @internal
+  bool debugConfigurePlatformOrderTrackingCalled = false;
+
+  /// Updates the native payment sheet with new order tracking information
+  /// **iOS-only.
+  ///
+  /// This method is required to call when the onOrderTracking is
+  /// called
+  Future<void> configurePlatformOrderTracking({
+    required PlatformPayOrderDetails orderDetails,
+  }) async {
+    await _awaitForSettings();
+    assert(() {
+      debugConfigurePlatformOrderTrackingCalled = true;
+      return true;
+    }());
+    return _platform.configurePlatformOrderTracking(orderDetails: orderDetails);
   }
 
   /// Creates a single-use token that represents an Apple Pay credit card’s details.

--- a/packages/stripe/lib/src/widgets/platform_pay_button.dart
+++ b/packages/stripe/lib/src/widgets/platform_pay_button.dart
@@ -18,23 +18,14 @@ class PlatformPayButton extends StatelessWidget {
     this.appearance = PlatformButtonStyle.automatic,
     this.borderRadius = 4.0,
     this.constraints,
-    this.onDidSetShippingContact,
-    this.onDidSetCoupon,
+    this.onShippingContactSelected,
+    this.onCouponCodeEntered,
     this.onShippingMethodSelected,
     this.onOrderTracking,
   });
 
   /// Defines the displayed text on the button.
   final PlatformButtonType type;
-
-  /// Callback that is executed when a shipping contact is entered
-  final OnDidSetShippingContact? onDidSetShippingContact;
-
-  /// Callback that is execyted when shipping method is selected
-  final OnDidSetShippingMethod? onShippingMethodSelected;
-
-  /// Callback that is execyted when shipping method is selected
-  final OnDidSetCoupon? onDidSetCoupon;
 
   /// iOS only, defines the color and border radius of the button
   final PlatformButtonStyle appearance;
@@ -50,11 +41,30 @@ class PlatformPayButton extends StatelessWidget {
   /// iOS only,  additional constraints for the Apple pay button widget.
   final BoxConstraints? constraints;
 
-  /// iOS only, callback function for setting the order details (retrieved from your server) to give users the
-  /// ability to track and manage their purchases in Wallet. Stripe calls your implementation after the
-  /// payment is complete, but before iOS dismisses the Apple Pay sheet. You must call the `completion`
-  /// function, or else the Apple Pay sheet will hang.
-  final SetOrderTracking? onOrderTracking;
+  /// For iOS only, a callback that is executed when a shipping contact is
+  /// entered. If implemented this method requires to call
+  /// 'Stripe.instance.updatePlatformSheet' with the updated shipping details
+  final OnDidSetShippingContact? onShippingContactSelected;
+
+  /// For iOS only, a callback that is executed when a shipping method is
+  /// selected. If implemented this method requires to call
+  /// 'Stripe.instance.updatePlatformSheet' with the updated price items
+  final OnDidSetShippingMethod? onShippingMethodSelected;
+
+  /// For iOS only, a callback that is executed when a shipping method is
+  /// selected. If implemented this method requires to call
+  /// 'Stripe.instance.updatePlatformSheet' with the updated price items
+  final OnCouponCodeEntered? onCouponCodeEntered;
+
+  /// For iOS only. If implemented, the callback is executed when an order is
+  /// about to be completed and the developer needs to provide the tracking
+  /// information. This method needs to call
+  /// 'Stripe.instance.configurePlatformOrderTracking' with that info for
+  /// setting the order details (retrieved from your server) to give users the
+  /// ability to track and manage their purchases in Wallet
+  ///
+  /// See https://stripe.com/docs/apple-pay?platform=ios&locale=es-ES#order-tracking
+  final OnOrderTracking? onOrderTracking;
 
   @override
   Widget build(BuildContext context) {
@@ -66,14 +76,14 @@ class PlatformPayButton extends StatelessWidget {
     } else if (Platform.isIOS) {
       return ApplePayButton(
         onPressed: onPressed,
-        onShippingContactSelected: onDidSetShippingContact,
         style: appearance,
         type: type,
         cornerRadius: borderRadius,
         constraints: constraints,
-        onOrderTracking: onOrderTracking,
-        onDidSetCoupon: onDidSetCoupon,
+        onShippingContactSelected: onShippingContactSelected,
         onShippingMethodSelected: onShippingMethodSelected,
+        onCouponCodeEntered: onCouponCodeEntered,
+        onOrderTracking: onOrderTracking,
       );
     }
     throw AssertionError('Platform not supported');

--- a/packages/stripe/pubspec.yaml
+++ b/packages/stripe/pubspec.yaml
@@ -21,6 +21,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
+  meta: ^1.8.0
   stripe_android: ^9.0.0+1
   stripe_ios: ^9.0.0
   stripe_platform_interface: ^9.0.0

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -523,7 +523,6 @@ class MethodChannelStripe extends StripePlatform {
       data = {
         'applePay': {
           ...params.applePayParams.toJson(),
-          ...params.applePayPaymentMethodParams.toJson()
         },
       };
     } else if (params is PlatformPayPaymentMethodParamsGooglePay) {
@@ -551,6 +550,16 @@ class MethodChannelStripe extends StripePlatform {
       {required PlatformPaySheetUpdateParams params}) async {
     await _methodChannel
         .invokeMethod('updatePlatformPaySheet', {'params': params.toJson()});
+  }
+
+  @override
+  Future<void> configurePlatformOrderTracking({
+    required PlatformPayOrderDetails orderDetails,
+  }) async {
+    await _methodChannel.invokeMethod(
+      'configureOrderTracking',
+      orderDetails.toJson(),
+    );
   }
 }
 

--- a/packages/stripe_platform_interface/lib/src/models/apple_pay.dart
+++ b/packages/stripe_platform_interface/lib/src/models/apple_pay.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'apple_pay.freezed.dart';
@@ -261,14 +263,10 @@ class ApplePayPostalAddress with _$ApplePayPostalAddress {
       _$ApplePayPostalAddressFromJson(json);
 }
 
-typedef OnDidSetShippingContact = void Function(
+typedef OnDidSetShippingContact = FutureOr<void> Function(
     ApplePayShippingContact contact);
-typedef OnDidSetShippingMethod = void Function(ApplePayShippingMethod method);
-typedef OnDidSetCoupon = void Function(String couponCode);
+typedef OnDidSetShippingMethod = FutureOr<void> Function(
+    ApplePayShippingMethod method);
+typedef OnCouponCodeEntered = FutureOr<void> Function(String couponCode);
 
-typedef SetOrderTracking = void Function(
-  String orderIdentifier,
-  String orderTypeIdentifier,
-  String authenticationToken,
-  String webServiceUrl,
-);
+typedef OnOrderTracking = FutureOr<void> Function();

--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.dart
@@ -105,7 +105,7 @@ class PaymentSheetApplePay with _$PaymentSheetApplePay {
     /// ability to track and manage their purchases in Wallet. Stripe calls your implementation after the
     /// payment is complete, but before iOS dismisses the Apple Pay sheet. You must call the `completion`
     /// function, or else the Apple Pay sheet will hang.
-    @JsonKey(ignore: true) SetOrderTracking? setOrderTracking,
+    @JsonKey(ignore: true) OnOrderTracking? setOrderTracking,
   }) = _PaymentSheetApplePay;
 
   factory PaymentSheetApplePay.fromJson(Map<String, dynamic> json) =>

--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.freezed.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.freezed.dart
@@ -698,7 +698,7 @@ mixin _$PaymentSheetApplePay {
   /// payment is complete, but before iOS dismisses the Apple Pay sheet. You must call the `completion`
   /// function, or else the Apple Pay sheet will hang.
   @JsonKey(ignore: true)
-  SetOrderTracking? get setOrderTracking => throw _privateConstructorUsedError;
+  OnOrderTracking? get setOrderTracking => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -717,7 +717,7 @@ abstract class $PaymentSheetApplePayCopyWith<$Res> {
       List<ApplePayCartSummaryItem>? cartItems,
       PlatformButtonType? buttonType,
       PaymentRequestType? request,
-      @JsonKey(ignore: true) SetOrderTracking? setOrderTracking});
+      @JsonKey(ignore: true) OnOrderTracking? setOrderTracking});
 
   $PaymentRequestTypeCopyWith<$Res>? get request;
 }
@@ -762,7 +762,7 @@ class _$PaymentSheetApplePayCopyWithImpl<$Res,
       setOrderTracking: freezed == setOrderTracking
           ? _value.setOrderTracking
           : setOrderTracking // ignore: cast_nullable_to_non_nullable
-              as SetOrderTracking?,
+              as OnOrderTracking?,
     ) as $Val);
   }
 
@@ -792,7 +792,7 @@ abstract class _$$_PaymentSheetApplePayCopyWith<$Res>
       List<ApplePayCartSummaryItem>? cartItems,
       PlatformButtonType? buttonType,
       PaymentRequestType? request,
-      @JsonKey(ignore: true) SetOrderTracking? setOrderTracking});
+      @JsonKey(ignore: true) OnOrderTracking? setOrderTracking});
 
   @override
   $PaymentRequestTypeCopyWith<$Res>? get request;
@@ -835,7 +835,7 @@ class __$$_PaymentSheetApplePayCopyWithImpl<$Res>
       setOrderTracking: freezed == setOrderTracking
           ? _value.setOrderTracking
           : setOrderTracking // ignore: cast_nullable_to_non_nullable
-              as SetOrderTracking?,
+              as OnOrderTracking?,
     ));
   }
 }
@@ -888,7 +888,7 @@ class _$_PaymentSheetApplePay implements _PaymentSheetApplePay {
   /// function, or else the Apple Pay sheet will hang.
   @override
   @JsonKey(ignore: true)
-  final SetOrderTracking? setOrderTracking;
+  final OnOrderTracking? setOrderTracking;
 
   @override
   String toString() {
@@ -942,7 +942,7 @@ abstract class _PaymentSheetApplePay implements PaymentSheetApplePay {
           final List<ApplePayCartSummaryItem>? cartItems,
           final PlatformButtonType? buttonType,
           final PaymentRequestType? request,
-          @JsonKey(ignore: true) final SetOrderTracking? setOrderTracking}) =
+          @JsonKey(ignore: true) final OnOrderTracking? setOrderTracking}) =
       _$_PaymentSheetApplePay;
 
   factory _PaymentSheetApplePay.fromJson(Map<String, dynamic> json) =
@@ -972,7 +972,7 @@ abstract class _PaymentSheetApplePay implements PaymentSheetApplePay {
   /// payment is complete, but before iOS dismisses the Apple Pay sheet. You must call the `completion`
   /// function, or else the Apple Pay sheet will hang.
   @JsonKey(ignore: true)
-  SetOrderTracking? get setOrderTracking;
+  OnOrderTracking? get setOrderTracking;
   @override
   @JsonKey(ignore: true)
   _$$_PaymentSheetApplePayCopyWith<_$_PaymentSheetApplePay> get copyWith =>

--- a/packages/stripe_platform_interface/lib/src/models/platform_pay.dart
+++ b/packages/stripe_platform_interface/lib/src/models/platform_pay.dart
@@ -96,7 +96,6 @@ class PlatformPayPaymentMethodParams with _$PlatformPayPaymentMethodParams {
   @JsonSerializable(explicitToJson: true)
   const factory PlatformPayPaymentMethodParams.applePay({
     required ApplePayParams applePayParams,
-    required ApplePayPaymentMethodParams applePayPaymentMethodParams,
   }) = PlatformPayPaymentMethodParamsApplePay;
 }
 
@@ -150,6 +149,15 @@ class ApplePayParams with _$ApplePayParams {
     /// A list of two-letter ISO 3166 country codes for limiting payment to cards from specific countries or regions.
     List<String>? supportedCountries,
 
+    /// Enables support for coupon codes in the Apple Pay button.
+    /// When this is set to true it shows the coupon code field and if [couponCode]
+    /// has a value it will display the value as default
+    ///
+    /// Supported on iOS 15 and higher.
+    bool? supportsCouponCode,
+
+    /// Default coupon code display in the apple pay sheet
+    String? couponCode,
 
     /// Use this to support different types of payment request.
     ///
@@ -159,31 +167,6 @@ class ApplePayParams with _$ApplePayParams {
 
   factory ApplePayParams.fromJson(Map<String, dynamic> json) =>
       _$ApplePayParamsFromJson(json);
-}
-
-@freezed
-
-/// Additional parameters for create apple pay paymentMethod
-class ApplePayPaymentMethodParams with _$ApplePayPaymentMethodParams {
-  @JsonSerializable(explicitToJson: true)
-  const factory ApplePayPaymentMethodParams({
-    /// Variable that enables the coupon code field.
-    ///
-    /// When this is set to true it shows the coupon code field and if [couponCode]
-    /// is set to true it will display the
-    bool? supportsCouponCode,
-
-    /// Value used for prefilling the coupon code field.
-    String? couponCode,
-
-    /// Use this to support different types of payment request.
-    ///
-    /// Only supported on iOS 16 and higher.
-    PaymentRequestType? request,
-  }) = _ApplePayPaymentMethodParams;
-
-  factory ApplePayPaymentMethodParams.fromJson(Map<String, dynamic> json) =>
-      _$ApplePayPaymentMethodParamsFromJson(json);
 }
 
 @freezed
@@ -399,4 +382,31 @@ class ApplePayMultiMerchant with _$ApplePayMultiMerchant {
 
   factory ApplePayMultiMerchant.fromJson(Map<String, dynamic> json) =>
       _$ApplePayMultiMerchantFromJson(json);
+}
+
+@freezed
+
+/// Parameters related to order details with Apple pay
+///
+/// At this moment only Apple pay is supported.
+/// Similar to [KPaymentOrderDetails]
+/// See https://stripe.com/docs/apple-pay?platform=ios&locale=es-ES#order-tracking
+class PlatformPayOrderDetails with _$PlatformPayOrderDetails {
+  @JsonSerializable(explicitToJson: true)
+  const factory PlatformPayOrderDetails.applePay({
+    /// eg: "com.myapp.order"
+    required String orderTypeIdentifier,
+
+    /// eg: "ABC123-AAAA-1111"
+    required String orderIdentifier,
+
+    /// eg: "https://my-backend.example.com/apple-order-tracking-backend"
+    required String webServiceUrl,
+
+    /// eg: "abc123"
+    required String authenticationToken,
+  }) = _PlatformPayOrderDetails;
+
+  factory PlatformPayOrderDetails.fromJson(Map<String, dynamic> json) =>
+      _$PlatformPayOrderDetailsFromJson(json);
 }

--- a/packages/stripe_platform_interface/lib/src/models/platform_pay.freezed.dart
+++ b/packages/stripe_platform_interface/lib/src/models/platform_pay.freezed.dart
@@ -1293,9 +1293,7 @@ mixin _$PlatformPayPaymentMethodParams {
     required TResult Function(GooglePayParams googlePayParams,
             GooglePayPaymentMethodParams googlePayPaymentMethodParams)
         googlePay,
-    required TResult Function(ApplePayParams applePayParams,
-            ApplePayPaymentMethodParams applePayPaymentMethodParams)
-        applePay,
+    required TResult Function(ApplePayParams applePayParams) applePay,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -1303,9 +1301,7 @@ mixin _$PlatformPayPaymentMethodParams {
     TResult? Function(GooglePayParams googlePayParams,
             GooglePayPaymentMethodParams googlePayPaymentMethodParams)?
         googlePay,
-    TResult? Function(ApplePayParams applePayParams,
-            ApplePayPaymentMethodParams applePayPaymentMethodParams)?
-        applePay,
+    TResult? Function(ApplePayParams applePayParams)? applePay,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -1313,9 +1309,7 @@ mixin _$PlatformPayPaymentMethodParams {
     TResult Function(GooglePayParams googlePayParams,
             GooglePayPaymentMethodParams googlePayPaymentMethodParams)?
         googlePay,
-    TResult Function(ApplePayParams applePayParams,
-            ApplePayPaymentMethodParams applePayPaymentMethodParams)?
-        applePay,
+    TResult Function(ApplePayParams applePayParams)? applePay,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -1474,9 +1468,7 @@ class _$PlatformPayPaymentMethodParamsGooglePay
     required TResult Function(GooglePayParams googlePayParams,
             GooglePayPaymentMethodParams googlePayPaymentMethodParams)
         googlePay,
-    required TResult Function(ApplePayParams applePayParams,
-            ApplePayPaymentMethodParams applePayPaymentMethodParams)
-        applePay,
+    required TResult Function(ApplePayParams applePayParams) applePay,
   }) {
     return googlePay(googlePayParams, googlePayPaymentMethodParams);
   }
@@ -1487,9 +1479,7 @@ class _$PlatformPayPaymentMethodParamsGooglePay
     TResult? Function(GooglePayParams googlePayParams,
             GooglePayPaymentMethodParams googlePayPaymentMethodParams)?
         googlePay,
-    TResult? Function(ApplePayParams applePayParams,
-            ApplePayPaymentMethodParams applePayPaymentMethodParams)?
-        applePay,
+    TResult? Function(ApplePayParams applePayParams)? applePay,
   }) {
     return googlePay?.call(googlePayParams, googlePayPaymentMethodParams);
   }
@@ -1500,9 +1490,7 @@ class _$PlatformPayPaymentMethodParamsGooglePay
     TResult Function(GooglePayParams googlePayParams,
             GooglePayPaymentMethodParams googlePayPaymentMethodParams)?
         googlePay,
-    TResult Function(ApplePayParams applePayParams,
-            ApplePayPaymentMethodParams applePayPaymentMethodParams)?
-        applePay,
+    TResult Function(ApplePayParams applePayParams)? applePay,
     required TResult orElse(),
   }) {
     if (googlePay != null) {
@@ -1568,12 +1556,9 @@ abstract class _$$PlatformPayPaymentMethodParamsApplePayCopyWith<$Res> {
           $Res Function(_$PlatformPayPaymentMethodParamsApplePay) then) =
       __$$PlatformPayPaymentMethodParamsApplePayCopyWithImpl<$Res>;
   @useResult
-  $Res call(
-      {ApplePayParams applePayParams,
-      ApplePayPaymentMethodParams applePayPaymentMethodParams});
+  $Res call({ApplePayParams applePayParams});
 
   $ApplePayParamsCopyWith<$Res> get applePayParams;
-  $ApplePayPaymentMethodParamsCopyWith<$Res> get applePayPaymentMethodParams;
 }
 
 /// @nodoc
@@ -1590,17 +1575,12 @@ class __$$PlatformPayPaymentMethodParamsApplePayCopyWithImpl<$Res>
   @override
   $Res call({
     Object? applePayParams = null,
-    Object? applePayPaymentMethodParams = null,
   }) {
     return _then(_$PlatformPayPaymentMethodParamsApplePay(
       applePayParams: null == applePayParams
           ? _value.applePayParams
           : applePayParams // ignore: cast_nullable_to_non_nullable
               as ApplePayParams,
-      applePayPaymentMethodParams: null == applePayPaymentMethodParams
-          ? _value.applePayPaymentMethodParams
-          : applePayPaymentMethodParams // ignore: cast_nullable_to_non_nullable
-              as ApplePayPaymentMethodParams,
     ));
   }
 
@@ -1611,15 +1591,6 @@ class __$$PlatformPayPaymentMethodParamsApplePayCopyWithImpl<$Res>
       return _then(_value.copyWith(applePayParams: value));
     });
   }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $ApplePayPaymentMethodParamsCopyWith<$Res> get applePayPaymentMethodParams {
-    return $ApplePayPaymentMethodParamsCopyWith<$Res>(
-        _value.applePayPaymentMethodParams, (value) {
-      return _then(_value.copyWith(applePayPaymentMethodParams: value));
-    });
-  }
 }
 
 /// @nodoc
@@ -1628,17 +1599,14 @@ class __$$PlatformPayPaymentMethodParamsApplePayCopyWithImpl<$Res>
 class _$PlatformPayPaymentMethodParamsApplePay
     implements PlatformPayPaymentMethodParamsApplePay {
   const _$PlatformPayPaymentMethodParamsApplePay(
-      {required this.applePayParams,
-      required this.applePayPaymentMethodParams});
+      {required this.applePayParams});
 
   @override
   final ApplePayParams applePayParams;
-  @override
-  final ApplePayPaymentMethodParams applePayPaymentMethodParams;
 
   @override
   String toString() {
-    return 'PlatformPayPaymentMethodParams.applePay(applePayParams: $applePayParams, applePayPaymentMethodParams: $applePayPaymentMethodParams)';
+    return 'PlatformPayPaymentMethodParams.applePay(applePayParams: $applePayParams)';
   }
 
   @override
@@ -1647,16 +1615,11 @@ class _$PlatformPayPaymentMethodParamsApplePay
         (other.runtimeType == runtimeType &&
             other is _$PlatformPayPaymentMethodParamsApplePay &&
             (identical(other.applePayParams, applePayParams) ||
-                other.applePayParams == applePayParams) &&
-            (identical(other.applePayPaymentMethodParams,
-                    applePayPaymentMethodParams) ||
-                other.applePayPaymentMethodParams ==
-                    applePayPaymentMethodParams));
+                other.applePayParams == applePayParams));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, applePayParams, applePayPaymentMethodParams);
+  int get hashCode => Object.hash(runtimeType, applePayParams);
 
   @JsonKey(ignore: true)
   @override
@@ -1672,11 +1635,9 @@ class _$PlatformPayPaymentMethodParamsApplePay
     required TResult Function(GooglePayParams googlePayParams,
             GooglePayPaymentMethodParams googlePayPaymentMethodParams)
         googlePay,
-    required TResult Function(ApplePayParams applePayParams,
-            ApplePayPaymentMethodParams applePayPaymentMethodParams)
-        applePay,
+    required TResult Function(ApplePayParams applePayParams) applePay,
   }) {
-    return applePay(applePayParams, applePayPaymentMethodParams);
+    return applePay(applePayParams);
   }
 
   @override
@@ -1685,11 +1646,9 @@ class _$PlatformPayPaymentMethodParamsApplePay
     TResult? Function(GooglePayParams googlePayParams,
             GooglePayPaymentMethodParams googlePayPaymentMethodParams)?
         googlePay,
-    TResult? Function(ApplePayParams applePayParams,
-            ApplePayPaymentMethodParams applePayPaymentMethodParams)?
-        applePay,
+    TResult? Function(ApplePayParams applePayParams)? applePay,
   }) {
-    return applePay?.call(applePayParams, applePayPaymentMethodParams);
+    return applePay?.call(applePayParams);
   }
 
   @override
@@ -1698,13 +1657,11 @@ class _$PlatformPayPaymentMethodParamsApplePay
     TResult Function(GooglePayParams googlePayParams,
             GooglePayPaymentMethodParams googlePayPaymentMethodParams)?
         googlePay,
-    TResult Function(ApplePayParams applePayParams,
-            ApplePayPaymentMethodParams applePayPaymentMethodParams)?
-        applePay,
+    TResult Function(ApplePayParams applePayParams)? applePay,
     required TResult orElse(),
   }) {
     if (applePay != null) {
-      return applePay(applePayParams, applePayPaymentMethodParams);
+      return applePay(applePayParams);
     }
     return orElse();
   }
@@ -1746,13 +1703,10 @@ class _$PlatformPayPaymentMethodParamsApplePay
 abstract class PlatformPayPaymentMethodParamsApplePay
     implements PlatformPayPaymentMethodParams {
   const factory PlatformPayPaymentMethodParamsApplePay(
-          {required final ApplePayParams applePayParams,
-          required final ApplePayPaymentMethodParams
-              applePayPaymentMethodParams}) =
+          {required final ApplePayParams applePayParams}) =
       _$PlatformPayPaymentMethodParamsApplePay;
 
   ApplePayParams get applePayParams;
-  ApplePayPaymentMethodParams get applePayPaymentMethodParams;
   @JsonKey(ignore: true)
   _$$PlatformPayPaymentMethodParamsApplePayCopyWith<
           _$PlatformPayPaymentMethodParamsApplePay>
@@ -2233,6 +2187,16 @@ mixin _$ApplePayParams {
   /// A list of two-letter ISO 3166 country codes for limiting payment to cards from specific countries or regions.
   List<String>? get supportedCountries => throw _privateConstructorUsedError;
 
+  /// Enables support for coupon codes in the Apple Pay button.
+  /// When this is set to true it shows the coupon code field and if [couponCode]
+  /// has a value it will display the value as default
+  ///
+  /// Supported on iOS 15 and higher.
+  bool? get supportsCouponCode => throw _privateConstructorUsedError;
+
+  /// Default coupon code display in the apple pay sheet
+  String? get couponCode => throw _privateConstructorUsedError;
+
   /// Use this to support different types of payment request.
   ///
   /// Only supported on iOS 16 and higher.
@@ -2261,6 +2225,8 @@ abstract class $ApplePayParamsCopyWith<$Res> {
       List<ApplePayMerchantCapability>? merchantCapabilities,
       ApplePayShippingType? shippingType,
       List<String>? supportedCountries,
+      bool? supportsCouponCode,
+      String? couponCode,
       PaymentRequestType? request});
 
   $PaymentRequestTypeCopyWith<$Res>? get request;
@@ -2289,6 +2255,8 @@ class _$ApplePayParamsCopyWithImpl<$Res, $Val extends ApplePayParams>
     Object? merchantCapabilities = freezed,
     Object? shippingType = freezed,
     Object? supportedCountries = freezed,
+    Object? supportsCouponCode = freezed,
+    Object? couponCode = freezed,
     Object? request = freezed,
   }) {
     return _then(_value.copyWith(
@@ -2332,6 +2300,14 @@ class _$ApplePayParamsCopyWithImpl<$Res, $Val extends ApplePayParams>
           ? _value.supportedCountries
           : supportedCountries // ignore: cast_nullable_to_non_nullable
               as List<String>?,
+      supportsCouponCode: freezed == supportsCouponCode
+          ? _value.supportsCouponCode
+          : supportsCouponCode // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      couponCode: freezed == couponCode
+          ? _value.couponCode
+          : couponCode // ignore: cast_nullable_to_non_nullable
+              as String?,
       request: freezed == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -2371,6 +2347,8 @@ abstract class _$$_ApplePayParamsCopyWith<$Res>
       List<ApplePayMerchantCapability>? merchantCapabilities,
       ApplePayShippingType? shippingType,
       List<String>? supportedCountries,
+      bool? supportsCouponCode,
+      String? couponCode,
       PaymentRequestType? request});
 
   @override
@@ -2398,6 +2376,8 @@ class __$$_ApplePayParamsCopyWithImpl<$Res>
     Object? merchantCapabilities = freezed,
     Object? shippingType = freezed,
     Object? supportedCountries = freezed,
+    Object? supportsCouponCode = freezed,
+    Object? couponCode = freezed,
     Object? request = freezed,
   }) {
     return _then(_$_ApplePayParams(
@@ -2441,6 +2421,14 @@ class __$$_ApplePayParamsCopyWithImpl<$Res>
           ? _value._supportedCountries
           : supportedCountries // ignore: cast_nullable_to_non_nullable
               as List<String>?,
+      supportsCouponCode: freezed == supportsCouponCode
+          ? _value.supportsCouponCode
+          : supportsCouponCode // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      couponCode: freezed == couponCode
+          ? _value.couponCode
+          : couponCode // ignore: cast_nullable_to_non_nullable
+              as String?,
       request: freezed == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -2464,6 +2452,8 @@ class _$_ApplePayParams implements _ApplePayParams {
       final List<ApplePayMerchantCapability>? merchantCapabilities,
       this.shippingType,
       final List<String>? supportedCountries,
+      this.supportsCouponCode,
+      this.couponCode,
       this.request})
       : _additionalEnabledNetworks = additionalEnabledNetworks,
         _cartItems = cartItems,
@@ -2582,6 +2572,18 @@ class _$_ApplePayParams implements _ApplePayParams {
     return EqualUnmodifiableListView(value);
   }
 
+  /// Enables support for coupon codes in the Apple Pay button.
+  /// When this is set to true it shows the coupon code field and if [couponCode]
+  /// has a value it will display the value as default
+  ///
+  /// Supported on iOS 15 and higher.
+  @override
+  final bool? supportsCouponCode;
+
+  /// Default coupon code display in the apple pay sheet
+  @override
+  final String? couponCode;
+
   /// Use this to support different types of payment request.
   ///
   /// Only supported on iOS 16 and higher.
@@ -2590,7 +2592,7 @@ class _$_ApplePayParams implements _ApplePayParams {
 
   @override
   String toString() {
-    return 'ApplePayParams(merchantCountryCode: $merchantCountryCode, currencyCode: $currencyCode, additionalEnabledNetworks: $additionalEnabledNetworks, cartItems: $cartItems, requiredShippingAddressFields: $requiredShippingAddressFields, requiredBillingContactFields: $requiredBillingContactFields, shippingMethods: $shippingMethods, merchantCapabilities: $merchantCapabilities, shippingType: $shippingType, supportedCountries: $supportedCountries, request: $request)';
+    return 'ApplePayParams(merchantCountryCode: $merchantCountryCode, currencyCode: $currencyCode, additionalEnabledNetworks: $additionalEnabledNetworks, cartItems: $cartItems, requiredShippingAddressFields: $requiredShippingAddressFields, requiredBillingContactFields: $requiredBillingContactFields, shippingMethods: $shippingMethods, merchantCapabilities: $merchantCapabilities, shippingType: $shippingType, supportedCountries: $supportedCountries, supportsCouponCode: $supportsCouponCode, couponCode: $couponCode, request: $request)';
   }
 
   @override
@@ -2620,6 +2622,10 @@ class _$_ApplePayParams implements _ApplePayParams {
                 other.shippingType == shippingType) &&
             const DeepCollectionEquality()
                 .equals(other._supportedCountries, _supportedCountries) &&
+            (identical(other.supportsCouponCode, supportsCouponCode) ||
+                other.supportsCouponCode == supportsCouponCode) &&
+            (identical(other.couponCode, couponCode) ||
+                other.couponCode == couponCode) &&
             (identical(other.request, request) || other.request == request));
   }
 
@@ -2637,6 +2643,8 @@ class _$_ApplePayParams implements _ApplePayParams {
       const DeepCollectionEquality().hash(_merchantCapabilities),
       shippingType,
       const DeepCollectionEquality().hash(_supportedCountries),
+      supportsCouponCode,
+      couponCode,
       request);
 
   @JsonKey(ignore: true)
@@ -2665,6 +2673,8 @@ abstract class _ApplePayParams implements ApplePayParams {
       final List<ApplePayMerchantCapability>? merchantCapabilities,
       final ApplePayShippingType? shippingType,
       final List<String>? supportedCountries,
+      final bool? supportsCouponCode,
+      final String? couponCode,
       final PaymentRequestType? request}) = _$_ApplePayParams;
 
   factory _ApplePayParams.fromJson(Map<String, dynamic> json) =
@@ -2712,242 +2722,15 @@ abstract class _ApplePayParams implements ApplePayParams {
   List<String>? get supportedCountries;
   @override
 
-  /// Use this to support different types of payment request.
-  ///
-  /// Only supported on iOS 16 and higher.
-  PaymentRequestType? get request;
-  @override
-  @JsonKey(ignore: true)
-  _$$_ApplePayParamsCopyWith<_$_ApplePayParams> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-ApplePayPaymentMethodParams _$ApplePayPaymentMethodParamsFromJson(
-    Map<String, dynamic> json) {
-  return _ApplePayPaymentMethodParams.fromJson(json);
-}
-
-/// @nodoc
-mixin _$ApplePayPaymentMethodParams {
-  /// Variable that enables the coupon code field.
-  ///
+  /// Enables support for coupon codes in the Apple Pay button.
   /// When this is set to true it shows the coupon code field and if [couponCode]
-  /// is set to true it will display the
-  bool? get supportsCouponCode => throw _privateConstructorUsedError;
-
-  /// Value used for prefilling the coupon code field.
-  String? get couponCode => throw _privateConstructorUsedError;
-
-  /// Use this to support different types of payment request.
+  /// has a value it will display the value as default
   ///
-  /// Only supported on iOS 16 and higher.
-  PaymentRequestType? get request => throw _privateConstructorUsedError;
-
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $ApplePayPaymentMethodParamsCopyWith<ApplePayPaymentMethodParams>
-      get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $ApplePayPaymentMethodParamsCopyWith<$Res> {
-  factory $ApplePayPaymentMethodParamsCopyWith(
-          ApplePayPaymentMethodParams value,
-          $Res Function(ApplePayPaymentMethodParams) then) =
-      _$ApplePayPaymentMethodParamsCopyWithImpl<$Res,
-          ApplePayPaymentMethodParams>;
-  @useResult
-  $Res call(
-      {bool? supportsCouponCode,
-      String? couponCode,
-      PaymentRequestType? request});
-
-  $PaymentRequestTypeCopyWith<$Res>? get request;
-}
-
-/// @nodoc
-class _$ApplePayPaymentMethodParamsCopyWithImpl<$Res,
-        $Val extends ApplePayPaymentMethodParams>
-    implements $ApplePayPaymentMethodParamsCopyWith<$Res> {
-  _$ApplePayPaymentMethodParamsCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? supportsCouponCode = freezed,
-    Object? couponCode = freezed,
-    Object? request = freezed,
-  }) {
-    return _then(_value.copyWith(
-      supportsCouponCode: freezed == supportsCouponCode
-          ? _value.supportsCouponCode
-          : supportsCouponCode // ignore: cast_nullable_to_non_nullable
-              as bool?,
-      couponCode: freezed == couponCode
-          ? _value.couponCode
-          : couponCode // ignore: cast_nullable_to_non_nullable
-              as String?,
-      request: freezed == request
-          ? _value.request
-          : request // ignore: cast_nullable_to_non_nullable
-              as PaymentRequestType?,
-    ) as $Val);
-  }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $PaymentRequestTypeCopyWith<$Res>? get request {
-    if (_value.request == null) {
-      return null;
-    }
-
-    return $PaymentRequestTypeCopyWith<$Res>(_value.request!, (value) {
-      return _then(_value.copyWith(request: value) as $Val);
-    });
-  }
-}
-
-/// @nodoc
-abstract class _$$_ApplePayPaymentMethodParamsCopyWith<$Res>
-    implements $ApplePayPaymentMethodParamsCopyWith<$Res> {
-  factory _$$_ApplePayPaymentMethodParamsCopyWith(
-          _$_ApplePayPaymentMethodParams value,
-          $Res Function(_$_ApplePayPaymentMethodParams) then) =
-      __$$_ApplePayPaymentMethodParamsCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {bool? supportsCouponCode,
-      String? couponCode,
-      PaymentRequestType? request});
-
-  @override
-  $PaymentRequestTypeCopyWith<$Res>? get request;
-}
-
-/// @nodoc
-class __$$_ApplePayPaymentMethodParamsCopyWithImpl<$Res>
-    extends _$ApplePayPaymentMethodParamsCopyWithImpl<$Res,
-        _$_ApplePayPaymentMethodParams>
-    implements _$$_ApplePayPaymentMethodParamsCopyWith<$Res> {
-  __$$_ApplePayPaymentMethodParamsCopyWithImpl(
-      _$_ApplePayPaymentMethodParams _value,
-      $Res Function(_$_ApplePayPaymentMethodParams) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? supportsCouponCode = freezed,
-    Object? couponCode = freezed,
-    Object? request = freezed,
-  }) {
-    return _then(_$_ApplePayPaymentMethodParams(
-      supportsCouponCode: freezed == supportsCouponCode
-          ? _value.supportsCouponCode
-          : supportsCouponCode // ignore: cast_nullable_to_non_nullable
-              as bool?,
-      couponCode: freezed == couponCode
-          ? _value.couponCode
-          : couponCode // ignore: cast_nullable_to_non_nullable
-              as String?,
-      request: freezed == request
-          ? _value.request
-          : request // ignore: cast_nullable_to_non_nullable
-              as PaymentRequestType?,
-    ));
-  }
-}
-
-/// @nodoc
-
-@JsonSerializable(explicitToJson: true)
-class _$_ApplePayPaymentMethodParams implements _ApplePayPaymentMethodParams {
-  const _$_ApplePayPaymentMethodParams(
-      {this.supportsCouponCode, this.couponCode, this.request});
-
-  factory _$_ApplePayPaymentMethodParams.fromJson(Map<String, dynamic> json) =>
-      _$$_ApplePayPaymentMethodParamsFromJson(json);
-
-  /// Variable that enables the coupon code field.
-  ///
-  /// When this is set to true it shows the coupon code field and if [couponCode]
-  /// is set to true it will display the
-  @override
-  final bool? supportsCouponCode;
-
-  /// Value used for prefilling the coupon code field.
-  @override
-  final String? couponCode;
-
-  /// Use this to support different types of payment request.
-  ///
-  /// Only supported on iOS 16 and higher.
-  @override
-  final PaymentRequestType? request;
-
-  @override
-  String toString() {
-    return 'ApplePayPaymentMethodParams(supportsCouponCode: $supportsCouponCode, couponCode: $couponCode, request: $request)';
-  }
-
-  @override
-  bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$_ApplePayPaymentMethodParams &&
-            (identical(other.supportsCouponCode, supportsCouponCode) ||
-                other.supportsCouponCode == supportsCouponCode) &&
-            (identical(other.couponCode, couponCode) ||
-                other.couponCode == couponCode) &&
-            (identical(other.request, request) || other.request == request));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, supportsCouponCode, couponCode, request);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$_ApplePayPaymentMethodParamsCopyWith<_$_ApplePayPaymentMethodParams>
-      get copyWith => __$$_ApplePayPaymentMethodParamsCopyWithImpl<
-          _$_ApplePayPaymentMethodParams>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$_ApplePayPaymentMethodParamsToJson(
-      this,
-    );
-  }
-}
-
-abstract class _ApplePayPaymentMethodParams
-    implements ApplePayPaymentMethodParams {
-  const factory _ApplePayPaymentMethodParams(
-      {final bool? supportsCouponCode,
-      final String? couponCode,
-      final PaymentRequestType? request}) = _$_ApplePayPaymentMethodParams;
-
-  factory _ApplePayPaymentMethodParams.fromJson(Map<String, dynamic> json) =
-      _$_ApplePayPaymentMethodParams.fromJson;
-
-  @override
-
-  /// Variable that enables the coupon code field.
-  ///
-  /// When this is set to true it shows the coupon code field and if [couponCode]
-  /// is set to true it will display the
+  /// Supported on iOS 15 and higher.
   bool? get supportsCouponCode;
   @override
 
-  /// Value used for prefilling the coupon code field.
+  /// Default coupon code display in the apple pay sheet
   String? get couponCode;
   @override
 
@@ -2957,8 +2740,8 @@ abstract class _ApplePayPaymentMethodParams
   PaymentRequestType? get request;
   @override
   @JsonKey(ignore: true)
-  _$$_ApplePayPaymentMethodParamsCopyWith<_$_ApplePayPaymentMethodParams>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_ApplePayParamsCopyWith<_$_ApplePayParams> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 GooglePayParams _$GooglePayParamsFromJson(Map<String, dynamic> json) {
@@ -5286,4 +5069,345 @@ abstract class _ApplePayMultiMerchant implements ApplePayMultiMerchant {
   @JsonKey(ignore: true)
   _$$_ApplePayMultiMerchantCopyWith<_$_ApplePayMultiMerchant> get copyWith =>
       throw _privateConstructorUsedError;
+}
+
+PlatformPayOrderDetails _$PlatformPayOrderDetailsFromJson(
+    Map<String, dynamic> json) {
+  return _PlatformPayOrderDetails.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PlatformPayOrderDetails {
+  /// eg: "com.myapp.order"
+  String get orderTypeIdentifier => throw _privateConstructorUsedError;
+
+  /// eg: "ABC123-AAAA-1111"
+  String get orderIdentifier => throw _privateConstructorUsedError;
+
+  /// eg: "https://my-backend.example.com/apple-order-tracking-backend"
+  String get webServiceUrl => throw _privateConstructorUsedError;
+
+  /// eg: "abc123"
+  String get authenticationToken => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+            String orderTypeIdentifier,
+            String orderIdentifier,
+            String webServiceUrl,
+            String authenticationToken)
+        applePay,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String orderTypeIdentifier, String orderIdentifier,
+            String webServiceUrl, String authenticationToken)?
+        applePay,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String orderTypeIdentifier, String orderIdentifier,
+            String webServiceUrl, String authenticationToken)?
+        applePay,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_PlatformPayOrderDetails value) applePay,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_PlatformPayOrderDetails value)? applePay,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_PlatformPayOrderDetails value)? applePay,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PlatformPayOrderDetailsCopyWith<PlatformPayOrderDetails> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PlatformPayOrderDetailsCopyWith<$Res> {
+  factory $PlatformPayOrderDetailsCopyWith(PlatformPayOrderDetails value,
+          $Res Function(PlatformPayOrderDetails) then) =
+      _$PlatformPayOrderDetailsCopyWithImpl<$Res, PlatformPayOrderDetails>;
+  @useResult
+  $Res call(
+      {String orderTypeIdentifier,
+      String orderIdentifier,
+      String webServiceUrl,
+      String authenticationToken});
+}
+
+/// @nodoc
+class _$PlatformPayOrderDetailsCopyWithImpl<$Res,
+        $Val extends PlatformPayOrderDetails>
+    implements $PlatformPayOrderDetailsCopyWith<$Res> {
+  _$PlatformPayOrderDetailsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? orderTypeIdentifier = null,
+    Object? orderIdentifier = null,
+    Object? webServiceUrl = null,
+    Object? authenticationToken = null,
+  }) {
+    return _then(_value.copyWith(
+      orderTypeIdentifier: null == orderTypeIdentifier
+          ? _value.orderTypeIdentifier
+          : orderTypeIdentifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      orderIdentifier: null == orderIdentifier
+          ? _value.orderIdentifier
+          : orderIdentifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      webServiceUrl: null == webServiceUrl
+          ? _value.webServiceUrl
+          : webServiceUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      authenticationToken: null == authenticationToken
+          ? _value.authenticationToken
+          : authenticationToken // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_PlatformPayOrderDetailsCopyWith<$Res>
+    implements $PlatformPayOrderDetailsCopyWith<$Res> {
+  factory _$$_PlatformPayOrderDetailsCopyWith(_$_PlatformPayOrderDetails value,
+          $Res Function(_$_PlatformPayOrderDetails) then) =
+      __$$_PlatformPayOrderDetailsCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String orderTypeIdentifier,
+      String orderIdentifier,
+      String webServiceUrl,
+      String authenticationToken});
+}
+
+/// @nodoc
+class __$$_PlatformPayOrderDetailsCopyWithImpl<$Res>
+    extends _$PlatformPayOrderDetailsCopyWithImpl<$Res,
+        _$_PlatformPayOrderDetails>
+    implements _$$_PlatformPayOrderDetailsCopyWith<$Res> {
+  __$$_PlatformPayOrderDetailsCopyWithImpl(_$_PlatformPayOrderDetails _value,
+      $Res Function(_$_PlatformPayOrderDetails) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? orderTypeIdentifier = null,
+    Object? orderIdentifier = null,
+    Object? webServiceUrl = null,
+    Object? authenticationToken = null,
+  }) {
+    return _then(_$_PlatformPayOrderDetails(
+      orderTypeIdentifier: null == orderTypeIdentifier
+          ? _value.orderTypeIdentifier
+          : orderTypeIdentifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      orderIdentifier: null == orderIdentifier
+          ? _value.orderIdentifier
+          : orderIdentifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      webServiceUrl: null == webServiceUrl
+          ? _value.webServiceUrl
+          : webServiceUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      authenticationToken: null == authenticationToken
+          ? _value.authenticationToken
+          : authenticationToken // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true)
+class _$_PlatformPayOrderDetails implements _PlatformPayOrderDetails {
+  const _$_PlatformPayOrderDetails(
+      {required this.orderTypeIdentifier,
+      required this.orderIdentifier,
+      required this.webServiceUrl,
+      required this.authenticationToken});
+
+  factory _$_PlatformPayOrderDetails.fromJson(Map<String, dynamic> json) =>
+      _$$_PlatformPayOrderDetailsFromJson(json);
+
+  /// eg: "com.myapp.order"
+  @override
+  final String orderTypeIdentifier;
+
+  /// eg: "ABC123-AAAA-1111"
+  @override
+  final String orderIdentifier;
+
+  /// eg: "https://my-backend.example.com/apple-order-tracking-backend"
+  @override
+  final String webServiceUrl;
+
+  /// eg: "abc123"
+  @override
+  final String authenticationToken;
+
+  @override
+  String toString() {
+    return 'PlatformPayOrderDetails.applePay(orderTypeIdentifier: $orderTypeIdentifier, orderIdentifier: $orderIdentifier, webServiceUrl: $webServiceUrl, authenticationToken: $authenticationToken)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_PlatformPayOrderDetails &&
+            (identical(other.orderTypeIdentifier, orderTypeIdentifier) ||
+                other.orderTypeIdentifier == orderTypeIdentifier) &&
+            (identical(other.orderIdentifier, orderIdentifier) ||
+                other.orderIdentifier == orderIdentifier) &&
+            (identical(other.webServiceUrl, webServiceUrl) ||
+                other.webServiceUrl == webServiceUrl) &&
+            (identical(other.authenticationToken, authenticationToken) ||
+                other.authenticationToken == authenticationToken));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, orderTypeIdentifier,
+      orderIdentifier, webServiceUrl, authenticationToken);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_PlatformPayOrderDetailsCopyWith<_$_PlatformPayOrderDetails>
+      get copyWith =>
+          __$$_PlatformPayOrderDetailsCopyWithImpl<_$_PlatformPayOrderDetails>(
+              this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+            String orderTypeIdentifier,
+            String orderIdentifier,
+            String webServiceUrl,
+            String authenticationToken)
+        applePay,
+  }) {
+    return applePay(orderTypeIdentifier, orderIdentifier, webServiceUrl,
+        authenticationToken);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String orderTypeIdentifier, String orderIdentifier,
+            String webServiceUrl, String authenticationToken)?
+        applePay,
+  }) {
+    return applePay?.call(orderTypeIdentifier, orderIdentifier, webServiceUrl,
+        authenticationToken);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String orderTypeIdentifier, String orderIdentifier,
+            String webServiceUrl, String authenticationToken)?
+        applePay,
+    required TResult orElse(),
+  }) {
+    if (applePay != null) {
+      return applePay(orderTypeIdentifier, orderIdentifier, webServiceUrl,
+          authenticationToken);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_PlatformPayOrderDetails value) applePay,
+  }) {
+    return applePay(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_PlatformPayOrderDetails value)? applePay,
+  }) {
+    return applePay?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_PlatformPayOrderDetails value)? applePay,
+    required TResult orElse(),
+  }) {
+    if (applePay != null) {
+      return applePay(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_PlatformPayOrderDetailsToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PlatformPayOrderDetails implements PlatformPayOrderDetails {
+  const factory _PlatformPayOrderDetails(
+      {required final String orderTypeIdentifier,
+      required final String orderIdentifier,
+      required final String webServiceUrl,
+      required final String authenticationToken}) = _$_PlatformPayOrderDetails;
+
+  factory _PlatformPayOrderDetails.fromJson(Map<String, dynamic> json) =
+      _$_PlatformPayOrderDetails.fromJson;
+
+  @override
+
+  /// eg: "com.myapp.order"
+  String get orderTypeIdentifier;
+  @override
+
+  /// eg: "ABC123-AAAA-1111"
+  String get orderIdentifier;
+  @override
+
+  /// eg: "https://my-backend.example.com/apple-order-tracking-backend"
+  String get webServiceUrl;
+  @override
+
+  /// eg: "abc123"
+  String get authenticationToken;
+  @override
+  @JsonKey(ignore: true)
+  _$$_PlatformPayOrderDetailsCopyWith<_$_PlatformPayOrderDetails>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/stripe_platform_interface/lib/src/models/platform_pay.g.dart
+++ b/packages/stripe_platform_interface/lib/src/models/platform_pay.g.dart
@@ -127,16 +127,12 @@ _$PlatformPayPaymentMethodParamsApplePay
         _$PlatformPayPaymentMethodParamsApplePay(
           applePayParams: ApplePayParams.fromJson(
               json['applePayParams'] as Map<String, dynamic>),
-          applePayPaymentMethodParams: ApplePayPaymentMethodParams.fromJson(
-              json['applePayPaymentMethodParams'] as Map<String, dynamic>),
         );
 
 Map<String, dynamic> _$$PlatformPayPaymentMethodParamsApplePayToJson(
         _$PlatformPayPaymentMethodParamsApplePay instance) =>
     <String, dynamic>{
       'applePayParams': instance.applePayParams.toJson(),
-      'applePayPaymentMethodParams':
-          instance.applePayPaymentMethodParams.toJson(),
     };
 
 _$PlatformPayConfirmParamsGooglePay
@@ -201,6 +197,8 @@ _$_ApplePayParams _$$_ApplePayParamsFromJson(Map<String, dynamic> json) =>
       supportedCountries: (json['supportedCountries'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
+      supportsCouponCode: json['supportsCouponCode'] as bool?,
+      couponCode: json['couponCode'] as String?,
       request: json['request'] == null
           ? null
           : PaymentRequestType.fromJson(
@@ -226,6 +224,8 @@ Map<String, dynamic> _$$_ApplePayParamsToJson(_$_ApplePayParams instance) =>
           .toList(),
       'shippingType': _$ApplePayShippingTypeEnumMap[instance.shippingType],
       'supportedCountries': instance.supportedCountries,
+      'supportsCouponCode': instance.supportsCouponCode,
+      'couponCode': instance.couponCode,
       'request': instance.request?.toJson(),
     };
 
@@ -249,25 +249,6 @@ const _$ApplePayShippingTypeEnumMap = {
   ApplePayShippingType.delivery: 'delivery',
   ApplePayShippingType.shipping: 'shipping',
 };
-
-_$_ApplePayPaymentMethodParams _$$_ApplePayPaymentMethodParamsFromJson(
-        Map<String, dynamic> json) =>
-    _$_ApplePayPaymentMethodParams(
-      supportsCouponCode: json['supportsCouponCode'] as bool?,
-      couponCode: json['couponCode'] as String?,
-      request: json['request'] == null
-          ? null
-          : PaymentRequestType.fromJson(
-              json['request'] as Map<String, dynamic>),
-    );
-
-Map<String, dynamic> _$$_ApplePayPaymentMethodParamsToJson(
-        _$_ApplePayPaymentMethodParams instance) =>
-    <String, dynamic>{
-      'supportsCouponCode': instance.supportsCouponCode,
-      'couponCode': instance.couponCode,
-      'request': instance.request?.toJson(),
-    };
 
 _$_GooglePayParams _$$_GooglePayParamsFromJson(Map<String, dynamic> json) =>
     _$_GooglePayParams(
@@ -442,4 +423,22 @@ Map<String, dynamic> _$$_ApplePayMultiMerchantToJson(
       'merchantName': instance.merchantName,
       'merchantDomain': instance.merchantDomain,
       'amount': instance.amount,
+    };
+
+_$_PlatformPayOrderDetails _$$_PlatformPayOrderDetailsFromJson(
+        Map<String, dynamic> json) =>
+    _$_PlatformPayOrderDetails(
+      orderTypeIdentifier: json['orderTypeIdentifier'] as String,
+      orderIdentifier: json['orderIdentifier'] as String,
+      webServiceUrl: json['webServiceUrl'] as String,
+      authenticationToken: json['authenticationToken'] as String,
+    );
+
+Map<String, dynamic> _$$_PlatformPayOrderDetailsToJson(
+        _$_PlatformPayOrderDetails instance) =>
+    <String, dynamic>{
+      'orderTypeIdentifier': instance.orderTypeIdentifier,
+      'orderIdentifier': instance.orderIdentifier,
+      'webServiceUrl': instance.webServiceUrl,
+      'authenticationToken': instance.authenticationToken,
     };

--- a/packages/stripe_platform_interface/lib/src/models/wallet.dart
+++ b/packages/stripe_platform_interface/lib/src/models/wallet.dart
@@ -10,8 +10,10 @@ enum CanAddToWalletErrorStatus {
   UNSUPPORTED_DEVICE,
   MISSING_CONFIGURATION,
   CARD_ALREADY_EXISTS,
+
   ///This card already exists on this device, but not on the paired device.
   CARD_EXISTS_ON_CURRENT_DEVICE,
+
   /// This card already exists on the paired device, but not on this device.
   CARD_EXISTS_ON_PAIRED_DEVICE,
 }

--- a/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
@@ -117,6 +117,9 @@ abstract class StripePlatform extends PlatformInterface {
   Future<void> updatePlatformSheet(
       {required PlatformPaySheetUpdateParams params});
 
+  Future<void> configurePlatformOrderTracking(
+      {required PlatformPayOrderDetails orderDetails});
+
   /// Creates a token for card details.
   ///
   /// Note this method is legacy and it is advised to use [PaymentIntent].

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -465,6 +465,12 @@ class WebStripe extends StripePlatform {
       {required PlatformPaySheetUpdateParams params}) {
     throw WebUnsupportedError.method('updatePlatformSheet');
   }
+
+  @override
+  Future<void> configurePlatformOrderTracking(
+      {required PlatformPayOrderDetails orderDetails}) {
+    throw WebUnsupportedError.method('configurePlatformOrderTracking');
+  }
 }
 
 class WebUnsupportedError extends Error implements UnsupportedError {


### PR DESCRIPTION
- Fixes Apple Pay

1. `onShippingContactSelected`, `onShippingMethodSelected`,  `onCouponCodeEntered` and `onOrderTracking` are now optional.

2. When using `onShippingContactSelected`, `onShippingMethodSelected`. It will be required to call ` Stripe.instance.updatePlatformSheet` with the new data

3. If you want to enable orderTracking implement a callback `onOrderTracking` that calls `Stripe.instance.configurePlatformOrderTracking`

4. To enable couponCode use `PlatformPayConfirmParams.applePay.supportsCouponCode` and `PlatformPayConfirmParams.applePay.couponCode`