### PR TITLE
Adds Android namespace

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'com.flutter.stripe.example'
     compileSdkVersion 33
 
     sourceSets {

--- a/packages/stripe_android/android/build.gradle
+++ b/packages/stripe_android/android/build.gradle
@@ -27,6 +27,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.flutter.stripe'
     compileSdkVersion 32
 
     sourceSets {


### PR DESCRIPTION
Adds a `namespace` attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0.
See:
https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b