### PR TITLE
fix: PaymentConfirmationRedirect enum value

### DIFF
--- a/packages/stripe_js/CHANGELOG.md
+++ b/packages/stripe_js/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.1 
+Fixes PaymentConfirmationRedirect.ifRedirect enum value parsing
 ## 3.0.0
 - Adds support for SetupIntent
 - Adds support for Tokens Api

--- a/packages/stripe_js/lib/src/api/payment_intents/confirm_payment_options.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/confirm_payment_options.dart
@@ -50,6 +50,6 @@ class ConfirmPaymentParams with _$ConfirmPaymentParams {
 /// will only redirect if your user chooses a redirect-based payment method.
 enum PaymentConfirmationRedirect {
   always,
-  @JsonKey(name: 'if_required')
+  @JsonValue('if_required')
   ifRequired,
 }

--- a/packages/stripe_js/lib/src/api/payment_intents/confirm_payment_options.g.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/confirm_payment_options.g.dart
@@ -34,7 +34,7 @@ Map<String, dynamic> _$$_ConfirmPaymentOptionsToJson(
 
 const _$PaymentConfirmationRedirectEnumMap = {
   PaymentConfirmationRedirect.always: 'always',
-  PaymentConfirmationRedirect.ifRequired: 'ifRequired',
+  PaymentConfirmationRedirect.ifRequired: 'if_required',
 };
 
 _$_ConfirmPaymentParams _$$_ConfirmPaymentParamsFromJson(Map json) =>

--- a/packages/stripe_js/pubspec.yaml
+++ b/packages/stripe_js/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stripe_js
 description: Stripe.js bindings for dart. This package is used by Stripe web so that the Stripe js sdk can be invoked directly.
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/flutter-stripe/flutter_stripe
 
 environment:


### PR DESCRIPTION
Fixes https://github.com/flutter-stripe/flutter_stripe/issues/1219

- Fixes error while parsing PaymentConfirmationRedirect.ifRedirect