### PR TITLE
Fix ApplePayButton styling

### DIFF
--- a/packages/stripe/lib/src/widgets/apple_pay_button.dart
+++ b/packages/stripe/lib/src/widgets/apple_pay_button.dart
@@ -146,7 +146,7 @@ class _UiKitApplePayButtonState extends State<_UiKitApplePayButton> {
       creationParamsCodec: const StandardMessageCodec(),
       creationParams: {
         'type': widget.type.id,
-        'style': widget.style.id,
+        'buttonStyle': widget.style.id,
         'borderRadius': widget.cornerRadius
       },
       onPlatformViewCreated: (viewId) {


### PR DESCRIPTION
Fix ApplePayButton passing an incorrect key for the styling option to the platform channel