### PR TITLE
 feat: web fixes and features

### DIFF
--- a/example/lib/screens/payment_sheet/payment_element/platforms/payment_element_web.dart
+++ b/example/lib/screens/payment_sheet/payment_element/platforms/payment_element_web.dart
@@ -4,7 +4,7 @@ import 'package:flutter_stripe_web/flutter_stripe_web.dart';
 import '../../../checkout/platforms/stripe_checkout_web.dart';
 
 Future<void> pay() async {
-  await WebStripe().confirmPaymentElement(
+  await WebStripe.instance.confirmPaymentElement(
     ConfirmPaymentElementOptions(
       confirmParams: ConfirmPaymentParams(return_url: getReturnUrl()),
     ),

--- a/packages/stripe_js/lib/src/api/elements/element_appearance.dart
+++ b/packages/stripe_js/lib/src/api/elements/element_appearance.dart
@@ -1,0 +1,26 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'element_appearance.freezed.dart';
+part 'element_appearance.g.dart';
+
+enum ElementTheme { stripe, night, flat, none }
+
+/// Enables switching between labels above form fields and floating
+/// labels within the form fields
+enum ElementAppearanceLabel { above, floating }
+
+@freezed
+
+/// Appareance options for the Payment Element and other elements.
+/// https://stripe.com/docs/elements/appearance-api
+class ElementAppearance with _$ElementAppearance {
+  const factory ElementAppearance({
+    @Default(ElementTheme.stripe) ElementTheme theme,
+    Map<String, String>? variables,
+    Map<String, Map<String, String>>? rules,
+    @Default(ElementAppearanceLabel.above) label,
+  }) = _ElementAppearance;
+
+  factory ElementAppearance.fromJson(Map<String, dynamic> json) =>
+      _$ElementAppearanceFromJson(json);
+}

--- a/packages/stripe_js/lib/src/api/elements/element_appearance.dart
+++ b/packages/stripe_js/lib/src/api/elements/element_appearance.dart
@@ -18,7 +18,7 @@ class ElementAppearance with _$ElementAppearance {
     @Default(ElementTheme.stripe) ElementTheme theme,
     Map<String, String>? variables,
     Map<String, Map<String, String>>? rules,
-    @Default(ElementAppearanceLabels.above) labels,
+    @Default(ElementAppearanceLabels.above) ElementAppearanceLabels labels,
   }) = _ElementAppearance;
 
   factory ElementAppearance.fromJson(Map<String, dynamic> json) =>

--- a/packages/stripe_js/lib/src/api/elements/element_appearance.dart
+++ b/packages/stripe_js/lib/src/api/elements/element_appearance.dart
@@ -7,7 +7,7 @@ enum ElementTheme { stripe, night, flat, none }
 
 /// Enables switching between labels above form fields and floating
 /// labels within the form fields
-enum ElementAppearanceLabel { above, floating }
+enum ElementAppearanceLabels { above, floating }
 
 @freezed
 
@@ -18,7 +18,7 @@ class ElementAppearance with _$ElementAppearance {
     @Default(ElementTheme.stripe) ElementTheme theme,
     Map<String, String>? variables,
     Map<String, Map<String, String>>? rules,
-    @Default(ElementAppearanceLabel.above) label,
+    @Default(ElementAppearanceLabels.above) labels,
   }) = _ElementAppearance;
 
   factory ElementAppearance.fromJson(Map<String, dynamic> json) =>

--- a/packages/stripe_js/lib/src/api/elements/element_appearance.freezed.dart
+++ b/packages/stripe_js/lib/src/api/elements/element_appearance.freezed.dart
@@ -24,7 +24,7 @@ mixin _$ElementAppearance {
   Map<String, String>? get variables => throw _privateConstructorUsedError;
   Map<String, Map<String, String>>? get rules =>
       throw _privateConstructorUsedError;
-  dynamic get labels => throw _privateConstructorUsedError;
+  ElementAppearanceLabels get labels => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -42,7 +42,7 @@ abstract class $ElementAppearanceCopyWith<$Res> {
       {ElementTheme theme,
       Map<String, String>? variables,
       Map<String, Map<String, String>>? rules,
-      dynamic labels});
+      ElementAppearanceLabels labels});
 }
 
 /// @nodoc
@@ -61,7 +61,7 @@ class _$ElementAppearanceCopyWithImpl<$Res, $Val extends ElementAppearance>
     Object? theme = null,
     Object? variables = freezed,
     Object? rules = freezed,
-    Object? labels = freezed,
+    Object? labels = null,
   }) {
     return _then(_value.copyWith(
       theme: null == theme
@@ -76,10 +76,10 @@ class _$ElementAppearanceCopyWithImpl<$Res, $Val extends ElementAppearance>
           ? _value.rules
           : rules // ignore: cast_nullable_to_non_nullable
               as Map<String, Map<String, String>>?,
-      labels: freezed == labels
+      labels: null == labels
           ? _value.labels
           : labels // ignore: cast_nullable_to_non_nullable
-              as dynamic,
+              as ElementAppearanceLabels,
     ) as $Val);
   }
 }
@@ -96,7 +96,7 @@ abstract class _$$_ElementAppearanceCopyWith<$Res>
       {ElementTheme theme,
       Map<String, String>? variables,
       Map<String, Map<String, String>>? rules,
-      dynamic labels});
+      ElementAppearanceLabels labels});
 }
 
 /// @nodoc
@@ -113,7 +113,7 @@ class __$$_ElementAppearanceCopyWithImpl<$Res>
     Object? theme = null,
     Object? variables = freezed,
     Object? rules = freezed,
-    Object? labels = freezed,
+    Object? labels = null,
   }) {
     return _then(_$_ElementAppearance(
       theme: null == theme
@@ -128,7 +128,10 @@ class __$$_ElementAppearanceCopyWithImpl<$Res>
           ? _value._rules
           : rules // ignore: cast_nullable_to_non_nullable
               as Map<String, Map<String, String>>?,
-      labels: freezed == labels ? _value.labels! : labels,
+      labels: null == labels
+          ? _value.labels
+          : labels // ignore: cast_nullable_to_non_nullable
+              as ElementAppearanceLabels,
     ));
   }
 }
@@ -172,7 +175,7 @@ class _$_ElementAppearance implements _ElementAppearance {
 
   @override
   @JsonKey()
-  final dynamic labels;
+  final ElementAppearanceLabels labels;
 
   @override
   String toString() {
@@ -188,7 +191,7 @@ class _$_ElementAppearance implements _ElementAppearance {
             const DeepCollectionEquality()
                 .equals(other._variables, _variables) &&
             const DeepCollectionEquality().equals(other._rules, _rules) &&
-            const DeepCollectionEquality().equals(other.labels, labels));
+            (identical(other.labels, labels) || other.labels == labels));
   }
 
   @JsonKey(ignore: true)
@@ -198,7 +201,7 @@ class _$_ElementAppearance implements _ElementAppearance {
       theme,
       const DeepCollectionEquality().hash(_variables),
       const DeepCollectionEquality().hash(_rules),
-      const DeepCollectionEquality().hash(labels));
+      labels);
 
   @JsonKey(ignore: true)
   @override
@@ -220,7 +223,7 @@ abstract class _ElementAppearance implements ElementAppearance {
       {final ElementTheme theme,
       final Map<String, String>? variables,
       final Map<String, Map<String, String>>? rules,
-      final dynamic labels}) = _$_ElementAppearance;
+      final ElementAppearanceLabels labels}) = _$_ElementAppearance;
 
   factory _ElementAppearance.fromJson(Map<String, dynamic> json) =
       _$_ElementAppearance.fromJson;
@@ -232,7 +235,7 @@ abstract class _ElementAppearance implements ElementAppearance {
   @override
   Map<String, Map<String, String>>? get rules;
   @override
-  dynamic get labels;
+  ElementAppearanceLabels get labels;
   @override
   @JsonKey(ignore: true)
   _$$_ElementAppearanceCopyWith<_$_ElementAppearance> get copyWith =>

--- a/packages/stripe_js/lib/src/api/elements/element_appearance.freezed.dart
+++ b/packages/stripe_js/lib/src/api/elements/element_appearance.freezed.dart
@@ -24,7 +24,7 @@ mixin _$ElementAppearance {
   Map<String, String>? get variables => throw _privateConstructorUsedError;
   Map<String, Map<String, String>>? get rules =>
       throw _privateConstructorUsedError;
-  dynamic get label => throw _privateConstructorUsedError;
+  dynamic get labels => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -42,7 +42,7 @@ abstract class $ElementAppearanceCopyWith<$Res> {
       {ElementTheme theme,
       Map<String, String>? variables,
       Map<String, Map<String, String>>? rules,
-      dynamic label});
+      dynamic labels});
 }
 
 /// @nodoc
@@ -61,7 +61,7 @@ class _$ElementAppearanceCopyWithImpl<$Res, $Val extends ElementAppearance>
     Object? theme = null,
     Object? variables = freezed,
     Object? rules = freezed,
-    Object? label = freezed,
+    Object? labels = freezed,
   }) {
     return _then(_value.copyWith(
       theme: null == theme
@@ -76,9 +76,9 @@ class _$ElementAppearanceCopyWithImpl<$Res, $Val extends ElementAppearance>
           ? _value.rules
           : rules // ignore: cast_nullable_to_non_nullable
               as Map<String, Map<String, String>>?,
-      label: freezed == label
-          ? _value.label
-          : label // ignore: cast_nullable_to_non_nullable
+      labels: freezed == labels
+          ? _value.labels
+          : labels // ignore: cast_nullable_to_non_nullable
               as dynamic,
     ) as $Val);
   }
@@ -96,7 +96,7 @@ abstract class _$$_ElementAppearanceCopyWith<$Res>
       {ElementTheme theme,
       Map<String, String>? variables,
       Map<String, Map<String, String>>? rules,
-      dynamic label});
+      dynamic labels});
 }
 
 /// @nodoc
@@ -113,7 +113,7 @@ class __$$_ElementAppearanceCopyWithImpl<$Res>
     Object? theme = null,
     Object? variables = freezed,
     Object? rules = freezed,
-    Object? label = freezed,
+    Object? labels = freezed,
   }) {
     return _then(_$_ElementAppearance(
       theme: null == theme
@@ -128,7 +128,7 @@ class __$$_ElementAppearanceCopyWithImpl<$Res>
           ? _value._rules
           : rules // ignore: cast_nullable_to_non_nullable
               as Map<String, Map<String, String>>?,
-      label: freezed == label ? _value.label! : label,
+      labels: freezed == labels ? _value.labels! : labels,
     ));
   }
 }
@@ -140,7 +140,7 @@ class _$_ElementAppearance implements _ElementAppearance {
       {this.theme = ElementTheme.stripe,
       final Map<String, String>? variables,
       final Map<String, Map<String, String>>? rules,
-      this.label = ElementAppearanceLabel.above})
+      this.labels = ElementAppearanceLabels.above})
       : _variables = variables,
         _rules = rules;
 
@@ -172,11 +172,11 @@ class _$_ElementAppearance implements _ElementAppearance {
 
   @override
   @JsonKey()
-  final dynamic label;
+  final dynamic labels;
 
   @override
   String toString() {
-    return 'ElementAppearance(theme: $theme, variables: $variables, rules: $rules, label: $label)';
+    return 'ElementAppearance(theme: $theme, variables: $variables, rules: $rules, labels: $labels)';
   }
 
   @override
@@ -188,7 +188,7 @@ class _$_ElementAppearance implements _ElementAppearance {
             const DeepCollectionEquality()
                 .equals(other._variables, _variables) &&
             const DeepCollectionEquality().equals(other._rules, _rules) &&
-            const DeepCollectionEquality().equals(other.label, label));
+            const DeepCollectionEquality().equals(other.labels, labels));
   }
 
   @JsonKey(ignore: true)
@@ -198,7 +198,7 @@ class _$_ElementAppearance implements _ElementAppearance {
       theme,
       const DeepCollectionEquality().hash(_variables),
       const DeepCollectionEquality().hash(_rules),
-      const DeepCollectionEquality().hash(label));
+      const DeepCollectionEquality().hash(labels));
 
   @JsonKey(ignore: true)
   @override
@@ -220,7 +220,7 @@ abstract class _ElementAppearance implements ElementAppearance {
       {final ElementTheme theme,
       final Map<String, String>? variables,
       final Map<String, Map<String, String>>? rules,
-      final dynamic label}) = _$_ElementAppearance;
+      final dynamic labels}) = _$_ElementAppearance;
 
   factory _ElementAppearance.fromJson(Map<String, dynamic> json) =
       _$_ElementAppearance.fromJson;
@@ -232,7 +232,7 @@ abstract class _ElementAppearance implements ElementAppearance {
   @override
   Map<String, Map<String, String>>? get rules;
   @override
-  dynamic get label;
+  dynamic get labels;
   @override
   @JsonKey(ignore: true)
   _$$_ElementAppearanceCopyWith<_$_ElementAppearance> get copyWith =>

--- a/packages/stripe_js/lib/src/api/elements/element_appearance.freezed.dart
+++ b/packages/stripe_js/lib/src/api/elements/element_appearance.freezed.dart
@@ -1,0 +1,240 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'element_appearance.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ElementAppearance _$ElementAppearanceFromJson(Map<String, dynamic> json) {
+  return _ElementAppearance.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ElementAppearance {
+  ElementTheme get theme => throw _privateConstructorUsedError;
+  Map<String, String>? get variables => throw _privateConstructorUsedError;
+  Map<String, Map<String, String>>? get rules =>
+      throw _privateConstructorUsedError;
+  dynamic get label => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ElementAppearanceCopyWith<ElementAppearance> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ElementAppearanceCopyWith<$Res> {
+  factory $ElementAppearanceCopyWith(
+          ElementAppearance value, $Res Function(ElementAppearance) then) =
+      _$ElementAppearanceCopyWithImpl<$Res, ElementAppearance>;
+  @useResult
+  $Res call(
+      {ElementTheme theme,
+      Map<String, String>? variables,
+      Map<String, Map<String, String>>? rules,
+      dynamic label});
+}
+
+/// @nodoc
+class _$ElementAppearanceCopyWithImpl<$Res, $Val extends ElementAppearance>
+    implements $ElementAppearanceCopyWith<$Res> {
+  _$ElementAppearanceCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? theme = null,
+    Object? variables = freezed,
+    Object? rules = freezed,
+    Object? label = freezed,
+  }) {
+    return _then(_value.copyWith(
+      theme: null == theme
+          ? _value.theme
+          : theme // ignore: cast_nullable_to_non_nullable
+              as ElementTheme,
+      variables: freezed == variables
+          ? _value.variables
+          : variables // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>?,
+      rules: freezed == rules
+          ? _value.rules
+          : rules // ignore: cast_nullable_to_non_nullable
+              as Map<String, Map<String, String>>?,
+      label: freezed == label
+          ? _value.label
+          : label // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_ElementAppearanceCopyWith<$Res>
+    implements $ElementAppearanceCopyWith<$Res> {
+  factory _$$_ElementAppearanceCopyWith(_$_ElementAppearance value,
+          $Res Function(_$_ElementAppearance) then) =
+      __$$_ElementAppearanceCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {ElementTheme theme,
+      Map<String, String>? variables,
+      Map<String, Map<String, String>>? rules,
+      dynamic label});
+}
+
+/// @nodoc
+class __$$_ElementAppearanceCopyWithImpl<$Res>
+    extends _$ElementAppearanceCopyWithImpl<$Res, _$_ElementAppearance>
+    implements _$$_ElementAppearanceCopyWith<$Res> {
+  __$$_ElementAppearanceCopyWithImpl(
+      _$_ElementAppearance _value, $Res Function(_$_ElementAppearance) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? theme = null,
+    Object? variables = freezed,
+    Object? rules = freezed,
+    Object? label = freezed,
+  }) {
+    return _then(_$_ElementAppearance(
+      theme: null == theme
+          ? _value.theme
+          : theme // ignore: cast_nullable_to_non_nullable
+              as ElementTheme,
+      variables: freezed == variables
+          ? _value._variables
+          : variables // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>?,
+      rules: freezed == rules
+          ? _value._rules
+          : rules // ignore: cast_nullable_to_non_nullable
+              as Map<String, Map<String, String>>?,
+      label: freezed == label ? _value.label! : label,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_ElementAppearance implements _ElementAppearance {
+  const _$_ElementAppearance(
+      {this.theme = ElementTheme.stripe,
+      final Map<String, String>? variables,
+      final Map<String, Map<String, String>>? rules,
+      this.label = ElementAppearanceLabel.above})
+      : _variables = variables,
+        _rules = rules;
+
+  factory _$_ElementAppearance.fromJson(Map<String, dynamic> json) =>
+      _$$_ElementAppearanceFromJson(json);
+
+  @override
+  @JsonKey()
+  final ElementTheme theme;
+  final Map<String, String>? _variables;
+  @override
+  Map<String, String>? get variables {
+    final value = _variables;
+    if (value == null) return null;
+    if (_variables is EqualUnmodifiableMapView) return _variables;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  final Map<String, Map<String, String>>? _rules;
+  @override
+  Map<String, Map<String, String>>? get rules {
+    final value = _rules;
+    if (value == null) return null;
+    if (_rules is EqualUnmodifiableMapView) return _rules;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  @override
+  @JsonKey()
+  final dynamic label;
+
+  @override
+  String toString() {
+    return 'ElementAppearance(theme: $theme, variables: $variables, rules: $rules, label: $label)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ElementAppearance &&
+            (identical(other.theme, theme) || other.theme == theme) &&
+            const DeepCollectionEquality()
+                .equals(other._variables, _variables) &&
+            const DeepCollectionEquality().equals(other._rules, _rules) &&
+            const DeepCollectionEquality().equals(other.label, label));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      theme,
+      const DeepCollectionEquality().hash(_variables),
+      const DeepCollectionEquality().hash(_rules),
+      const DeepCollectionEquality().hash(label));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_ElementAppearanceCopyWith<_$_ElementAppearance> get copyWith =>
+      __$$_ElementAppearanceCopyWithImpl<_$_ElementAppearance>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_ElementAppearanceToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ElementAppearance implements ElementAppearance {
+  const factory _ElementAppearance(
+      {final ElementTheme theme,
+      final Map<String, String>? variables,
+      final Map<String, Map<String, String>>? rules,
+      final dynamic label}) = _$_ElementAppearance;
+
+  factory _ElementAppearance.fromJson(Map<String, dynamic> json) =
+      _$_ElementAppearance.fromJson;
+
+  @override
+  ElementTheme get theme;
+  @override
+  Map<String, String>? get variables;
+  @override
+  Map<String, Map<String, String>>? get rules;
+  @override
+  dynamic get label;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ElementAppearanceCopyWith<_$_ElementAppearance> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/stripe_js/lib/src/api/elements/element_appearance.g.dart
+++ b/packages/stripe_js/lib/src/api/elements/element_appearance.g.dart
@@ -1,0 +1,45 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'element_appearance.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_ElementAppearance _$$_ElementAppearanceFromJson(Map json) =>
+    _$_ElementAppearance(
+      theme: $enumDecodeNullable(_$ElementThemeEnumMap, json['theme']) ??
+          ElementTheme.stripe,
+      variables: (json['variables'] as Map?)?.map(
+        (k, e) => MapEntry(k as String, e as String),
+      ),
+      rules: (json['rules'] as Map?)?.map(
+        (k, e) => MapEntry(k as String, Map<String, String>.from(e as Map)),
+      ),
+      label: json['label'] ?? ElementAppearanceLabel.above,
+    );
+
+Map<String, dynamic> _$$_ElementAppearanceToJson(
+    _$_ElementAppearance instance) {
+  final val = <String, dynamic>{
+    'theme': _$ElementThemeEnumMap[instance.theme]!,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('variables', instance.variables);
+  writeNotNull('rules', instance.rules);
+  writeNotNull('label', instance.label);
+  return val;
+}
+
+const _$ElementThemeEnumMap = {
+  ElementTheme.stripe: 'stripe',
+  ElementTheme.night: 'night',
+  ElementTheme.flat: 'flat',
+  ElementTheme.none: 'none',
+};

--- a/packages/stripe_js/lib/src/api/elements/element_appearance.g.dart
+++ b/packages/stripe_js/lib/src/api/elements/element_appearance.g.dart
@@ -16,7 +16,9 @@ _$_ElementAppearance _$$_ElementAppearanceFromJson(Map json) =>
       rules: (json['rules'] as Map?)?.map(
         (k, e) => MapEntry(k as String, Map<String, String>.from(e as Map)),
       ),
-      labels: json['labels'] ?? ElementAppearanceLabels.above,
+      labels: $enumDecodeNullable(
+              _$ElementAppearanceLabelsEnumMap, json['labels']) ??
+          ElementAppearanceLabels.above,
     );
 
 Map<String, dynamic> _$$_ElementAppearanceToJson(
@@ -33,7 +35,7 @@ Map<String, dynamic> _$$_ElementAppearanceToJson(
 
   writeNotNull('variables', instance.variables);
   writeNotNull('rules', instance.rules);
-  writeNotNull('labels', instance.labels);
+  val['labels'] = _$ElementAppearanceLabelsEnumMap[instance.labels]!;
   return val;
 }
 
@@ -42,4 +44,9 @@ const _$ElementThemeEnumMap = {
   ElementTheme.night: 'night',
   ElementTheme.flat: 'flat',
   ElementTheme.none: 'none',
+};
+
+const _$ElementAppearanceLabelsEnumMap = {
+  ElementAppearanceLabels.above: 'above',
+  ElementAppearanceLabels.floating: 'floating',
 };

--- a/packages/stripe_js/lib/src/api/elements/element_appearance.g.dart
+++ b/packages/stripe_js/lib/src/api/elements/element_appearance.g.dart
@@ -16,7 +16,7 @@ _$_ElementAppearance _$$_ElementAppearanceFromJson(Map json) =>
       rules: (json['rules'] as Map?)?.map(
         (k, e) => MapEntry(k as String, Map<String, String>.from(e as Map)),
       ),
-      label: json['label'] ?? ElementAppearanceLabel.above,
+      labels: json['labels'] ?? ElementAppearanceLabels.above,
     );
 
 Map<String, dynamic> _$$_ElementAppearanceToJson(
@@ -33,7 +33,7 @@ Map<String, dynamic> _$$_ElementAppearanceToJson(
 
   writeNotNull('variables', instance.variables);
   writeNotNull('rules', instance.rules);
-  writeNotNull('label', instance.label);
+  writeNotNull('labels', instance.labels);
   return val;
 }
 

--- a/packages/stripe_js/lib/src/api/elements/elements.dart
+++ b/packages/stripe_js/lib/src/api/elements/elements.dart
@@ -1,6 +1,7 @@
 export 'card_element_change_event.dart';
 export 'card_element_options.dart';
 export 'element.dart';
+export 'element_appearance.dart';
 export 'payment_element_change_event.dart';
 export 'payment_element_options.dart';
 export 'payment_intent_shipping_information.dart';

--- a/packages/stripe_js/lib/src/js/elements/element_creation_options.dart
+++ b/packages/stripe_js/lib/src/js/elements/element_creation_options.dart
@@ -6,30 +6,32 @@ import 'package:stripe_js/stripe_js.dart';
 
 @anonymous
 @JS()
-abstract class ElementsCreateOptions {
-  external factory ElementsCreateOptions({
-    JsArray<Font> fonts,
-    String locale,
-    String clientSecret,
-    JsElementAppearance appearance,
+abstract class JsElementsCreateOptions {
+  @JS("ElementsCreateOptions")
+  external factory JsElementsCreateOptions({
+    JsArray<Font>? fonts,
+    String? locale,
+    String? clientSecret,
+    JsElementAppearance? appearance,
     String loader = "auto",
   });
+
   external JsArray<Font> fonts;
   external String locale;
   external String clientSecret;
   external JsElementAppearance appearance;
 }
 
-enum ElementTheme { stripe, night, flat, none }
-
-JsElementAppearance ElementAppareance({ElementTheme? theme}) {
-  return JsElementAppearance._(theme: theme?.name);
-}
-
 @anonymous
 @JS()
 class JsElementAppearance {
   external String? theme;
+  external Map<String, String>? variables;
+  external Map<String, Map<String, String>>? rules;
   @JS("ElementAppearance")
-  external factory JsElementAppearance._({String? theme});
+  external factory JsElementAppearance({
+    String? theme,
+    Map<String, String>? variables,
+    Map<String, Map<String, String>>? rules,
+  });
 }

--- a/packages/stripe_js/lib/src/js/elements/element_creation_options.dart
+++ b/packages/stripe_js/lib/src/js/elements/element_creation_options.dart
@@ -28,10 +28,12 @@ class JsElementAppearance {
   external String? theme;
   external Map<String, String>? variables;
   external Map<String, Map<String, String>>? rules;
+  external String? labels;
   @JS("ElementAppearance")
   external factory JsElementAppearance({
     String? theme,
     Map<String, String>? variables,
     Map<String, Map<String, String>>? rules,
+    String? labels,
   });
 }

--- a/packages/stripe_js/lib/src/js/stripe.dart
+++ b/packages/stripe_js/lib/src/js/stripe.dart
@@ -18,7 +18,7 @@ class Stripe {
   }
   external static num get version;
 
-  external StripeElements elements([ElementsCreateOptions options]);
+  external StripeElements elements([JsElementsCreateOptions options]);
 
   external String? get stripeAccount;
   external set stripeAccount(String? stripeAccount);

--- a/packages/stripe_js/test/src/js/elements/element_payment_test.dart
+++ b/packages/stripe_js/test/src/js/elements/element_payment_test.dart
@@ -17,7 +17,7 @@ void main() {
       final stripe = Stripe(stripePublishableKey);
 
       elements = stripe.elements(
-        ElementsCreateOptions(
+        JsElementsCreateOptions(
           clientSecret: setupInputClientSecret,
         ),
       );

--- a/packages/stripe_js/test/src/js/elements/elements_base_test.dart
+++ b/packages/stripe_js/test/src/js/elements/elements_base_test.dart
@@ -16,12 +16,13 @@ void main() {
     });
 
     test('can be initialized with options', () {
-      expect(stripe.elements(ElementsCreateOptions()), isNotNull);
+      expect(stripe.elements(JsElementsCreateOptions()), isNotNull);
     });
 
     test('can be initialized with custom ElementAppareance', () {
-      final options = ElementsCreateOptions(
-          appearance: ElementAppareance(theme: ElementTheme.flat));
+      final options = JsElementsCreateOptions(
+        appearance: JsElementAppearance(theme: 'stripe'),
+      );
       expect(stripe.elements(options), isNotNull);
     });
   });

--- a/packages/stripe_web/lib/src/parser/payment_intent.dart
+++ b/packages/stripe_web/lib/src/parser/payment_intent.dart
@@ -53,7 +53,7 @@ extension PaymentIntentsStatusExtension on PaymentIntentsStatus {
       case 'Unknown':
         return PaymentIntentsStatus.Unknown;
     }
-    throw '$value is not a payment intent status';
+    throw Exception('$value is not a payment intent status');
   }
 }
 
@@ -67,7 +67,7 @@ extension CaptureMethodExtension on CaptureMethod {
       case 'manual':
         return CaptureMethod.Manual;
     }
-    throw '$value is not a valid capture method';
+    throw Exception('$value is not a valid capture method');
   }
 }
 
@@ -81,7 +81,7 @@ extension ConfirmationMethodExtension on ConfirmationMethod {
       case 'manual':
         return ConfirmationMethod.Manual;
     }
-    throw '$value is not a valid confirmation method';
+    throw Exception('$value is not a valid confirmation method');
   }
 }
 

--- a/packages/stripe_web/lib/src/parser/payment_intent.dart
+++ b/packages/stripe_web/lib/src/parser/payment_intent.dart
@@ -136,23 +136,23 @@ extension BillingDetailsToJs on BillingDetails {
 extension ShippingAddressFromJs on Address {
   js.BillingAddress toBillingAddressJs() {
     return js.BillingAddress(
-      city: city ?? '',
-      country: country ?? '',
-      line1: line1 ?? '',
-      line2: line2 ?? '',
-      postalCode: postalCode ?? '',
-      state: state ?? '',
+      city: city,
+      country: country,
+      line1: line1,
+      line2: line2,
+      postalCode: postalCode,
+      state: state,
     );
   }
 
   js.ShippingDetailsAddress toShippingAddressJs() {
     return js.ShippingDetailsAddress(
-      city: city ?? '',
-      country: country ?? '',
-      line1: line1 ?? '',
-      line2: line2 ?? '',
-      postalCode: postalCode ?? '',
-      state: state ?? '',
+      city: city,
+      country: country,
+      line1: line1,
+      line2: line2,
+      postalCode: postalCode,
+      state: state,
     );
   }
 }

--- a/packages/stripe_web/lib/src/parser/payment_methods.dart
+++ b/packages/stripe_web/lib/src/parser/payment_methods.dart
@@ -31,7 +31,7 @@ extension StripeParser on js.CardPaymentMethod {
     return Card(
       brand: brand,
       country: country,
-      expMonth: expYear,
+      expMonth: expMonth,
       expYear: expYear,
       funding: funding,
       last4: last4,

--- a/packages/stripe_web/lib/src/parser/payment_methods.dart
+++ b/packages/stripe_web/lib/src/parser/payment_methods.dart
@@ -34,6 +34,9 @@ extension StripeParser on js.CardPaymentMethod {
       expMonth: expYear,
       expYear: expYear,
       funding: funding,
+      last4: last4,
+      availableNetworks: availableNetworks,
+      preferredNetwork: preferredNetwork,
     );
   }
 }

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -30,7 +30,7 @@ class WebStripe extends StripePlatform {
 
   WebStripe._();
   @Deprecated('Use WebStripe.instance instead')
-  WebStripe();
+  factory WebStripe() => instance;
 
   @override
   bool get updateSettingsLazily => false;

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -168,7 +168,7 @@ class WebStripe extends StripePlatform {
         );
       },
       orElse: () {
-        throw UnimplementedError();
+        throw WebUnsupportedError();
       },
     );
     if (response.error != null) {
@@ -198,7 +198,7 @@ class WebStripe extends StripePlatform {
 
     if (response.error != null) {
       throw StripeError(
-        message: response.error?.message ?? '',
+        message: response.error!.message ?? '',
         code: response.error!.code,
       );
     }

--- a/packages/stripe_web/lib/src/widgets/card_field.dart
+++ b/packages/stripe_web/lib/src/widgets/card_field.dart
@@ -85,7 +85,9 @@ class WebStripeCardState extends State<WebCardField> with CardFieldContext {
             const CardFieldInputDetails(complete: false),
             controller,
           );
-          element = WebStripe.js.elements().createCard(createOptions())
+          element = WebStripe.js
+              .elements(createElementOptions())
+              .createCard(createOptions())
             ..mount('#card-element')
             ..onBlur(requestBlur)
             ..onFocus(requestFocus)
@@ -135,6 +137,24 @@ class WebStripeCardState extends State<WebCardField> with CardFieldContext {
         ),
       ),
     );
+  }
+
+  js.JsElementsCreateOptions createElementOptions() {
+    final textColor = widget.style?.textColor;
+    return js.JsElementsCreateOptions(
+      appearance: js.jsify(
+        js.ElementAppearance(
+          theme: js.ElementTheme.stripe,
+          variables: {
+            if (textColor != null) 'colorText': colorToCssString(textColor),
+          },
+        ).toJson(),
+      ) as js.JsElementAppearance,
+    );
+  }
+
+  String colorToCssString(Color color) {
+    return 'rgb(${color.red}, ${color.green}, ${color.blue})';
   }
 
   js.CardElementOptions createOptions() {

--- a/packages/stripe_web/lib/src/widgets/payment_element.dart
+++ b/packages/stripe_web/lib/src/widgets/payment_element.dart
@@ -9,6 +9,10 @@ import '../../flutter_stripe_web.dart';
 import 'package:stripe_js/stripe_js.dart' as js;
 import 'package:stripe_js/stripe_api.dart' as js;
 
+export 'package:stripe_js/stripe_api.dart' show PaymentElementLayout;
+
+typedef PaymentElementTheme = js.ElementTheme;
+
 class PaymentElement extends StatefulWidget {
   PaymentElement({
     required this.onCardChanged,
@@ -23,6 +27,8 @@ class PaymentElement extends StatefulWidget {
     this.focusNode,
     required this.clientSecret,
     this.autofocus = false,
+    this.layout = PaymentElementLayout.accordion,
+    this.appearance,
   })  : assert(constraints == null || constraints.debugAssertIsValid()),
         constraints = (width != null || height != null)
             ? constraints?.tighten(width: width, height: height) ??
@@ -39,6 +45,8 @@ class PaymentElement extends StatefulWidget {
   final bool enablePostalCode;
   final FocusNode? focusNode;
   final bool autofocus;
+  final PaymentElementLayout layout;
+  final js.ElementAppearance? appearance;
   @override
   PaymentElementState createState() => PaymentElementState();
 }
@@ -143,18 +151,16 @@ class PaymentElementState extends State<PaymentElement> {
     );
   }
 
-  js.ElementsCreateOptions createOptions() {
-    final appearance = js.ElementAppareance(theme: js.ElementTheme.night);
-    return js.ElementsCreateOptions(
+  js.JsElementsCreateOptions createOptions() {
+    final appearance = widget.appearance ?? js.ElementAppearance();
+    return js.JsElementsCreateOptions(
       clientSecret: widget.clientSecret,
-      appearance: appearance,
+      appearance: js.jsify(appearance.toJson()) as js.JsElementAppearance,
     );
   }
 
   js.PaymentElementOptions elementOptions() {
-    return const js.PaymentElementOptions(
-      layout: js.PaymentElementLayout.accordion,
-    );
+    return js.PaymentElementOptions(layout: widget.layout);
   }
 
   @override


### PR DESCRIPTION
- Makes a singleton for WebStripe. Accesible by WebStripe.instance
- Allows to change the layout for the payment element. Closes #1260 
- Allows to change the full appearance for the payment element. It is possible to fully customise it by adding any of the values from [the appearance api](https://stripe.com/docs/elements/appearance-api)
- Fixes parsing PaymentMethod to contain dates and last4 digits. Closes #1212
- Fixes parsing Address to not add empty strings if null. Closes #1208
- Adds support for confirmAcssDebitPayment on web  `WebStripe.instance.confirmAcssDebitPayment`. Ref #794 
- Fixes text color not sync with CardStyle on the web card field. Closes #541 
- Adds independent method for `confirmIdealPayment`: `WebStripe.instance.confirmIdealPayment`, that allows to pass a custom returnUrl. Ref #1075
