### PR TITLE
FIX: #1246 handle empty params on confirmPayment

### DIFF
--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
@@ -238,10 +238,13 @@ If you continue to have trouble, follow this discussion to get some support http
 }
 
 private inline fun <reified T> MethodCall.optionalArgument(key: String): T? {
+    val value = argument<T>(key)
+    if (value == JSONObject.NULL)
+        return null
     if (T::class.java == ReadableMap::class.java) {
         return ReadableMap(argument<JSONObject>(key) ?: JSONObject()) as T
     }
-    return argument<T>(key)
+    return value
 }
 
 private inline fun <reified T> MethodCall.requiredArgument(key: String): T {

--- a/packages/stripe_ios/ios/Classes/StripePlugin.swift
+++ b/packages/stripe_ios/ios/Classes/StripePlugin.swift
@@ -378,12 +378,12 @@ extension  StripePlugin {
     
     func confirmPayment(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let arguments = call.arguments as? FlutterMap,
-        let paymentIntentClientSecret = arguments["paymentIntentClientSecret"] as? String,
-        let params = arguments["params"] as? NSDictionary,
-        let options = arguments["options"] as? NSDictionary else {
+              let paymentIntentClientSecret = arguments["paymentIntentClientSecret"] as? String,
+              let options = arguments["options"] as? NSDictionary else {
             result(FlutterError.invalidParams)
             return
         }
+        let params = arguments["params"] as? NSDictionary
         confirmPayment(
             paymentIntentClientSecret: paymentIntentClientSecret,
             params: params,

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -95,7 +95,7 @@ class MethodChannelStripe extends StripePlatform {
     final result = await _methodChannel
         .invokeMapMethod<String, dynamic>('confirmPayment', {
       'paymentIntentClientSecret': paymentIntentClientSecret,
-      'params': params?.toJson() ?? {},
+      'params': params?.toJson(),
       'options': options?.toJson() ?? {},
     });
 


### PR DESCRIPTION
It's been over a month since reporting the #1246 issue, and I'm running out of time to deliver a feature dependant on this fix, so I decided to have a go at trying to fix it myself. The details of why the `confirmPayment` method should handle null this way, are described in my issue description. I have next to none prior experience with Swift or Kotlin, so please double check that my changes don't break any other use cases.