### PR TITLE
Update card_field.mdx

### DIFF
--- a/docs/card_field.mdx
+++ b/docs/card_field.mdx
@@ -109,7 +109,7 @@ await Stripe.instance.confirmPayment(
 );
 ```
 
-### 3b Cardfirn 
+### 3b Cardform 
 
 In case you want to display the card entry fields in multiple lines you can use the `Cardform` widget. 
 


### PR DESCRIPTION
fixed typo from "CardFirn" to "CardForm"