### PR TITLE
Minor change to 'run the example app' in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,16 @@ Future<void> onGooglePayResult(paymentResult) async {
   - [Get your test Stripe API keys](https://stripe.com/docs/keys)
   - `cp lib/.env.example.dart lib/.env.dart` and set your Stripe publishable key.
   - `cp server/.env.example server/.env` and set the variable values in your newly created `.env` file.
-- Install the server dependencies: `npm install` or `yarn --cwd "server"`
+- Install the server dependencies in the `server` directory: 
+  * `cd server`
+  * `npm install` or `yarn --cwd "server"`
 - Start the example
-  - Terminal 1: `npm start` or `yarn --cwd "server" start`
-  - Terminal 2: `flutter run`
+  - Terminal 1: 
+    * Move to the `server` directory: `cd server`
+    * Run npm or yarn: `npm start` or `yarn --cwd "server" start`
+  - Terminal 2: 
+    * Move to the `lib` directory: `cd lib`
+    * Run flutter: `flutter run`
 
 ##### Additional steps for webhook forwarding
 


### PR DESCRIPTION
Super minor change that may save new users (like me) some time. Guides the user to the correct directory for running the start up commands necessary to get the example up and running. 