### PR TITLE
Updating values to the new API

### DIFF
--- a/example/lib/screens/payment_sheet/payment_sheet_screen.dart
+++ b/example/lib/screens/payment_sheet/payment_sheet_screen.dart
@@ -88,11 +88,11 @@ class _PaymentSheetScreenState extends State<PaymentSheetScreen> {
       await Stripe.instance.initPaymentSheet(
         paymentSheetParameters: SetupPaymentSheetParameters(
           // Main params
-          paymentIntentClientSecret: data['paymentIntent'],
+           paymentIntentClientSecret: data['client_secret'],
+
           merchantDisplayName: 'Flutter Stripe Store Demo',
           // Customer params
           customerId: data['customer'],
-          customerEphemeralKeySecret: data['ephemeralKey'],
           // Extra params
           primaryButtonLabel: 'Pay now',
           applePay: PaymentSheetApplePay(


### PR DESCRIPTION
PaymentInet and ephemeralKey are not longer used  and makes the paymentSheet not been initialised .  it has been changed for the new      "client_secret" as per the API reference.