### PR TITLE
fix: convert from array to dictionary

### DIFF
--- a/packages/stripe_ios/ios/Classes/Stripe Sdk/StripeSdk.swift
+++ b/packages/stripe_ios/ios/Classes/Stripe Sdk/StripeSdk.swift
@@ -197,7 +197,7 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
                     paymentSheetViewController = nil
                     switch paymentResult {
                     case .completed:
-                        resolve([])
+                        resolve([:])
                         self.paymentSheet = nil
                     case .canceled:
                         resolve(Errors.createError(ErrorType.Canceled, "The payment has been canceled"))


### PR DESCRIPTION
This fixes https://github.com/flutter-stripe/flutter_stripe/issues/1321 where Flutter would expect a `Map<String,dynamic>?` while iOS was sending an empty array.

This resulted in  `type 'List<dynamic>' is not a subtype of type 'Map<String, dynamic>?'` exception.

 