### PR TITLE
Update Apple Pay docs

### DIFF
--- a/docs/sheet.mdx
+++ b/docs/sheet.mdx
@@ -175,15 +175,31 @@ Add the Apple Pay capability to your app. In Xcode, open your project settings, 
 <img src="https://b.stripecdn.com/docs/assets/xcode.a05220aeae26f8b793b5694692a79117.png" height="36" />
 
 ####  Add Apple Pay
-To add Apple Pay to PaymentSheet, set `applePay: true`  with your Apple merchant ID and the country code of your business.
+To add Apple Pay to PaymentSheet, 
+Make sure to set your Apple merchant ID `Stripe.merchantIdentifier` when you init stripe instance in your `main.dart`
+
+[Check stripe docs](https://support.stripe.com/questions/enable-apple-pay-on-your-stripe-account) for enabling Apple Pay on your Stripe account & create merchantIdentifier
+
+
+```dart
+  Stripe.publishableKey = stripePublishableKey;
+  Stripe.merchantIdentifier = 'merchant.flutter.stripe.test';
+  Stripe.urlScheme = 'flutterstripe';
+  await Stripe.instance.applySettings();
+```
+
+
+then add `applePay: PaymentSheetApplePay()`  with your  and the country code of your business.
  
 ```dart
 Stripe.instance.initPaymentSheet(
   paymentSheetParameters: SetupPaymentSheetParameters(
     merchantDisplayName: 'Flutter Stripe Store Demo',
     //...
-    merchantId: "merchant.com.your_app_name",
-    merchantCountryCode: "US
+    applePay: const PaymentSheetApplePay(
+      buttonType: PlatformButtonType.buy,
+      merchantCountryCode: 'US',
+    ),
   ),
 );
 ```


### PR DESCRIPTION
Previously, the Apple Pay documentation lacked essential configuration details and was outdated.