### PR TITLE
issue #1423

### DIFF
--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/utils/Mappers.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/utils/Mappers.kt
@@ -578,6 +578,7 @@ internal fun mapToShippingDetails(shippingDetails: ReadableMap?): ConfirmPayment
 
   return ConfirmPaymentIntentParams.Shipping(
     name = getValOr(shippingDetails, "name") ?: "",
+    phone = getValOr(shippingDetails, "phone") ?: "",
     address = address
   )
 }

--- a/packages/stripe_ios/ios/Classes/Stripe Sdk/Mappers.swift
+++ b/packages/stripe_ios/ios/Classes/Stripe Sdk/Mappers.swift
@@ -543,7 +543,7 @@ class Mappers {
         }
 
         let shipping = STPPaymentIntentShippingDetailsParams(address: shippingAddress, name: shippingDetails["name"] as? String ?? "")
-
+        shipping.phone = shippingDetails["phone"] as? String ?? ""
         return shipping
     }
 


### PR DESCRIPTION
Adding missing phone field to the mapper so the data will be sent into the payload

For Android and iOS

this fix a problem when using Affirm payment method (and probably some others)