### PR TITLE
Fix: invalid argument `requires_capture` on web

### DIFF
--- a/packages/stripe_js/lib/src/api/payment_intents/payment_intent.g.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/payment_intent.g.dart
@@ -195,6 +195,7 @@ const _$PaymentIntentsStatusEnumMap = {
   PaymentIntentsStatus.requiresPaymentMethod: 'requires_payment_method',
   PaymentIntentsStatus.requiresConfirmation: 'requires_confirmation',
   PaymentIntentsStatus.requiresAction: 'requires_action',
+  PaymentIntentsStatus.requiresCapture: 'requires_capture',
   PaymentIntentsStatus.processing: 'processing',
   PaymentIntentsStatus.succeeded: 'succeeded',
   PaymentIntentsStatus.canceled: 'canceled',

--- a/packages/stripe_js/lib/src/api/payment_intents/payment_intent_status.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/payment_intent_status.dart
@@ -23,6 +23,11 @@ enum PaymentIntentsStatus {
   /// with 3D Secure, the PaymentIntent has a status of requires_action.
   requiresAction,
 
+  /// If you’re separately authorising and capturing funds, your PaymentIntent 
+  /// can instead move to requires_capture. In that case, attempting to capture 
+  /// the funds moves it to processing.
+  requiresCapture,
+
   /// Once required actions are handled, the PaymentIntent moves to processing.
   /// While for some payment methods (for example, cards) processing can be
   /// quick, other types of payment methods can take up to a few days to process.

--- a/packages/stripe_js/test/src/api/payment_intents/payment_intent_test.dart
+++ b/packages/stripe_js/test/src/api/payment_intents/payment_intent_test.dart
@@ -131,7 +131,7 @@ void main() {
       );
     });
 
-    test('parses intent with requires_action status', () {
+    test('parses intent with requires_action status', () {      
       expect(
         PaymentIntent.fromJson(_paymentIntentWithStatusJson('requires_action')), 
         _expectedPaymentIntentWithStatus(PaymentIntentsStatus.requiresAction)

--- a/packages/stripe_js/test/src/api/payment_intents/payment_intent_test.dart
+++ b/packages/stripe_js/test/src/api/payment_intents/payment_intent_test.dart
@@ -138,6 +138,13 @@ void main() {
       );
     });
 
+    test('parses intent with requires_capture status', () {
+      expect(
+        PaymentIntent.fromJson(_paymentIntentWithStatusJson('requires_capture')), 
+        _expectedPaymentIntentWithStatus(PaymentIntentsStatus.requiresCapture)
+      );
+    });
+
     test('parses intent with requires_confirmation status', () {
       expect(
         PaymentIntent.fromJson(_paymentIntentWithStatusJson('requires_confirmation')), 

--- a/packages/stripe_js/test/src/api/payment_intents/payment_intent_test.dart
+++ b/packages/stripe_js/test/src/api/payment_intents/payment_intent_test.dart
@@ -116,5 +116,113 @@ void main() {
         ),
       );
     });
+  
+    test('parses intent with canceled status', () {
+      expect(
+        PaymentIntent.fromJson(_paymentIntentWithStatusJson('canceled')), 
+        _expectedPaymentIntentWithStatus(PaymentIntentsStatus.canceled)
+      );
+    });
+
+    test('parses intent with processing status', () {
+      expect(
+        PaymentIntent.fromJson(_paymentIntentWithStatusJson('processing')), 
+        _expectedPaymentIntentWithStatus(PaymentIntentsStatus.processing)
+      );
+    });
+
+    test('parses intent with requires_action status', () {
+      expect(
+        PaymentIntent.fromJson(_paymentIntentWithStatusJson('requires_action')), 
+        _expectedPaymentIntentWithStatus(PaymentIntentsStatus.requiresAction)
+      );
+    });
+
+    test('parses intent with requires_confirmation status', () {
+      expect(
+        PaymentIntent.fromJson(_paymentIntentWithStatusJson('requires_confirmation')), 
+        _expectedPaymentIntentWithStatus(PaymentIntentsStatus.requiresConfirmation)
+      );
+    });
+
+    test('parses intent with requires_payment_method status', () {
+      expect(
+        PaymentIntent.fromJson(_paymentIntentWithStatusJson('requires_payment_method')), 
+        _expectedPaymentIntentWithStatus(PaymentIntentsStatus.requiresPaymentMethod)
+      );
+    });
+
+    test('parses intent with succeeded status', () {
+      expect(
+        PaymentIntent.fromJson(_paymentIntentWithStatusJson('succeeded')), 
+        _expectedPaymentIntentWithStatus(PaymentIntentsStatus.succeeded)
+      );
+    });
   });
+}
+
+Map<String, dynamic> _paymentIntentWithStatusJson(String status) {
+  return {
+    "id": "pi_1Dsr1T2eZvKYlo2C7KHhBRmV",
+    "object": "payment_intent",
+    "amount": 100,
+    "amount_capturable": 0,
+    "amount_details": {"tip": {}},
+    "amount_received": 0,
+    "application": null,
+    "application_fee_amount": null,
+    "automatic_payment_methods": null,
+    "canceled_at": null,
+    "cancellation_reason": null,
+    "capture_method": "automatic",
+    "client_secret":
+        "pi_1Dsr1T2eZvKYlo2C7KHhBRmV_secret_qH4mhHMXKbJjDgyVuBao7MkBq",
+    "confirmation_method": "automatic",
+    "created": 1547555283,
+    "currency": "usd",
+    "customer": null,
+    "description": null,
+    "invoice": null,
+    "last_payment_error": null,
+    "latest_charge": null,
+    "livemode": false,
+    "metadata": {},
+    "next_action": null,
+    "on_behalf_of": null,
+    "payment_method": null,
+    "payment_method_options": {},
+    "payment_method_types": ["card"],
+    "processing": null,
+    "receipt_email": null,
+    "redaction": null,
+    "review": null,
+    "setup_future_usage": null,
+    "shipping": null,
+    "statement_descriptor": null,
+    "statement_descriptor_suffix": null,
+    "status": status,
+    "transfer_data": null,
+    "transfer_group": null
+  };
+}
+
+PaymentIntent _expectedPaymentIntentWithStatus(PaymentIntentsStatus status) {
+  return PaymentIntent(
+    id: "pi_1Dsr1T2eZvKYlo2C7KHhBRmV",
+    amount: 100,
+    amountCapturable: 0,
+    amountDetails: PaymentIntentAmountDetails(
+      tip: PaymentIntentTip(),
+    ),
+    amountReceived: 0,
+    clientSecret:
+        "pi_1Dsr1T2eZvKYlo2C7KHhBRmV_secret_qH4mhHMXKbJjDgyVuBao7MkBq",
+    currency: "usd",
+    created: 1547555283,
+    livemode: false,
+    paymentMethodTypes: [
+      PaymentMethodType.card,
+    ],
+    status: status
+  );
 }

--- a/packages/stripe_web/lib/src/parser/payment_intent.dart
+++ b/packages/stripe_web/lib/src/parser/payment_intent.dart
@@ -31,25 +31,35 @@ extension PaymentIntentsStatusExtension on PaymentIntentsStatus {
       case 'Succeeded':
       case 'succeeded':
         return PaymentIntentsStatus.Succeeded;
+        
       case 'RequiresPaymentMethod':
       case 'requires_payment_method':
+      case 'requiresPaymentMethod':
         return PaymentIntentsStatus.RequiresPaymentMethod;
+
       case 'RequiresConfirmation':
       case 'requires_confirmation':
+      case 'requiresConfirmation':
         return PaymentIntentsStatus.RequiresConfirmation;
 
       case 'Canceled':
       case 'canceled':
         return PaymentIntentsStatus.Canceled;
+
       case 'Processing':
       case 'processing':
         return PaymentIntentsStatus.Processing;
+
       case 'RequiresAction':
       case 'requires_action':
+      case 'requiresAction':
         return PaymentIntentsStatus.RequiresAction;
+
       case 'RequiresCapture':
       case 'requires_capture':
+      case 'requiresCapture':
         return PaymentIntentsStatus.RequiresCapture;
+        
       case 'Unknown':
         return PaymentIntentsStatus.Unknown;
     }

--- a/packages/stripe_web/test/parser/payment_intent_test.dart
+++ b/packages/stripe_web/test/parser/payment_intent_test.dart
@@ -1,0 +1,112 @@
+
+import 'package:flutter_stripe_web/src/parser/payment_intent.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stripe_js/stripe_api.dart' as js;
+import 'package:stripe_platform_interface/stripe_platform_interface.dart';
+
+void main() {
+  group('PaymentIntentsStatusExtension', () {
+    test('parses canceled status', () {
+      expect(
+        _parsedPaymentIntentStatus('canceled'),
+        PaymentIntentsStatus.Canceled
+      );
+    });
+
+    test('parses processing status', () {
+      expect(
+        _parsedPaymentIntentStatus('processing'),
+        PaymentIntentsStatus.Processing
+      );
+    });
+
+    test('parses requires_action status', () {
+      expect(
+        _parsedPaymentIntentStatus('requires_action'),
+        PaymentIntentsStatus.RequiresAction
+      );
+    });
+
+    test('parses requires_capture status', () {
+      expect(
+        _parsedPaymentIntentStatus('requires_capture'),
+        PaymentIntentsStatus.RequiresCapture
+      );
+    });
+
+    test('parses requires_payment_method status', () {
+      expect(
+        _parsedPaymentIntentStatus('requires_payment_method'),
+        PaymentIntentsStatus.RequiresPaymentMethod
+      );
+    });
+
+    test('parses requires_confirmation status', () {
+      expect(
+        _parsedPaymentIntentStatus('requires_confirmation'),
+        PaymentIntentsStatus.RequiresConfirmation
+      );
+    });
+
+    test('parses succeeded status', () {
+      expect(
+        _parsedPaymentIntentStatus('succeeded'),
+        PaymentIntentsStatus.Succeeded
+      );
+    });
+  });
+}
+
+PaymentIntentsStatus _parsedPaymentIntentStatus(String status) {
+  final intent = _paymentIntentWithParsedStatus(status);
+  return PaymentIntentsStatusExtension.parse(intent.status.name);
+}
+
+js.PaymentIntent _paymentIntentWithParsedStatus(String status) {
+  return js.PaymentIntent.fromJson(_paymentIntentWithStatusJson(status));
+}
+
+Map<String, dynamic> _paymentIntentWithStatusJson(String status) {
+  return {
+    "id": "pi_1Dsr1T2eZvKYlo2C7KHhBRmV",
+    "object": "payment_intent",
+    "amount": 100,
+    "amount_capturable": 0,
+    "amount_details": {"tip": {}},
+    "amount_received": 0,
+    "application": null,
+    "application_fee_amount": null,
+    "automatic_payment_methods": null,
+    "canceled_at": null,
+    "cancellation_reason": null,
+    "capture_method": "automatic",
+    "client_secret":
+        "pi_1Dsr1T2eZvKYlo2C7KHhBRmV_secret_qH4mhHMXKbJjDgyVuBao7MkBq",
+    "confirmation_method": "automatic",
+    "created": 1547555283,
+    "currency": "usd",
+    "customer": null,
+    "description": null,
+    "invoice": null,
+    "last_payment_error": null,
+    "latest_charge": null,
+    "livemode": false,
+    "metadata": {},
+    "next_action": null,
+    "on_behalf_of": null,
+    "payment_method": null,
+    "payment_method_options": {},
+    "payment_method_types": ["card"],
+    "processing": null,
+    "receipt_email": null,
+    "redaction": null,
+    "review": null,
+    "setup_future_usage": null,
+    "shipping": null,
+    "statement_descriptor": null,
+    "statement_descriptor_suffix": null,
+    "status": status,
+    "transfer_data": null,
+    "transfer_group": null
+  };
+}


### PR DESCRIPTION
Added missing `requiresCapture` from `PaymentIntentsStatus`.

In the [docs](https://stripe.com/docs/payments/paymentintents/lifecycle#intent-statuses), it pretty easy to miss `requries_capture`. 

<img width="500" alt="Screenshot 2023-09-26 at 06 48 59" src="https://github.com/flutter-stripe/flutter_stripe/assets/23617988/4148961c-2ff2-4890-a867-0d46b1fac02a">

Also, other comments that reference the `PaymentIntentsStatus` mention there being a `requiresCapture` type, so it looks like this one was just missed.

https://github.com/flutter-stripe/flutter_stripe/blob/1a56658e71748688dde1c4fcb1e9f3126a9e14d7/packages/stripe_js/lib/src/api/payment_intents/payment_intent.dart#L258

---

I realised after that this PR was also in-review:

https://github.com/wt-health/flutter_stripe/pull/1

which implements the same fix. I've included some extra tests, so I thought I'd submit this one anyway.