### PR TITLE
fix: collectBankAccount returns PlatformException(Invalid Params)

### DIFF
--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -538,9 +538,7 @@ class Stripe {
   ///
   /// Only US bank accounts are supported. This method is only implemented for
   /// iOS at the moment.
-  Future<PaymentIntent> collectBankAccount({
-    /// Whether the clientsecret is associated with setup or paymentintent
-    required bool isPaymentIntent,
+  Future<PaymentIntent> collectBankAccountPayment({
 
     /// The clientSecret of the payment and setup intent
     required String clientSecret,
@@ -550,8 +548,27 @@ class Stripe {
     /// The name and email is required.
     required CollectBankAccountParams params,
   }) async {
-    return await _platform.collectBankAccount(
-      isPaymentIntent: isPaymentIntent,
+    return await _platform.collectBankAccountPayment(
+      clientSecret: clientSecret,
+      params: params,
+    );
+  }
+
+  /// Collect the bankaccount details for the setup intent.
+  ///
+  /// Only US bank accounts are supported. This method is only implemented for
+  /// iOS at the moment.
+  Future<SetupIntent> collectBankAccountSetup({
+
+    /// The clientSecret of the payment and setup intent
+    required String clientSecret,
+
+    /// Parameters associated with the account holder.
+    ///
+    /// The name and email is required.
+    required CollectBankAccountParams params,
+  }) async {
+    return await _platform.collectBankAccountSetup(
       clientSecret: clientSecret,
       params: params,
     );

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
@@ -151,7 +151,7 @@ If you continue to have trouble, follow this discussion to get some support http
                 result.success(null)
             }
             "collectBankAccount" -> stripeSdk.collectBankAccount(
-                isPaymentIntent = call.requiredArgument("isPaymentIntent"),
+                isPaymentIntent = call.requiredArgument("intentType"),
                 clientSecret = call.requiredArgument("clientSecret"),
                 params = call.requiredArgument("params"),
                 promise = Promise(result)

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -482,7 +482,7 @@ class MethodChannelStripe extends StripePlatform {
   }) async {
     final result = await _methodChannel
         .invokeMapMethod<String, dynamic>('collectBankAccount', {
-      'isPaymentIntent': isPaymentIntent,
+      'intentType': isPaymentIntent,
       'params': params.toJson(),
       'clientSecret': clientSecret,
     });

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -475,14 +475,13 @@ class MethodChannelStripe extends StripePlatform {
   }
 
   @override
-  Future<PaymentIntent> collectBankAccount({
-    required bool isPaymentIntent,
+  Future<PaymentIntent> collectBankAccountPayment({
     required String clientSecret,
     required CollectBankAccountParams params,
   }) async {
     final result = await _methodChannel
         .invokeMapMethod<String, dynamic>('collectBankAccount', {
-      'intentType': isPaymentIntent,
+      'intentType': true,
       'params': params.toJson(),
       'clientSecret': clientSecret,
     });
@@ -490,6 +489,23 @@ class MethodChannelStripe extends StripePlatform {
     return ResultParser<PaymentIntent>(
             parseJson: (json) => PaymentIntent.fromJson(json))
         .parse(result: result!, successResultKey: 'paymentIntent');
+  }
+
+  @override
+  Future<SetupIntent> collectBankAccountSetup({
+    required String clientSecret,
+    required CollectBankAccountParams params,
+  }) async {
+    final result = await _methodChannel
+        .invokeMapMethod<String, dynamic>('collectBankAccount', {
+      'intentType': false,
+      'params': params.toJson(),
+      'clientSecret': clientSecret,
+    });
+
+    return ResultParser<SetupIntent>(
+            parseJson: (json) => SetupIntent.fromJson(json))
+        .parse(result: result!, successResultKey: 'setupIntent');
   }
 
   @override

--- a/packages/stripe_platform_interface/lib/src/models/ach_params.dart
+++ b/packages/stripe_platform_interface/lib/src/models/ach_params.dart
@@ -11,10 +11,10 @@ part 'ach_params.g.dart';
 class CollectBankAccountParams with _$CollectBankAccountParams {
   @JsonSerializable(explicitToJson: true)
   const factory CollectBankAccountParams({
-    /// Billingdetails of the account holder
+    /// Generic payment method data object that holds the billingdetails.
     ///
     /// It is required to fill in the name in the billing details
-    required BillingDetails billingDetails,
+    required PaymentMethodData paymentMethodData,
 
     /// The paymentmethod type. At this point only method [PaymentMethodType.USBankAccount]
     /// is supported.

--- a/packages/stripe_platform_interface/lib/src/models/ach_params.freezed.dart
+++ b/packages/stripe_platform_interface/lib/src/models/ach_params.freezed.dart
@@ -21,10 +21,10 @@ CollectBankAccountParams _$CollectBankAccountParamsFromJson(
 
 /// @nodoc
 mixin _$CollectBankAccountParams {
-  /// Billingdetails of the account holder
+  /// Generic payment method data object that holds the billingdetails.
   ///
   /// It is required to fill in the name in the billing details
-  BillingDetails get billingDetails => throw _privateConstructorUsedError;
+  PaymentMethodData get paymentMethodData => throw _privateConstructorUsedError;
 
   /// The paymentmethod type. At this point only method [PaymentMethodType.USBankAccount]
   /// is supported.
@@ -43,9 +43,10 @@ abstract class $CollectBankAccountParamsCopyWith<$Res> {
       _$CollectBankAccountParamsCopyWithImpl<$Res, CollectBankAccountParams>;
   @useResult
   $Res call(
-      {BillingDetails billingDetails, PaymentMethodType paymentMethodType});
+      {PaymentMethodData paymentMethodData,
+      PaymentMethodType paymentMethodType});
 
-  $BillingDetailsCopyWith<$Res> get billingDetails;
+  $PaymentMethodDataCopyWith<$Res> get paymentMethodData;
 }
 
 /// @nodoc
@@ -62,14 +63,14 @@ class _$CollectBankAccountParamsCopyWithImpl<$Res,
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? billingDetails = null,
+    Object? paymentMethodData = null,
     Object? paymentMethodType = null,
   }) {
     return _then(_value.copyWith(
-      billingDetails: null == billingDetails
-          ? _value.billingDetails
-          : billingDetails // ignore: cast_nullable_to_non_nullable
-              as BillingDetails,
+      paymentMethodData: null == paymentMethodData
+          ? _value.paymentMethodData
+          : paymentMethodData // ignore: cast_nullable_to_non_nullable
+              as PaymentMethodData,
       paymentMethodType: null == paymentMethodType
           ? _value.paymentMethodType
           : paymentMethodType // ignore: cast_nullable_to_non_nullable
@@ -79,49 +80,51 @@ class _$CollectBankAccountParamsCopyWithImpl<$Res,
 
   @override
   @pragma('vm:prefer-inline')
-  $BillingDetailsCopyWith<$Res> get billingDetails {
-    return $BillingDetailsCopyWith<$Res>(_value.billingDetails, (value) {
-      return _then(_value.copyWith(billingDetails: value) as $Val);
+  $PaymentMethodDataCopyWith<$Res> get paymentMethodData {
+    return $PaymentMethodDataCopyWith<$Res>(_value.paymentMethodData, (value) {
+      return _then(_value.copyWith(paymentMethodData: value) as $Val);
     });
   }
 }
 
 /// @nodoc
-abstract class _$$_CollectBankAccountParamsCopyWith<$Res>
+abstract class _$$CollectBankAccountParamsImplCopyWith<$Res>
     implements $CollectBankAccountParamsCopyWith<$Res> {
-  factory _$$_CollectBankAccountParamsCopyWith(
-          _$_CollectBankAccountParams value,
-          $Res Function(_$_CollectBankAccountParams) then) =
-      __$$_CollectBankAccountParamsCopyWithImpl<$Res>;
+  factory _$$CollectBankAccountParamsImplCopyWith(
+          _$CollectBankAccountParamsImpl value,
+          $Res Function(_$CollectBankAccountParamsImpl) then) =
+      __$$CollectBankAccountParamsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
-      {BillingDetails billingDetails, PaymentMethodType paymentMethodType});
+      {PaymentMethodData paymentMethodData,
+      PaymentMethodType paymentMethodType});
 
   @override
-  $BillingDetailsCopyWith<$Res> get billingDetails;
+  $PaymentMethodDataCopyWith<$Res> get paymentMethodData;
 }
 
 /// @nodoc
-class __$$_CollectBankAccountParamsCopyWithImpl<$Res>
+class __$$CollectBankAccountParamsImplCopyWithImpl<$Res>
     extends _$CollectBankAccountParamsCopyWithImpl<$Res,
-        _$_CollectBankAccountParams>
-    implements _$$_CollectBankAccountParamsCopyWith<$Res> {
-  __$$_CollectBankAccountParamsCopyWithImpl(_$_CollectBankAccountParams _value,
-      $Res Function(_$_CollectBankAccountParams) _then)
+        _$CollectBankAccountParamsImpl>
+    implements _$$CollectBankAccountParamsImplCopyWith<$Res> {
+  __$$CollectBankAccountParamsImplCopyWithImpl(
+      _$CollectBankAccountParamsImpl _value,
+      $Res Function(_$CollectBankAccountParamsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? billingDetails = null,
+    Object? paymentMethodData = null,
     Object? paymentMethodType = null,
   }) {
-    return _then(_$_CollectBankAccountParams(
-      billingDetails: null == billingDetails
-          ? _value.billingDetails
-          : billingDetails // ignore: cast_nullable_to_non_nullable
-              as BillingDetails,
+    return _then(_$CollectBankAccountParamsImpl(
+      paymentMethodData: null == paymentMethodData
+          ? _value.paymentMethodData
+          : paymentMethodData // ignore: cast_nullable_to_non_nullable
+              as PaymentMethodData,
       paymentMethodType: null == paymentMethodType
           ? _value.paymentMethodType
           : paymentMethodType // ignore: cast_nullable_to_non_nullable
@@ -133,19 +136,19 @@ class __$$_CollectBankAccountParamsCopyWithImpl<$Res>
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true)
-class _$_CollectBankAccountParams implements _CollectBankAccountParams {
-  const _$_CollectBankAccountParams(
-      {required this.billingDetails,
+class _$CollectBankAccountParamsImpl implements _CollectBankAccountParams {
+  const _$CollectBankAccountParamsImpl(
+      {required this.paymentMethodData,
       this.paymentMethodType = PaymentMethodType.USBankAccount});
 
-  factory _$_CollectBankAccountParams.fromJson(Map<String, dynamic> json) =>
-      _$$_CollectBankAccountParamsFromJson(json);
+  factory _$CollectBankAccountParamsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CollectBankAccountParamsImplFromJson(json);
 
-  /// Billingdetails of the account holder
+  /// Generic payment method data object that holds the billingdetails.
   ///
   /// It is required to fill in the name in the billing details
   @override
-  final BillingDetails billingDetails;
+  final PaymentMethodData paymentMethodData;
 
   /// The paymentmethod type. At this point only method [PaymentMethodType.USBankAccount]
   /// is supported.
@@ -155,16 +158,16 @@ class _$_CollectBankAccountParams implements _CollectBankAccountParams {
 
   @override
   String toString() {
-    return 'CollectBankAccountParams(billingDetails: $billingDetails, paymentMethodType: $paymentMethodType)';
+    return 'CollectBankAccountParams(paymentMethodData: $paymentMethodData, paymentMethodType: $paymentMethodType)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CollectBankAccountParams &&
-            (identical(other.billingDetails, billingDetails) ||
-                other.billingDetails == billingDetails) &&
+            other is _$CollectBankAccountParamsImpl &&
+            (identical(other.paymentMethodData, paymentMethodData) ||
+                other.paymentMethodData == paymentMethodData) &&
             (identical(other.paymentMethodType, paymentMethodType) ||
                 other.paymentMethodType == paymentMethodType));
   }
@@ -172,18 +175,18 @@ class _$_CollectBankAccountParams implements _CollectBankAccountParams {
   @JsonKey(ignore: true)
   @override
   int get hashCode =>
-      Object.hash(runtimeType, billingDetails, paymentMethodType);
+      Object.hash(runtimeType, paymentMethodData, paymentMethodType);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CollectBankAccountParamsCopyWith<_$_CollectBankAccountParams>
-      get copyWith => __$$_CollectBankAccountParamsCopyWithImpl<
-          _$_CollectBankAccountParams>(this, _$identity);
+  _$$CollectBankAccountParamsImplCopyWith<_$CollectBankAccountParamsImpl>
+      get copyWith => __$$CollectBankAccountParamsImplCopyWithImpl<
+          _$CollectBankAccountParamsImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CollectBankAccountParamsToJson(
+    return _$$CollectBankAccountParamsImplToJson(
       this,
     );
   }
@@ -191,18 +194,19 @@ class _$_CollectBankAccountParams implements _CollectBankAccountParams {
 
 abstract class _CollectBankAccountParams implements CollectBankAccountParams {
   const factory _CollectBankAccountParams(
-      {required final BillingDetails billingDetails,
-      final PaymentMethodType paymentMethodType}) = _$_CollectBankAccountParams;
+          {required final PaymentMethodData paymentMethodData,
+          final PaymentMethodType paymentMethodType}) =
+      _$CollectBankAccountParamsImpl;
 
   factory _CollectBankAccountParams.fromJson(Map<String, dynamic> json) =
-      _$_CollectBankAccountParams.fromJson;
+      _$CollectBankAccountParamsImpl.fromJson;
 
   @override
 
-  /// Billingdetails of the account holder
+  /// Generic payment method data object that holds the billingdetails.
   ///
   /// It is required to fill in the name in the billing details
-  BillingDetails get billingDetails;
+  PaymentMethodData get paymentMethodData;
   @override
 
   /// The paymentmethod type. At this point only method [PaymentMethodType.USBankAccount]
@@ -210,7 +214,7 @@ abstract class _CollectBankAccountParams implements CollectBankAccountParams {
   PaymentMethodType get paymentMethodType;
   @override
   @JsonKey(ignore: true)
-  _$$_CollectBankAccountParamsCopyWith<_$_CollectBankAccountParams>
+  _$$CollectBankAccountParamsImplCopyWith<_$CollectBankAccountParamsImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -278,25 +282,25 @@ class _$VerifyMicroDepositsParamsCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_VerifyMicroDepositsParamsCopyWith<$Res>
+abstract class _$$VerifyMicroDepositsParamsImplCopyWith<$Res>
     implements $VerifyMicroDepositsParamsCopyWith<$Res> {
-  factory _$$_VerifyMicroDepositsParamsCopyWith(
-          _$_VerifyMicroDepositsParams value,
-          $Res Function(_$_VerifyMicroDepositsParams) then) =
-      __$$_VerifyMicroDepositsParamsCopyWithImpl<$Res>;
+  factory _$$VerifyMicroDepositsParamsImplCopyWith(
+          _$VerifyMicroDepositsParamsImpl value,
+          $Res Function(_$VerifyMicroDepositsParamsImpl) then) =
+      __$$VerifyMicroDepositsParamsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<int>? amounts, String? descriptorCode});
 }
 
 /// @nodoc
-class __$$_VerifyMicroDepositsParamsCopyWithImpl<$Res>
+class __$$VerifyMicroDepositsParamsImplCopyWithImpl<$Res>
     extends _$VerifyMicroDepositsParamsCopyWithImpl<$Res,
-        _$_VerifyMicroDepositsParams>
-    implements _$$_VerifyMicroDepositsParamsCopyWith<$Res> {
-  __$$_VerifyMicroDepositsParamsCopyWithImpl(
-      _$_VerifyMicroDepositsParams _value,
-      $Res Function(_$_VerifyMicroDepositsParams) _then)
+        _$VerifyMicroDepositsParamsImpl>
+    implements _$$VerifyMicroDepositsParamsImplCopyWith<$Res> {
+  __$$VerifyMicroDepositsParamsImplCopyWithImpl(
+      _$VerifyMicroDepositsParamsImpl _value,
+      $Res Function(_$VerifyMicroDepositsParamsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -305,7 +309,7 @@ class __$$_VerifyMicroDepositsParamsCopyWithImpl<$Res>
     Object? amounts = freezed,
     Object? descriptorCode = freezed,
   }) {
-    return _then(_$_VerifyMicroDepositsParams(
+    return _then(_$VerifyMicroDepositsParamsImpl(
       amounts: freezed == amounts
           ? _value._amounts
           : amounts // ignore: cast_nullable_to_non_nullable
@@ -321,13 +325,13 @@ class __$$_VerifyMicroDepositsParamsCopyWithImpl<$Res>
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true)
-class _$_VerifyMicroDepositsParams implements _VerifyMicroDepositsParams {
-  const _$_VerifyMicroDepositsParams(
+class _$VerifyMicroDepositsParamsImpl implements _VerifyMicroDepositsParams {
+  const _$VerifyMicroDepositsParamsImpl(
       {final List<int>? amounts, this.descriptorCode})
       : _amounts = amounts;
 
-  factory _$_VerifyMicroDepositsParams.fromJson(Map<String, dynamic> json) =>
-      _$$_VerifyMicroDepositsParamsFromJson(json);
+  factory _$VerifyMicroDepositsParamsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$VerifyMicroDepositsParamsImplFromJson(json);
 
   /// The amounts of the microdeposits that are deposited on the account.
   ///
@@ -363,7 +367,7 @@ class _$_VerifyMicroDepositsParams implements _VerifyMicroDepositsParams {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_VerifyMicroDepositsParams &&
+            other is _$VerifyMicroDepositsParamsImpl &&
             const DeepCollectionEquality().equals(other._amounts, _amounts) &&
             (identical(other.descriptorCode, descriptorCode) ||
                 other.descriptorCode == descriptorCode));
@@ -377,13 +381,13 @@ class _$_VerifyMicroDepositsParams implements _VerifyMicroDepositsParams {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_VerifyMicroDepositsParamsCopyWith<_$_VerifyMicroDepositsParams>
-      get copyWith => __$$_VerifyMicroDepositsParamsCopyWithImpl<
-          _$_VerifyMicroDepositsParams>(this, _$identity);
+  _$$VerifyMicroDepositsParamsImplCopyWith<_$VerifyMicroDepositsParamsImpl>
+      get copyWith => __$$VerifyMicroDepositsParamsImplCopyWithImpl<
+          _$VerifyMicroDepositsParamsImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_VerifyMicroDepositsParamsToJson(
+    return _$$VerifyMicroDepositsParamsImplToJson(
       this,
     );
   }
@@ -392,10 +396,10 @@ class _$_VerifyMicroDepositsParams implements _VerifyMicroDepositsParams {
 abstract class _VerifyMicroDepositsParams implements VerifyMicroDepositsParams {
   const factory _VerifyMicroDepositsParams(
       {final List<int>? amounts,
-      final String? descriptorCode}) = _$_VerifyMicroDepositsParams;
+      final String? descriptorCode}) = _$VerifyMicroDepositsParamsImpl;
 
   factory _VerifyMicroDepositsParams.fromJson(Map<String, dynamic> json) =
-      _$_VerifyMicroDepositsParams.fromJson;
+      _$VerifyMicroDepositsParamsImpl.fromJson;
 
   @override
 
@@ -412,6 +416,6 @@ abstract class _VerifyMicroDepositsParams implements VerifyMicroDepositsParams {
   String? get descriptorCode;
   @override
   @JsonKey(ignore: true)
-  _$$_VerifyMicroDepositsParamsCopyWith<_$_VerifyMicroDepositsParams>
+  _$$VerifyMicroDepositsParamsImplCopyWith<_$VerifyMicroDepositsParamsImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/stripe_platform_interface/lib/src/models/ach_params.g.dart
+++ b/packages/stripe_platform_interface/lib/src/models/ach_params.g.dart
@@ -6,20 +6,20 @@ part of 'ach_params.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CollectBankAccountParams _$$_CollectBankAccountParamsFromJson(
+_$CollectBankAccountParamsImpl _$$CollectBankAccountParamsImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CollectBankAccountParams(
-      billingDetails: BillingDetails.fromJson(
-          json['billingDetails'] as Map<String, dynamic>),
+    _$CollectBankAccountParamsImpl(
+      paymentMethodData: PaymentMethodData.fromJson(
+          json['paymentMethodData'] as Map<String, dynamic>),
       paymentMethodType: $enumDecodeNullable(
               _$PaymentMethodTypeEnumMap, json['paymentMethodType']) ??
           PaymentMethodType.USBankAccount,
     );
 
-Map<String, dynamic> _$$_CollectBankAccountParamsToJson(
-        _$_CollectBankAccountParams instance) =>
+Map<String, dynamic> _$$CollectBankAccountParamsImplToJson(
+        _$CollectBankAccountParamsImpl instance) =>
     <String, dynamic>{
-      'billingDetails': instance.billingDetails.toJson(),
+      'paymentMethodData': instance.paymentMethodData.toJson(),
       'paymentMethodType':
           _$PaymentMethodTypeEnumMap[instance.paymentMethodType]!,
     };
@@ -48,16 +48,16 @@ const _$PaymentMethodTypeEnumMap = {
   PaymentMethodType.Unknown: 'Unknown',
 };
 
-_$_VerifyMicroDepositsParams _$$_VerifyMicroDepositsParamsFromJson(
+_$VerifyMicroDepositsParamsImpl _$$VerifyMicroDepositsParamsImplFromJson(
         Map<String, dynamic> json) =>
-    _$_VerifyMicroDepositsParams(
+    _$VerifyMicroDepositsParamsImpl(
       amounts:
           (json['amounts'] as List<dynamic>?)?.map((e) => e as int).toList(),
       descriptorCode: json['descriptorCode'] as String?,
     );
 
-Map<String, dynamic> _$$_VerifyMicroDepositsParamsToJson(
-        _$_VerifyMicroDepositsParams instance) =>
+Map<String, dynamic> _$$VerifyMicroDepositsParamsImplToJson(
+        _$VerifyMicroDepositsParamsImpl instance) =>
     <String, dynamic>{
       'amounts': instance.amounts,
       'descriptorCode': instance.descriptorCode,

--- a/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
@@ -139,8 +139,12 @@ abstract class StripePlatform extends PlatformInterface {
   Future<String> createTokenForCVCUpdate(String cvc);
 
   /// Methods related to ACH payments
-  Future<PaymentIntent> collectBankAccount({
-    required bool isPaymentIntent,
+  Future<PaymentIntent> collectBankAccountPayment({
+    required String clientSecret,
+    required CollectBankAccountParams params,
+  });
+
+  Future<SetupIntent> collectBankAccountSetup({
     required String clientSecret,
     required CollectBankAccountParams params,
   });


### PR DESCRIPTION
closes: #1467 

Refactor `collectBankAccount` to resolve the issue.

Changed `isPaymentIntent` to `intentType` and `BillingDetails` to `PaymentMethodData`.

The methodChannel invokes `collectBankAccount` which shows the Stripe sheet, but due to above issues the problems was occuring which is reported in #1467 .

The generated code is created using `flutter pub run build_runner build --delete-conflicting-outputs`, note that the new generated files now has a different way of creating classes. 

