### PR TITLE
fix: [WEB]Issue of saving/not saving payment information for future. …

### DIFF
--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -119,9 +119,7 @@ class WebStripe extends StripePlatform {
           paymentIntentClientSecret,
           data: stripe_js.ConfirmCardPaymentData(
             paymentMethod: stripe_js.CardPaymentMethodDetails(card: element!),
-            setupFutureUsage: (options?.setupFutureUsage ??
-                    PaymentIntentsFutureUsage.OnSession)
-                .toJs(),
+            setupFutureUsage: options?.setupFutureUsage?.toJs(),
           ),
         );
       },


### PR DESCRIPTION
…#1673

According to the documentation, `setup_future_usage` can be set to `OnSession`, `OffSession`, and `Null`. However, the current code only corresponds to `OnSession` and `OffSession`.


Document:
https://docs.stripe.com/api/payment_intents/confirm#confirm_payment_intent-setup_future_usage