### PR TITLE
Fix: Apply dynamic Stripe account ID to confirmPayment method in WebS…

### DIFF
--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -55,13 +55,21 @@ class WebStripe extends StripePlatform {
     bool? setReturnUrlSchemeOnAndroid,
   }) async {
     this._urlScheme = urlScheme;
+
     if (__stripe != null) {
-      __stripe!.stripeAccount = stripeAccountId;
+      // Check if the new stripeAccountId is different
+      if (__stripe!.stripeAccount != stripeAccountId) {
+        // Re-initialize with new stripeAccountId
+        await stripe_js.loadStripe();
+        var stripeOption = stripe_js.StripeOptions();
+        stripeOption.stripeAccount = stripeAccountId;
+        __stripe = stripe_js.Stripe(publishableKey, stripeOption);
+      }
       return;
     }
 
     await stripe_js.loadStripe();
-    final stripeOption = stripe_js.StripeOptions();
+    var stripeOption = stripe_js.StripeOptions();
     if (stripeAccountId != null) {
       stripeOption.stripeAccount = stripeAccountId;
     }


### PR DESCRIPTION
…tripe

Fixes a bug where updating the Stripe account ID using await Stripe.instance.applySettings(); did not apply to the confirmPayment() method on web platforms.

Bug Description:
- Using await Stripe.instance.applySettings(); to update an account ID shows the updated account ID when printed but does not apply to the confirmPayment() method.
- This issue occurs when attempting to update Stripe.stripeAccountId within the app, such as on the payment page.

Steps to Reproduce:
1. Initialize a Stripe instance within main.dart, setting the Stripe publisher key (no account ID set).
2. Have a page within the app that initializes Stripe and adds the Stripe connect ID: ```dart Stripe.stripeAccountId = id; await Stripe.instance.applySettings();