### PR TITLE
Fixes Issue #1834

### DIFF
--- a/packages/stripe_ios/ios/Classes/Stripe Sdk/StripeSdk+PaymentSheet.swift
+++ b/packages/stripe_ios/ios/Classes/Stripe Sdk/StripeSdk+PaymentSheet.swift
@@ -224,9 +224,11 @@ extension StripeSdk {
             mode = PaymentSheet.IntentConfiguration.Mode.payment(
                 amount: amount,
                 currency: modeParams["currencyCode"] as? String ?? "",
-                setupFutureUsage: modeParams["setupFutureUsage"] != nil
-                    ? (modeParams["setupFutureUsage"] as? String == "OffSession" ? .offSession : .onSession)
-                    : nil,
+                setupFutureUsage: { return switch modeParams["setupFutureUsage"] as? String {
+                                                      case "OffSession":  .offSession
+                                                      case "OnSession":  .onSession
+                                                      default:  nil
+                                                  } }(),
             captureMethod: captureMethod
             )
         } else {


### PR DESCRIPTION
If the value for setupFutureUsage from json map is not null, it was incorrectly serialized as "onSession" when invoking iOS platform code. after further investigations, I found that this happens because a null value in dart, comes in platform sida as a "Optional<null>". 
I only have a doubt about this PR: It is ok as is, or it would be better to add "includeIfNull:" false to "@JsonSerializable" directives in stripe_platform_interface library?
In doubt I proposed this solution, that doesn't change anyting in platforms other than iOS. 