### PR TITLE
Fix a couple issues that arose in platform pay on web after the package:web upgrade

### DIFF
--- a/packages/stripe_js/lib/src/js/payment_requests/payment_request.dart
+++ b/packages/stripe_js/lib/src/js/payment_requests/payment_request.dart
@@ -62,7 +62,7 @@ extension type JsPaymentResponse._(JSObject o) {
   @JS('complete')
   external JSFunction get _complete;
   void Function(String) get complete {
-    return (String val) => _complete.callAsFunction(val.toJS);
+    return _complete.dartify() as void Function(String);
   }
 }
 

--- a/packages/stripe_web/lib/src/widgets/platform_pay_button.dart
+++ b/packages/stripe_web/lib/src/widgets/platform_pay_button.dart
@@ -1,13 +1,11 @@
 import 'dart:js_interop';
-
-import 'package:web/web.dart' as web;
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_stripe_web/flutter_stripe_web.dart';
 import 'package:flutter_stripe_web/src/parser/payment_request.dart';
-
 import 'package:stripe_js/stripe_js.dart';
+import 'package:web/web.dart' as web;
 
 const kPlatformPayButtonDefaultHeight = 40.0;
 
@@ -76,7 +74,7 @@ class _WebPlatformPayButtonState extends State<WebPlatformPayButton> {
                   height: '${constraints.maxHeight}px',
                 ))))
           ..on('click', (event) {
-            //callMethod(event, 'preventDefault', []);
+            event.toDart['preventDefault']();
             widget.onPressed();
           })
           ..mount('#platform-pay-button'.toJS);


### PR DESCRIPTION
* Not calling preventDefault on PlatformPayButton means users will end up with duplicate platform pay requests
* Calling 'complete' on pay request wasn't working