### PR TITLE
Fix attempt to present view not in hierarchy

### DIFF
--- a/packages/stripe_ios/ios/Classes/Stripe Sdk/StripeSdk.swift
+++ b/packages/stripe_ios/ios/Classes/Stripe Sdk/StripeSdk.swift
@@ -197,7 +197,9 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
             }
         }
         DispatchQueue.main.async {
-            paymentSheetViewController = UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController()
+            paymentSheetViewController = UIApplication.shared.delegate?.window??.rootViewController ?? UIApplication.shared.windows.first(where: {
+                $0.isKeyWindow
+            })?.rootViewController ?? UIViewController()
             if let paymentSheetFlowController = self.paymentSheetFlowController {
                 paymentSheetFlowController.presentPaymentOptions(from: findViewControllerPresenter(from: paymentSheetViewController!)
                 ) {

--- a/packages/stripe_ios/pubspec.yaml
+++ b/packages/stripe_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stripe_ios
 description: Stripe platform implementation for iOS
-version: 11.0.0
+version: 11.0.1
 repository: https://github.com/flutter-stripe/flutter_stripe
 homepage: https://pub.dev/packages/flutter_stripe
 


### PR DESCRIPTION
In a situation when `rootViewController` is not set by the application,
the main view controller is not found, resulting in error:

```
Attempt to present <STP_Internal_BottomSheetViewController> on <UIViewController> (from <UIViewController>) whose view is not in the window hierarchy.
````

which then prevents the Stripe bottom sheet from showing. Blocking the
payment flow.

To prevent this, a fallback is added to traverse the windows hierarchy
and find the first one that has `isKeyWindow` set to `true`.

Co-authored-by: Bruno Pastre <bruno.pastre@onefootball.com>