### PR TITLE
Added bug fix for automaticAsync parsing

### DIFF
--- a/packages/stripe_web/lib/src/parser/payment_intent.dart
+++ b/packages/stripe_web/lib/src/parser/payment_intent.dart
@@ -76,6 +76,7 @@ extension CaptureMethodExtension on CaptureMethod {
         return CaptureMethod.Automatic;
       case 'AutomaticAsync':
       case 'automatic_async':
+      case 'automaticAsync':
         return CaptureMethod.AutomaticAsync;
       case 'Manual':
       case 'manual':


### PR DESCRIPTION
In flutter_stripe_web, PaymentIntentExtension, parsing happens in the following code:
captureMethod: CaptureMethodExtension.parse(captureMethod.name),

and captureMethod name for automatic_async is automaticAsync, adding this in order properly parse the value.