### PR TITLE
remove html import

### DIFF
--- a/example/lib/screens/payment_sheet/payment_element/platforms/stripe_checkout_web.dart
+++ b/example/lib/screens/payment_sheet/payment_element/platforms/stripe_checkout_web.dart
@@ -1,4 +1,4 @@
-import 'dart:html' as html;
+import 'package:web/web.dart' as html;
 
 String getUrlPort() => html.window.location.port;
 


### PR DESCRIPTION
I believe `import 'dart:html' as html;` is not supposed to be there. 