### PR TITLE
add ConfirmSetup to stripe web

### DIFF
--- a/packages/stripe_js/lib/src/api/elements/express_checkout_element_options.freezed.dart
+++ b/packages/stripe_js/lib/src/api/elements/express_checkout_element_options.freezed.dart
@@ -368,6 +368,7 @@ ExpressCheckoutConfirmEvent _$ExpressCheckoutConfirmEventFromJson(
 
 /// @nodoc
 mixin _$ExpressCheckoutConfirmEvent {
+  /// The method that was used to pay.
   String get expressPaymentType => throw _privateConstructorUsedError;
   BillingDetails? get billingDetails => throw _privateConstructorUsedError;
 
@@ -497,6 +498,7 @@ class _$ExpressCheckoutConfirmEventImpl
           Map<String, dynamic> json) =>
       _$$ExpressCheckoutConfirmEventImplFromJson(json);
 
+  /// The method that was used to pay.
   @override
   final String expressPaymentType;
   @override
@@ -550,6 +552,7 @@ abstract class _ExpressCheckoutConfirmEvent
   factory _ExpressCheckoutConfirmEvent.fromJson(Map<String, dynamic> json) =
       _$ExpressCheckoutConfirmEventImpl.fromJson;
 
+  /// The method that was used to pay.
   @override
   String get expressPaymentType;
   @override

--- a/packages/stripe_js/lib/src/api/setup_intents/confirm_setup_options.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/confirm_setup_options.dart
@@ -1,0 +1,62 @@
+import 'package:stripe_js/src/api/converters/js_converter.dart';
+import 'package:stripe_js/stripe_api.dart';
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'confirm_setup_options.freezed.dart';
+part 'confirm_setup_options.g.dart';
+
+@freezed
+class ConfirmSetupOptions with _$ConfirmSetupOptions {
+  const factory ConfirmSetupOptions({
+    /// Required if you collect payment details before creating an Intent. It's always required if you don't provide a clientSecret.
+    @ElementsConverter() required Elements elements,
+
+    /// Required if you collect payment details before creating an Intent.
+    /// It's always required if you don't provide an elements instance containing a client secret.
+    String? clientSecret,
+
+    /// Parameters that will be passed on to the Stripe API.
+    /// Refer to the Payment Intents API for a full list of parameters.
+    required ConfirmSetupParams confirmParams,
+
+    /// By default, stripe.confirmSetup will always redirect to your return_url
+    /// after a successful confirmation. If you set redirect: "if_required",
+    /// then stripe.confirmSetup will only redirect if your user chooses a
+    /// redirect-based payment method.
+
+    /// Note: Setting if_required requires that you handle successful confirmations
+    /// for redirect-based and non-redirect based payment methods separately.
+    /// When a non-redirect based payment method is successfully confirmed,
+    /// stripe.confirmSetup will resolve with a {setupIntent} object.
+    SetupConfirmationRedirect? redirect,
+  }) = _ConfirmSetupOptions;
+
+  factory ConfirmSetupOptions.fromJson(Map<String, dynamic> json) =>
+      _$ConfirmSetupOptionsFromJson(json);
+}
+
+@freezed
+class ConfirmSetupParams with _$ConfirmSetupParams {
+  const factory ConfirmSetupParams({
+    /// The url your customer will be directed to after they complete authentication.
+    required String return_url,
+
+    /// If collected previously, the ID of the ConfirmationToken to use to confirm this SetupIntent.
+    /// This is mutually exclusive with the elements parameter.
+    String? confirmation_token,
+  }) = _ConfirmSetupParams;
+
+  factory ConfirmSetupParams.fromJson(Map<String, dynamic> json) =>
+      _$ConfirmSetupParamsFromJson(json);
+}
+
+/// By default, stripe.confirmPayment will always redirect to
+/// your return_url after a successful confirmation.
+/// If you set redirect: "if_required", then stripe.confirmPayment
+/// will only redirect if your user chooses a redirect-based payment method.
+enum SetupConfirmationRedirect {
+  always,
+  @JsonValue('if_required')
+  ifRequired,
+}

--- a/packages/stripe_js/lib/src/api/setup_intents/confirm_setup_options.freezed.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/confirm_setup_options.freezed.dart
@@ -1,0 +1,483 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'confirm_setup_options.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ConfirmSetupOptions _$ConfirmSetupOptionsFromJson(Map<String, dynamic> json) {
+  return _ConfirmSetupOptions.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ConfirmSetupOptions {
+  /// Required if you collect payment details before creating an Intent. It's always required if you don't provide a clientSecret.
+  @ElementsConverter()
+  Elements get elements => throw _privateConstructorUsedError;
+
+  /// Required if you collect payment details before creating an Intent.
+  /// It's always required if you don't provide an elements instance containing a client secret.
+  String? get clientSecret => throw _privateConstructorUsedError;
+
+  /// Parameters that will be passed on to the Stripe API.
+  /// Refer to the Payment Intents API for a full list of parameters.
+  ConfirmSetupParams get confirmParams => throw _privateConstructorUsedError;
+
+  /// By default, stripe.confirmSetup will always redirect to your return_url
+  /// after a successful confirmation. If you set redirect: "if_required",
+  /// then stripe.confirmSetup will only redirect if your user chooses a
+  /// redirect-based payment method.
+  /// Note: Setting if_required requires that you handle successful confirmations
+  /// for redirect-based and non-redirect based payment methods separately.
+  /// When a non-redirect based payment method is successfully confirmed,
+  /// stripe.confirmSetup will resolve with a {setupIntent} object.
+  SetupConfirmationRedirect? get redirect => throw _privateConstructorUsedError;
+
+  /// Serializes this ConfirmSetupOptions to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ConfirmSetupOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ConfirmSetupOptionsCopyWith<ConfirmSetupOptions> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ConfirmSetupOptionsCopyWith<$Res> {
+  factory $ConfirmSetupOptionsCopyWith(
+          ConfirmSetupOptions value, $Res Function(ConfirmSetupOptions) then) =
+      _$ConfirmSetupOptionsCopyWithImpl<$Res, ConfirmSetupOptions>;
+  @useResult
+  $Res call(
+      {@ElementsConverter() Elements elements,
+      String? clientSecret,
+      ConfirmSetupParams confirmParams,
+      SetupConfirmationRedirect? redirect});
+
+  $ConfirmSetupParamsCopyWith<$Res> get confirmParams;
+}
+
+/// @nodoc
+class _$ConfirmSetupOptionsCopyWithImpl<$Res, $Val extends ConfirmSetupOptions>
+    implements $ConfirmSetupOptionsCopyWith<$Res> {
+  _$ConfirmSetupOptionsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ConfirmSetupOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? elements = null,
+    Object? clientSecret = freezed,
+    Object? confirmParams = null,
+    Object? redirect = freezed,
+  }) {
+    return _then(_value.copyWith(
+      elements: null == elements
+          ? _value.elements
+          : elements // ignore: cast_nullable_to_non_nullable
+              as Elements,
+      clientSecret: freezed == clientSecret
+          ? _value.clientSecret
+          : clientSecret // ignore: cast_nullable_to_non_nullable
+              as String?,
+      confirmParams: null == confirmParams
+          ? _value.confirmParams
+          : confirmParams // ignore: cast_nullable_to_non_nullable
+              as ConfirmSetupParams,
+      redirect: freezed == redirect
+          ? _value.redirect
+          : redirect // ignore: cast_nullable_to_non_nullable
+              as SetupConfirmationRedirect?,
+    ) as $Val);
+  }
+
+  /// Create a copy of ConfirmSetupOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ConfirmSetupParamsCopyWith<$Res> get confirmParams {
+    return $ConfirmSetupParamsCopyWith<$Res>(_value.confirmParams, (value) {
+      return _then(_value.copyWith(confirmParams: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ConfirmSetupOptionsImplCopyWith<$Res>
+    implements $ConfirmSetupOptionsCopyWith<$Res> {
+  factory _$$ConfirmSetupOptionsImplCopyWith(_$ConfirmSetupOptionsImpl value,
+          $Res Function(_$ConfirmSetupOptionsImpl) then) =
+      __$$ConfirmSetupOptionsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@ElementsConverter() Elements elements,
+      String? clientSecret,
+      ConfirmSetupParams confirmParams,
+      SetupConfirmationRedirect? redirect});
+
+  @override
+  $ConfirmSetupParamsCopyWith<$Res> get confirmParams;
+}
+
+/// @nodoc
+class __$$ConfirmSetupOptionsImplCopyWithImpl<$Res>
+    extends _$ConfirmSetupOptionsCopyWithImpl<$Res, _$ConfirmSetupOptionsImpl>
+    implements _$$ConfirmSetupOptionsImplCopyWith<$Res> {
+  __$$ConfirmSetupOptionsImplCopyWithImpl(_$ConfirmSetupOptionsImpl _value,
+      $Res Function(_$ConfirmSetupOptionsImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ConfirmSetupOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? elements = null,
+    Object? clientSecret = freezed,
+    Object? confirmParams = null,
+    Object? redirect = freezed,
+  }) {
+    return _then(_$ConfirmSetupOptionsImpl(
+      elements: null == elements
+          ? _value.elements
+          : elements // ignore: cast_nullable_to_non_nullable
+              as Elements,
+      clientSecret: freezed == clientSecret
+          ? _value.clientSecret
+          : clientSecret // ignore: cast_nullable_to_non_nullable
+              as String?,
+      confirmParams: null == confirmParams
+          ? _value.confirmParams
+          : confirmParams // ignore: cast_nullable_to_non_nullable
+              as ConfirmSetupParams,
+      redirect: freezed == redirect
+          ? _value.redirect
+          : redirect // ignore: cast_nullable_to_non_nullable
+              as SetupConfirmationRedirect?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ConfirmSetupOptionsImpl implements _ConfirmSetupOptions {
+  const _$ConfirmSetupOptionsImpl(
+      {@ElementsConverter() required this.elements,
+      this.clientSecret,
+      required this.confirmParams,
+      this.redirect});
+
+  factory _$ConfirmSetupOptionsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ConfirmSetupOptionsImplFromJson(json);
+
+  /// Required if you collect payment details before creating an Intent. It's always required if you don't provide a clientSecret.
+  @override
+  @ElementsConverter()
+  final Elements elements;
+
+  /// Required if you collect payment details before creating an Intent.
+  /// It's always required if you don't provide an elements instance containing a client secret.
+  @override
+  final String? clientSecret;
+
+  /// Parameters that will be passed on to the Stripe API.
+  /// Refer to the Payment Intents API for a full list of parameters.
+  @override
+  final ConfirmSetupParams confirmParams;
+
+  /// By default, stripe.confirmSetup will always redirect to your return_url
+  /// after a successful confirmation. If you set redirect: "if_required",
+  /// then stripe.confirmSetup will only redirect if your user chooses a
+  /// redirect-based payment method.
+  /// Note: Setting if_required requires that you handle successful confirmations
+  /// for redirect-based and non-redirect based payment methods separately.
+  /// When a non-redirect based payment method is successfully confirmed,
+  /// stripe.confirmSetup will resolve with a {setupIntent} object.
+  @override
+  final SetupConfirmationRedirect? redirect;
+
+  @override
+  String toString() {
+    return 'ConfirmSetupOptions(elements: $elements, clientSecret: $clientSecret, confirmParams: $confirmParams, redirect: $redirect)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ConfirmSetupOptionsImpl &&
+            (identical(other.elements, elements) ||
+                other.elements == elements) &&
+            (identical(other.clientSecret, clientSecret) ||
+                other.clientSecret == clientSecret) &&
+            (identical(other.confirmParams, confirmParams) ||
+                other.confirmParams == confirmParams) &&
+            (identical(other.redirect, redirect) ||
+                other.redirect == redirect));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, elements, clientSecret, confirmParams, redirect);
+
+  /// Create a copy of ConfirmSetupOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ConfirmSetupOptionsImplCopyWith<_$ConfirmSetupOptionsImpl> get copyWith =>
+      __$$ConfirmSetupOptionsImplCopyWithImpl<_$ConfirmSetupOptionsImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ConfirmSetupOptionsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ConfirmSetupOptions implements ConfirmSetupOptions {
+  const factory _ConfirmSetupOptions(
+      {@ElementsConverter() required final Elements elements,
+      final String? clientSecret,
+      required final ConfirmSetupParams confirmParams,
+      final SetupConfirmationRedirect? redirect}) = _$ConfirmSetupOptionsImpl;
+
+  factory _ConfirmSetupOptions.fromJson(Map<String, dynamic> json) =
+      _$ConfirmSetupOptionsImpl.fromJson;
+
+  /// Required if you collect payment details before creating an Intent. It's always required if you don't provide a clientSecret.
+  @override
+  @ElementsConverter()
+  Elements get elements;
+
+  /// Required if you collect payment details before creating an Intent.
+  /// It's always required if you don't provide an elements instance containing a client secret.
+  @override
+  String? get clientSecret;
+
+  /// Parameters that will be passed on to the Stripe API.
+  /// Refer to the Payment Intents API for a full list of parameters.
+  @override
+  ConfirmSetupParams get confirmParams;
+
+  /// By default, stripe.confirmSetup will always redirect to your return_url
+  /// after a successful confirmation. If you set redirect: "if_required",
+  /// then stripe.confirmSetup will only redirect if your user chooses a
+  /// redirect-based payment method.
+  /// Note: Setting if_required requires that you handle successful confirmations
+  /// for redirect-based and non-redirect based payment methods separately.
+  /// When a non-redirect based payment method is successfully confirmed,
+  /// stripe.confirmSetup will resolve with a {setupIntent} object.
+  @override
+  SetupConfirmationRedirect? get redirect;
+
+  /// Create a copy of ConfirmSetupOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ConfirmSetupOptionsImplCopyWith<_$ConfirmSetupOptionsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+ConfirmSetupParams _$ConfirmSetupParamsFromJson(Map<String, dynamic> json) {
+  return _ConfirmSetupParams.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ConfirmSetupParams {
+  /// The url your customer will be directed to after they complete authentication.
+  String get return_url => throw _privateConstructorUsedError;
+
+  /// If collected previously, the ID of the ConfirmationToken to use to confirm this SetupIntent.
+  /// This is mutually exclusive with the elements parameter.
+  String? get confirmation_token => throw _privateConstructorUsedError;
+
+  /// Serializes this ConfirmSetupParams to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ConfirmSetupParams
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ConfirmSetupParamsCopyWith<ConfirmSetupParams> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ConfirmSetupParamsCopyWith<$Res> {
+  factory $ConfirmSetupParamsCopyWith(
+          ConfirmSetupParams value, $Res Function(ConfirmSetupParams) then) =
+      _$ConfirmSetupParamsCopyWithImpl<$Res, ConfirmSetupParams>;
+  @useResult
+  $Res call({String return_url, String? confirmation_token});
+}
+
+/// @nodoc
+class _$ConfirmSetupParamsCopyWithImpl<$Res, $Val extends ConfirmSetupParams>
+    implements $ConfirmSetupParamsCopyWith<$Res> {
+  _$ConfirmSetupParamsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ConfirmSetupParams
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? return_url = null,
+    Object? confirmation_token = freezed,
+  }) {
+    return _then(_value.copyWith(
+      return_url: null == return_url
+          ? _value.return_url
+          : return_url // ignore: cast_nullable_to_non_nullable
+              as String,
+      confirmation_token: freezed == confirmation_token
+          ? _value.confirmation_token
+          : confirmation_token // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ConfirmSetupParamsImplCopyWith<$Res>
+    implements $ConfirmSetupParamsCopyWith<$Res> {
+  factory _$$ConfirmSetupParamsImplCopyWith(_$ConfirmSetupParamsImpl value,
+          $Res Function(_$ConfirmSetupParamsImpl) then) =
+      __$$ConfirmSetupParamsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String return_url, String? confirmation_token});
+}
+
+/// @nodoc
+class __$$ConfirmSetupParamsImplCopyWithImpl<$Res>
+    extends _$ConfirmSetupParamsCopyWithImpl<$Res, _$ConfirmSetupParamsImpl>
+    implements _$$ConfirmSetupParamsImplCopyWith<$Res> {
+  __$$ConfirmSetupParamsImplCopyWithImpl(_$ConfirmSetupParamsImpl _value,
+      $Res Function(_$ConfirmSetupParamsImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ConfirmSetupParams
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? return_url = null,
+    Object? confirmation_token = freezed,
+  }) {
+    return _then(_$ConfirmSetupParamsImpl(
+      return_url: null == return_url
+          ? _value.return_url
+          : return_url // ignore: cast_nullable_to_non_nullable
+              as String,
+      confirmation_token: freezed == confirmation_token
+          ? _value.confirmation_token
+          : confirmation_token // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ConfirmSetupParamsImpl implements _ConfirmSetupParams {
+  const _$ConfirmSetupParamsImpl(
+      {required this.return_url, this.confirmation_token});
+
+  factory _$ConfirmSetupParamsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ConfirmSetupParamsImplFromJson(json);
+
+  /// The url your customer will be directed to after they complete authentication.
+  @override
+  final String return_url;
+
+  /// If collected previously, the ID of the ConfirmationToken to use to confirm this SetupIntent.
+  /// This is mutually exclusive with the elements parameter.
+  @override
+  final String? confirmation_token;
+
+  @override
+  String toString() {
+    return 'ConfirmSetupParams(return_url: $return_url, confirmation_token: $confirmation_token)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ConfirmSetupParamsImpl &&
+            (identical(other.return_url, return_url) ||
+                other.return_url == return_url) &&
+            (identical(other.confirmation_token, confirmation_token) ||
+                other.confirmation_token == confirmation_token));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, return_url, confirmation_token);
+
+  /// Create a copy of ConfirmSetupParams
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ConfirmSetupParamsImplCopyWith<_$ConfirmSetupParamsImpl> get copyWith =>
+      __$$ConfirmSetupParamsImplCopyWithImpl<_$ConfirmSetupParamsImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ConfirmSetupParamsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ConfirmSetupParams implements ConfirmSetupParams {
+  const factory _ConfirmSetupParams(
+      {required final String return_url,
+      final String? confirmation_token}) = _$ConfirmSetupParamsImpl;
+
+  factory _ConfirmSetupParams.fromJson(Map<String, dynamic> json) =
+      _$ConfirmSetupParamsImpl.fromJson;
+
+  /// The url your customer will be directed to after they complete authentication.
+  @override
+  String get return_url;
+
+  /// If collected previously, the ID of the ConfirmationToken to use to confirm this SetupIntent.
+  /// This is mutually exclusive with the elements parameter.
+  @override
+  String? get confirmation_token;
+
+  /// Create a copy of ConfirmSetupParams
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ConfirmSetupParamsImplCopyWith<_$ConfirmSetupParamsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/stripe_js/lib/src/api/setup_intents/confirm_setup_options.g.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/confirm_setup_options.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'confirm_setup_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ConfirmSetupOptionsImpl _$$ConfirmSetupOptionsImplFromJson(Map json) =>
+    _$ConfirmSetupOptionsImpl(
+      elements: const ElementsConverter().fromJson(json['elements']),
+      clientSecret: json['clientSecret'] as String?,
+      confirmParams: ConfirmSetupParams.fromJson(
+          Map<String, dynamic>.from(json['confirmParams'] as Map)),
+      redirect: $enumDecodeNullable(
+          _$SetupConfirmationRedirectEnumMap, json['redirect']),
+    );
+
+Map<String, dynamic> _$$ConfirmSetupOptionsImplToJson(
+    _$ConfirmSetupOptionsImpl instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('elements', const ElementsConverter().toJson(instance.elements));
+  writeNotNull('clientSecret', instance.clientSecret);
+  val['confirmParams'] = instance.confirmParams.toJson();
+  writeNotNull(
+      'redirect', _$SetupConfirmationRedirectEnumMap[instance.redirect]);
+  return val;
+}
+
+const _$SetupConfirmationRedirectEnumMap = {
+  SetupConfirmationRedirect.always: 'always',
+  SetupConfirmationRedirect.ifRequired: 'if_required',
+};
+
+_$ConfirmSetupParamsImpl _$$ConfirmSetupParamsImplFromJson(Map json) =>
+    _$ConfirmSetupParamsImpl(
+      return_url: json['return_url'] as String,
+      confirmation_token: json['confirmation_token'] as String?,
+    );
+
+Map<String, dynamic> _$$ConfirmSetupParamsImplToJson(
+    _$ConfirmSetupParamsImpl instance) {
+  final val = <String, dynamic>{
+    'return_url': instance.return_url,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('confirmation_token', instance.confirmation_token);
+  return val;
+}

--- a/packages/stripe_js/lib/src/api/setup_intents/setup_intents.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/setup_intents.dart
@@ -4,3 +4,4 @@ export 'confirm_sepa_debit_setup_data.dart';
 export 'setup_intent.dart';
 export 'setup_intent_response.dart';
 export 'setup_intent_status.dart';
+export 'confirm_setup_options.dart';

--- a/packages/stripe_js/lib/src/js/setup_intents/confirm_setup.dart
+++ b/packages/stripe_js/lib/src/js/setup_intents/confirm_setup.dart
@@ -1,0 +1,25 @@
+import 'package:stripe_js/stripe_api.dart';
+import 'package:stripe_js/stripe_js.dart';
+import '../utils/utils.dart';
+import 'dart:js_interop';
+
+extension ExtensionConfirmCardSetup on Stripe {
+  Future<SetupIntentResponse> confirmSetup(
+    String clientSecret, {
+    ConfirmCardSetupData? data,
+    ConfirmCardSetupOptions? options,
+  }) {
+    final jsData = (data?.toJson() ?? {}).jsify();
+    final jsOptions = (options?.toJson() ?? {}).jsify();
+    return _confirmCardSetup(clientSecret, jsData, jsOptions)
+        .toDart
+        .then((response) => response.toDart);
+  }
+
+  @JS('confirmSetup')
+  external JSPromise<JSSetupIntentResponse> _confirmCardSetup(
+    String clientSecret, [
+    JSAny? data,
+    JSAny? options,
+  ]);
+}

--- a/packages/stripe_js/lib/src/js/setup_intents/confirm_setup.dart
+++ b/packages/stripe_js/lib/src/js/setup_intents/confirm_setup.dart
@@ -1,25 +1,31 @@
-import 'package:stripe_js/stripe_api.dart';
-import 'package:stripe_js/stripe_js.dart';
-import '../utils/utils.dart';
+import 'dart:async';
 import 'dart:js_interop';
 
-extension ExtensionConfirmCardSetup on Stripe {
-  Future<SetupIntentResponse> confirmSetup(
-    String clientSecret, {
-    ConfirmCardSetupData? data,
-    ConfirmCardSetupOptions? options,
-  }) {
-    final jsData = (data?.toJson() ?? {}).jsify();
-    final jsOptions = (options?.toJson() ?? {}).jsify();
-    return _confirmCardSetup(clientSecret, jsData, jsOptions)
+import 'package:stripe_js/src/api/setup_intents/confirm_setup_options.dart';
+import 'package:stripe_js/stripe_js.dart';
+
+extension ExtensionConfirmPayment on Stripe {
+  /// Use stripe.confirmSetup to confirm a SetupIntent using data collected
+  /// by the Payment Element, or with manually provided data via confirmParams.
+  /// When called, stripe.confirmSetup will attempt to complete any required actions,
+  /// such as authenticating your user by displaying a 3DS dialog or redirecting
+  /// them to a bank authorization page. Your user will be redirected to the
+  /// return_url you pass once the authorization is complete.
+  ///
+  /// [confirmSetup] will return a Future. Upon a successful authorization,
+  /// your user will be redirected to the return_url you provide
+  /// before the Future ever resolves.
+  /// see: https://docs.stripe.com/js/setup_intents/confirm_setup
+  Future<void> confirmSetup(
+    ConfirmSetupOptions options,
+  ) async {
+    final completer = Completer();
+    _confirmSetup(options.toJson().jsify())
         .toDart
-        .then((response) => response.toDart);
+        .then((response) => completer.complete());
+    return completer.future;
   }
 
   @JS('confirmSetup')
-  external JSPromise<JSSetupIntentResponse> _confirmCardSetup(
-    String clientSecret, [
-    JSAny? data,
-    JSAny? options,
-  ]);
+  external JSPromise<JSAny> _confirmSetup(JSAny? options);
 }

--- a/packages/stripe_js/lib/src/js/setup_intents/confirm_setup.dart
+++ b/packages/stripe_js/lib/src/js/setup_intents/confirm_setup.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
 import 'dart:js_interop';
 
-import 'package:stripe_js/src/api/setup_intents/confirm_setup_options.dart';
+import 'package:stripe_js/src/js/utils/utils.dart';
+import 'package:stripe_js/stripe_api.dart';
 import 'package:stripe_js/stripe_js.dart';
 
-extension ExtensionConfirmPayment on Stripe {
+extension ExtensionConfirmSetup on Stripe {
   /// Use stripe.confirmSetup to confirm a SetupIntent using data collected
   /// by the Payment Element, or with manually provided data via confirmParams.
   /// When called, stripe.confirmSetup will attempt to complete any required actions,
@@ -16,16 +17,14 @@ extension ExtensionConfirmPayment on Stripe {
   /// your user will be redirected to the return_url you provide
   /// before the Future ever resolves.
   /// see: https://docs.stripe.com/js/setup_intents/confirm_setup
-  Future<void> confirmSetup(
+  Future<SetupIntentResponse> confirmSetup(
     ConfirmSetupOptions options,
   ) async {
-    final completer = Completer();
-    _confirmSetup(options.toJson().jsify())
+    return _confirmSetup(options.toJson().jsify())
         .toDart
-        .then((response) => completer.complete());
-    return completer.future;
+        .then((response) => response.toDart);
   }
 
   @JS('confirmSetup')
-  external JSPromise<JSAny> _confirmSetup(JSAny? options);
+  external JSPromise<JSSetupIntentResponse> _confirmSetup(JSAny? options);
 }

--- a/packages/stripe_js/lib/src/js/setup_intents/setup_intents.dart
+++ b/packages/stripe_js/lib/src/js/setup_intents/setup_intents.dart
@@ -1,3 +1,4 @@
 export 'confirm_card_setup.dart';
 export 'confirm_sepa_debit_setup.dart';
 export 'retrieve_setup_intent.dart';
+export 'confirm_setup.dart';

--- a/packages/stripe_web/lib/flutter_stripe_web.dart
+++ b/packages/stripe_web/lib/flutter_stripe_web.dart
@@ -1,6 +1,7 @@
 library stripe_web;
 
-export 'package:stripe_js/stripe_api.dart' show ConfirmPaymentParams;
+export 'package:stripe_js/stripe_api.dart'
+    show ConfirmPaymentParams, ConfirmSetupParams;
 export 'package:stripe_platform_interface/stripe_platform_interface.dart';
 
 export 'src/models/models.dart';

--- a/packages/stripe_web/lib/src/models/confirm_setup_options.dart
+++ b/packages/stripe_web/lib/src/models/confirm_setup_options.dart
@@ -1,7 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:stripe_js/stripe_api.dart';
 export 'package:stripe_js/stripe_api.dart'
-    show PaymentConfirmationRedirect, ConfirmPaymentParams;
+    show SetupConfirmationRedirect, ConfirmSetupParams;
 
 part 'confirm_setup_options.freezed.dart';
 part 'confirm_setup_options.g.dart';

--- a/packages/stripe_web/lib/src/models/confirm_setup_options.dart
+++ b/packages/stripe_web/lib/src/models/confirm_setup_options.dart
@@ -1,0 +1,25 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:stripe_js/stripe_api.dart';
+export 'package:stripe_js/stripe_api.dart'
+    show PaymentConfirmationRedirect, ConfirmPaymentParams;
+
+part 'confirm_setup_options.freezed.dart';
+part 'confirm_setup_options.g.dart';
+
+@freezed
+class ConfirmSetupElementOptions with _$ConfirmSetupElementOptions {
+  const factory ConfirmSetupElementOptions({
+    /// Parameters that will be passed on to the Stripe API.
+    /// Refer to the Payment Intents API for a full list of parameters.
+    required ConfirmSetupParams confirmParams,
+
+    /// By default, stripe.confirmPayment will always redirect to
+    /// your return_url after a successful confirmation.
+    /// If you set redirect: "if_required", then stripe.confirmPayment
+    /// will only redirect if your user chooses a redirect-based payment method.
+    SetupConfirmationRedirect? redirect,
+  }) = _SetupPaymentElementOptions;
+
+  factory ConfirmSetupElementOptions.fromJson(Map<String, dynamic> json) =>
+      _$ConfirmSetupElementOptionsFromJson(json);
+}

--- a/packages/stripe_web/lib/src/models/confirm_setup_options.freezed.dart
+++ b/packages/stripe_web/lib/src/models/confirm_setup_options.freezed.dart
@@ -3,7 +3,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-part of 'confirm_payment_options.dart';
+part of 'confirm_setup_options.dart';
 
 // **************************************************************************
 // FreezedGenerator
@@ -14,16 +14,16 @@ T _$identity<T>(T value) => value;
 final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
-ConfirmPaymentElementOptions _$ConfirmPaymentElementOptionsFromJson(
+ConfirmSetupElementOptions _$ConfirmSetupElementOptionsFromJson(
     Map<String, dynamic> json) {
-  return _ConfirmPaymentElementOptions.fromJson(json);
+  return _SetupPaymentElementOptions.fromJson(json);
 }
 
 /// @nodoc
-mixin _$ConfirmPaymentElementOptions {
+mixin _$ConfirmSetupElementOptions {
   /// Parameters that will be passed on to the Stripe API.
-  /// Refer to the Payment Intents API for a full list of parameters.
-  ConfirmPaymentParams get confirmParams => throw _privateConstructorUsedError;
+  /// Refer to the Setup Intents API for a full list of parameters.
+  ConfirmSetupParams get confirmParams => throw _privateConstructorUsedError;
 
   /// By default, stripe.confirmPayment will always redirect to your
   /// return_url after a successful confirmation.
@@ -35,46 +35,43 @@ mixin _$ConfirmPaymentElementOptions {
   /// methods separately. When a non-redirect based payment method is
   /// successfully confirmed, stripe.confirmPayment will resolve with a
   /// {paymentIntent} object.
-  PaymentConfirmationRedirect? get redirect =>
-      throw _privateConstructorUsedError;
+  SetupConfirmationRedirect? get redirect => throw _privateConstructorUsedError;
 
-  /// Serializes this ConfirmPaymentElementOptions to a JSON map.
+  /// Serializes this ConfirmSetupElementOptions to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 
-  /// Create a copy of ConfirmPaymentElementOptions
+  /// Create a copy of ConfirmSetupElementOptions
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $ConfirmPaymentElementOptionsCopyWith<ConfirmPaymentElementOptions>
+  $ConfirmSetupElementOptionsCopyWith<ConfirmSetupElementOptions>
       get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class $ConfirmPaymentElementOptionsCopyWith<$Res> {
-  factory $ConfirmPaymentElementOptionsCopyWith(
-          ConfirmPaymentElementOptions value,
-          $Res Function(ConfirmPaymentElementOptions) then) =
-      _$ConfirmPaymentElementOptionsCopyWithImpl<$Res,
-          ConfirmPaymentElementOptions>;
+abstract class $ConfirmSetupElementOptionsCopyWith<$Res> {
+  factory $ConfirmSetupElementOptionsCopyWith(ConfirmSetupElementOptions value,
+          $Res Function(ConfirmSetupElementOptions) then) =
+      _$ConfirmSetupElementOptionsCopyWithImpl<$Res,
+          ConfirmSetupElementOptions>;
   @useResult
   $Res call(
-      {ConfirmPaymentParams confirmParams,
-      PaymentConfirmationRedirect? redirect});
+      {ConfirmSetupParams confirmParams, SetupConfirmationRedirect? redirect});
 
-  $ConfirmPaymentParamsCopyWith<$Res> get confirmParams;
+  $ConfirmSetupParamsCopyWith<$Res> get confirmParams;
 }
 
 /// @nodoc
-class _$ConfirmPaymentElementOptionsCopyWithImpl<$Res,
-        $Val extends ConfirmPaymentElementOptions>
-    implements $ConfirmPaymentElementOptionsCopyWith<$Res> {
-  _$ConfirmPaymentElementOptionsCopyWithImpl(this._value, this._then);
+class _$ConfirmSetupElementOptionsCopyWithImpl<$Res,
+        $Val extends ConfirmSetupElementOptions>
+    implements $ConfirmSetupElementOptionsCopyWith<$Res> {
+  _$ConfirmSetupElementOptionsCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ConfirmPaymentElementOptions
+  /// Create a copy of ConfirmSetupElementOptions
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
@@ -86,53 +83,52 @@ class _$ConfirmPaymentElementOptionsCopyWithImpl<$Res,
       confirmParams: null == confirmParams
           ? _value.confirmParams
           : confirmParams // ignore: cast_nullable_to_non_nullable
-              as ConfirmPaymentParams,
+              as ConfirmSetupParams,
       redirect: freezed == redirect
           ? _value.redirect
           : redirect // ignore: cast_nullable_to_non_nullable
-              as PaymentConfirmationRedirect?,
+              as SetupConfirmationRedirect?,
     ) as $Val);
   }
 
-  /// Create a copy of ConfirmPaymentElementOptions
+  /// Create a copy of ConfirmSetupElementOptions
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  $ConfirmPaymentParamsCopyWith<$Res> get confirmParams {
-    return $ConfirmPaymentParamsCopyWith<$Res>(_value.confirmParams, (value) {
+  $ConfirmSetupParamsCopyWith<$Res> get confirmParams {
+    return $ConfirmSetupParamsCopyWith<$Res>(_value.confirmParams, (value) {
       return _then(_value.copyWith(confirmParams: value) as $Val);
     });
   }
 }
 
 /// @nodoc
-abstract class _$$ConfirmPaymentElementOptionsImplCopyWith<$Res>
-    implements $ConfirmPaymentElementOptionsCopyWith<$Res> {
-  factory _$$ConfirmPaymentElementOptionsImplCopyWith(
-          _$ConfirmPaymentElementOptionsImpl value,
-          $Res Function(_$ConfirmPaymentElementOptionsImpl) then) =
-      __$$ConfirmPaymentElementOptionsImplCopyWithImpl<$Res>;
+abstract class _$$SetupPaymentElementOptionsImplCopyWith<$Res>
+    implements $ConfirmSetupElementOptionsCopyWith<$Res> {
+  factory _$$SetupPaymentElementOptionsImplCopyWith(
+          _$SetupPaymentElementOptionsImpl value,
+          $Res Function(_$SetupPaymentElementOptionsImpl) then) =
+      __$$SetupPaymentElementOptionsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
-      {ConfirmPaymentParams confirmParams,
-      PaymentConfirmationRedirect? redirect});
+      {ConfirmSetupParams confirmParams, SetupConfirmationRedirect? redirect});
 
   @override
-  $ConfirmPaymentParamsCopyWith<$Res> get confirmParams;
+  $ConfirmSetupParamsCopyWith<$Res> get confirmParams;
 }
 
 /// @nodoc
-class __$$ConfirmPaymentElementOptionsImplCopyWithImpl<$Res>
-    extends _$ConfirmPaymentElementOptionsCopyWithImpl<$Res,
-        _$ConfirmPaymentElementOptionsImpl>
-    implements _$$ConfirmPaymentElementOptionsImplCopyWith<$Res> {
-  __$$ConfirmPaymentElementOptionsImplCopyWithImpl(
-      _$ConfirmPaymentElementOptionsImpl _value,
-      $Res Function(_$ConfirmPaymentElementOptionsImpl) _then)
+class __$$SetupPaymentElementOptionsImplCopyWithImpl<$Res>
+    extends _$ConfirmSetupElementOptionsCopyWithImpl<$Res,
+        _$SetupPaymentElementOptionsImpl>
+    implements _$$SetupPaymentElementOptionsImplCopyWith<$Res> {
+  __$$SetupPaymentElementOptionsImplCopyWithImpl(
+      _$SetupPaymentElementOptionsImpl _value,
+      $Res Function(_$SetupPaymentElementOptionsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ConfirmPaymentElementOptions
+  /// Create a copy of ConfirmSetupElementOptions
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
@@ -140,34 +136,33 @@ class __$$ConfirmPaymentElementOptionsImplCopyWithImpl<$Res>
     Object? confirmParams = null,
     Object? redirect = freezed,
   }) {
-    return _then(_$ConfirmPaymentElementOptionsImpl(
+    return _then(_$SetupPaymentElementOptionsImpl(
       confirmParams: null == confirmParams
           ? _value.confirmParams
           : confirmParams // ignore: cast_nullable_to_non_nullable
-              as ConfirmPaymentParams,
+              as ConfirmSetupParams,
       redirect: freezed == redirect
           ? _value.redirect
           : redirect // ignore: cast_nullable_to_non_nullable
-              as PaymentConfirmationRedirect?,
+              as SetupConfirmationRedirect?,
     ));
   }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$ConfirmPaymentElementOptionsImpl
-    implements _ConfirmPaymentElementOptions {
-  const _$ConfirmPaymentElementOptionsImpl(
+class _$SetupPaymentElementOptionsImpl implements _SetupPaymentElementOptions {
+  const _$SetupPaymentElementOptionsImpl(
       {required this.confirmParams, this.redirect});
 
-  factory _$ConfirmPaymentElementOptionsImpl.fromJson(
+  factory _$SetupPaymentElementOptionsImpl.fromJson(
           Map<String, dynamic> json) =>
-      _$$ConfirmPaymentElementOptionsImplFromJson(json);
+      _$$SetupPaymentElementOptionsImplFromJson(json);
 
   /// Parameters that will be passed on to the Stripe API.
-  /// Refer to the Payment Intents API for a full list of parameters.
+  /// Refer to the Setup Intents API for a full list of parameters.
   @override
-  final ConfirmPaymentParams confirmParams;
+  final ConfirmSetupParams confirmParams;
 
   /// By default, stripe.confirmPayment will always redirect to your
   /// return_url after a successful confirmation.
@@ -180,18 +175,18 @@ class _$ConfirmPaymentElementOptionsImpl
   /// successfully confirmed, stripe.confirmPayment will resolve with a
   /// {paymentIntent} object.
   @override
-  final PaymentConfirmationRedirect? redirect;
+  final SetupConfirmationRedirect? redirect;
 
   @override
   String toString() {
-    return 'ConfirmPaymentElementOptions(confirmParams: $confirmParams, redirect: $redirect)';
+    return 'ConfirmSetupElementOptions(confirmParams: $confirmParams, redirect: $redirect)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ConfirmPaymentElementOptionsImpl &&
+            other is _$SetupPaymentElementOptionsImpl &&
             (identical(other.confirmParams, confirmParams) ||
                 other.confirmParams == confirmParams) &&
             (identical(other.redirect, redirect) ||
@@ -202,38 +197,37 @@ class _$ConfirmPaymentElementOptionsImpl
   @override
   int get hashCode => Object.hash(runtimeType, confirmParams, redirect);
 
-  /// Create a copy of ConfirmPaymentElementOptions
+  /// Create a copy of ConfirmSetupElementOptions
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$ConfirmPaymentElementOptionsImplCopyWith<
-          _$ConfirmPaymentElementOptionsImpl>
-      get copyWith => __$$ConfirmPaymentElementOptionsImplCopyWithImpl<
-          _$ConfirmPaymentElementOptionsImpl>(this, _$identity);
+  _$$SetupPaymentElementOptionsImplCopyWith<_$SetupPaymentElementOptionsImpl>
+      get copyWith => __$$SetupPaymentElementOptionsImplCopyWithImpl<
+          _$SetupPaymentElementOptionsImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ConfirmPaymentElementOptionsImplToJson(
+    return _$$SetupPaymentElementOptionsImplToJson(
       this,
     );
   }
 }
 
-abstract class _ConfirmPaymentElementOptions
-    implements ConfirmPaymentElementOptions {
-  const factory _ConfirmPaymentElementOptions(
-          {required final ConfirmPaymentParams confirmParams,
-          final PaymentConfirmationRedirect? redirect}) =
-      _$ConfirmPaymentElementOptionsImpl;
+abstract class _SetupPaymentElementOptions
+    implements ConfirmSetupElementOptions {
+  const factory _SetupPaymentElementOptions(
+          {required final ConfirmSetupParams confirmParams,
+          final SetupConfirmationRedirect? redirect}) =
+      _$SetupPaymentElementOptionsImpl;
 
-  factory _ConfirmPaymentElementOptions.fromJson(Map<String, dynamic> json) =
-      _$ConfirmPaymentElementOptionsImpl.fromJson;
+  factory _SetupPaymentElementOptions.fromJson(Map<String, dynamic> json) =
+      _$SetupPaymentElementOptionsImpl.fromJson;
 
   /// Parameters that will be passed on to the Stripe API.
-  /// Refer to the Payment Intents API for a full list of parameters.
+  /// Refer to the Setup Intents API for a full list of parameters.
   @override
-  ConfirmPaymentParams get confirmParams;
+  ConfirmSetupParams get confirmParams;
 
   /// By default, stripe.confirmPayment will always redirect to your
   /// return_url after a successful confirmation.
@@ -246,13 +240,12 @@ abstract class _ConfirmPaymentElementOptions
   /// successfully confirmed, stripe.confirmPayment will resolve with a
   /// {paymentIntent} object.
   @override
-  PaymentConfirmationRedirect? get redirect;
+  SetupConfirmationRedirect? get redirect;
 
-  /// Create a copy of ConfirmPaymentElementOptions
+  /// Create a copy of ConfirmSetupElementOptions
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ConfirmPaymentElementOptionsImplCopyWith<
-          _$ConfirmPaymentElementOptionsImpl>
+  _$$SetupPaymentElementOptionsImplCopyWith<_$SetupPaymentElementOptionsImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/stripe_web/lib/src/models/confirm_setup_options.g.dart
+++ b/packages/stripe_web/lib/src/models/confirm_setup_options.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'confirm_setup_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SetupPaymentElementOptionsImpl _$$SetupPaymentElementOptionsImplFromJson(
+        Map json) =>
+    _$SetupPaymentElementOptionsImpl(
+      confirmParams: ConfirmSetupParams.fromJson(
+          Map<String, dynamic>.from(json['confirmParams'] as Map)),
+      redirect: $enumDecodeNullable(
+          _$SetupConfirmationRedirectEnumMap, json['redirect']),
+    );
+
+Map<String, dynamic> _$$SetupPaymentElementOptionsImplToJson(
+    _$SetupPaymentElementOptionsImpl instance) {
+  final val = <String, dynamic>{
+    'confirmParams': instance.confirmParams.toJson(),
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull(
+      'redirect', _$SetupConfirmationRedirectEnumMap[instance.redirect]);
+  return val;
+}
+
+const _$SetupConfirmationRedirectEnumMap = {
+  SetupConfirmationRedirect.always: 'always',
+  SetupConfirmationRedirect.ifRequired: 'if_required',
+};

--- a/packages/stripe_web/lib/src/models/models.dart
+++ b/packages/stripe_web/lib/src/models/models.dart
@@ -1,1 +1,2 @@
 export 'confirm_payment_options.dart';
+export 'confirm_setup_options.dart';

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -409,6 +409,23 @@ class WebStripe extends StripePlatform {
     }
   }
 
+  Future<void> confirmSetupElement(
+    ConfirmSetupElementOptions options,
+  ) async {
+    final response = await js.confirmSetup(
+      stripe_js.ConfirmSetupOptions(
+        elements: elements!,
+        confirmParams: options.confirmParams,
+        redirect: options.redirect,
+      ),
+    );
+    if (response.error != null) {
+      throw response.error!;
+    } else {
+      return;
+    }
+  }
+
   @override
   Widget buildCard({
     Key? key,

--- a/packages/stripe_web/pubspec.yaml
+++ b/packages/stripe_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_stripe_web
 description: Stripe sdk bindings for the Flutter web platform. This package contains the implementation of the platform interface for web.
-version: 6.2.0
+version: 6.2.1
 homepage: https://github.com/flutter-stripe/flutter_stripe
 
 environment:
@@ -14,7 +14,11 @@ dependencies:
     sdk: flutter
   freezed_annotation: ^2.0.3
   stripe_platform_interface: ^11.2.0
-  stripe_js: ^6.2.0
+  stripe_js:
+    git:
+      url: git@github.com:cedvdb/flutter_stripe.git
+      path: packages/stripe_js
+      ref: setup_confirm
   web: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
This effectively adds setup intent support for any kind of payment method on the web.

This adds [ConfirmSetup](https://docs.stripe.com/js/setup_intents/confirm_setup) to stripe web as `confirmSetupIntent` is deprecated. I used [ConfirmPayment] as a template to follow the conventions of this package.

This does not have test yet