### PR TITLE
Fix issue with CaptureMethod.Manual on iOS.

### DIFF
--- a/packages/stripe_ios/ios/Classes/Stripe Sdk/StripeSdk+PaymentSheet.swift
+++ b/packages/stripe_ios/ios/Classes/Stripe Sdk/StripeSdk+PaymentSheet.swift
@@ -187,7 +187,7 @@ extension StripeSdk {
                 resolve(Errors.createError(ErrorType.Failed, "You must provide `intentConfiguration.confirmHandler` if you are not passing an intent client secret"))
                 return
             }
-            let captureMethodString = intentConfiguration["captureMethod"] as? String
+            let captureMethodString = modeParams["captureMethod"] as? String
             let intentConfig = buildIntentConfiguration(
                 modeParams: modeParams,
                 paymentMethodTypes: intentConfiguration["paymentMethodTypes"] as? [String],


### PR DESCRIPTION
This pull request fixes a bug in the stripe_ios package where the intent configuration capture method is ignored, when using deferred payments.

## Steps to reproduce the bug

1. Add `captureMethod: CaptureMethod.Manual` to the `IntentMode` in the deferred payments example from <https://docs.page/flutter-stripe/flutter_stripe/sheet_deferred>

    ```dart
    Future<void> initPaymentSheet() async {
        try {
          // 1. create payment intent on the server
          final data = await _createTestPaymentSheet();

          // 2. initialize the payment sheet
         await Stripe.instance.initPaymentSheet(
            paymentSheetParameters: SetupPaymentSheetParameters(
              // Enable custom flow
              customFlow: false,
              // Main params
              merchantDisplayName: 'Flutter Stripe Store Demo',
              intentConfiguration: IntentConfiguration(
                  mode: IntentMode(
                    currencyCode: 'USD',
                    amount: 1500,
                    captureMethod: CaptureMethod.Manual
                  ),
                  confirmHandler: (method, saveFuture) {
                    // This is the method where you call the server to create a paymentintent for the payment method id supplied in the callback.
                    _createIntentAndConfirmToUser(method.id);
                  }),         
              // Customer keys
              customerEphemeralKeySecret: data['ephemeralKey'],
              customerId: data['customer'],
              // Extra options
              testEnv: true,
              applePay: true,
              googlePay: true,
              style: ThemeMode.dark,
              merchantCountryCode: 'DE',
            ),
          );
          setState(() {
            _ready = true;
          });
        } catch (e) {
          ScaffoldMessenger.of(context).showSnackBar(
            SnackBar(content: Text('Error: $e')),
          );
          rethrow;
        }
    }
    ```

2. Update the backend to create a payment intent with the capture method set to manual.
3. Run the example on iOS.

## Expected result:

The payment intent is confirmed when the user taps the pay button in the payment sheet.

## Actual result:

The following error is printed in the payment sheet:

"An error occurred in PaymentSheet. Your PaymentIntent captureMethod (manual) does not match the PaymentIntent.IntentConfiguration amount (automatic)"

The captureMethod parameter is ignored by the stripe_ios package and the automatic capture method is always used regardless of the value given for captureMethod.