### PR TITLE
Add P24 confirm payment functionality for web integration

### DIFF
--- a/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_data.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_data.dart
@@ -1,0 +1,34 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:stripe_js/stripe_api.dart';
+
+part 'confirm_p24_payment_data.freezed.dart';
+part 'confirm_p24_payment_data.g.dart';
+
+@freezed
+class ConfirmP24PaymentData with _$ConfirmP24PaymentData {
+  const factory ConfirmP24PaymentData({
+    /// Either the ID of an existing PaymentMethod, or an object containing
+    /// data to create a PaymentMethod with.
+    ///
+    /// This is required to process the payment. If you already have a PaymentMethod
+    /// attached to the PaymentIntent, you do not need to specify this field.
+    ///
+    /// See the official Stripe documentation for additional details:
+    /// https://stripe.com/docs/payments/p24
+    @paymentMethodDetailJsonKey P24PaymentMethodDetails? paymentMethod,
+
+    /// The url your customer will be directed to after they complete authentication.
+    @JsonKey(name: "return_url") String? returnUrl,
+
+    /// To set up a SEPA Direct Debit payment method using the bank details
+    ///  from this P24 payment, set this parameter to off_session.
+    /// When using this parameter, a customer will need to be set on the
+    /// PaymentIntent. The newly created SEPA Direct Debit PaymentMethod
+    /// will be attached to this customer.
+    @JsonKey(name: "setup_future_usage")
+    PaymentIntentSetupFutureUsage? setupFutureUsage,
+  }) = _ConfirmP24PaymentData;
+
+  factory ConfirmP24PaymentData.fromJson(Map<String, dynamic> json) =>
+      _$ConfirmP24PaymentDataFromJson(json);
+}

--- a/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_data.freezed.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_data.freezed.dart
@@ -1,0 +1,285 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'confirm_p24_payment_data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ConfirmP24PaymentData _$ConfirmP24PaymentDataFromJson(
+    Map<String, dynamic> json) {
+  return _ConfirmP24PaymentData.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ConfirmP24PaymentData {
+  /// Either the id of an existing PaymentMethod, or an object containing
+  /// data to create a PaymentMethod with.
+  /// See the use case sections below for details.
+  @paymentMethodDetailJsonKey
+  P24PaymentMethodDetails? get paymentMethod =>
+      throw _privateConstructorUsedError;
+
+  /// The url your customer will be directed to after they complete authentication.
+  @JsonKey(name: "return_url")
+  String? get returnUrl => throw _privateConstructorUsedError;
+
+  /// To set up a SEPA Direct Debit payment method using the bank details
+  ///  from this iDEAL payment, set this parameter to off_session.
+  /// When using this parameter, a customer will need to be set on the
+  /// PaymentIntent. The newly created SEPA Direct Debit PaymentMethod
+  /// will be attached to this customer.
+  @JsonKey(name: "setup_future_usage")
+  PaymentIntentSetupFutureUsage? get setupFutureUsage =>
+      throw _privateConstructorUsedError;
+
+  /// Serializes this ConfirmP24PaymentData to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ConfirmP24PaymentData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ConfirmP24PaymentDataCopyWith<ConfirmP24PaymentData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ConfirmP24PaymentDataCopyWith<$Res> {
+  factory $ConfirmP24PaymentDataCopyWith(ConfirmP24PaymentData value,
+          $Res Function(ConfirmP24PaymentData) then) =
+      _$ConfirmP24PaymentDataCopyWithImpl<$Res, ConfirmP24PaymentData>;
+  @useResult
+  $Res call(
+      {@paymentMethodDetailJsonKey P24PaymentMethodDetails? paymentMethod,
+      @JsonKey(name: "return_url") String? returnUrl,
+      @JsonKey(name: "setup_future_usage")
+      PaymentIntentSetupFutureUsage? setupFutureUsage});
+
+  $P24PaymentMethodDetailsCopyWith<$Res>? get paymentMethod;
+}
+
+/// @nodoc
+class _$ConfirmP24PaymentDataCopyWithImpl<$Res,
+        $Val extends ConfirmP24PaymentData>
+    implements $ConfirmP24PaymentDataCopyWith<$Res> {
+  _$ConfirmP24PaymentDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ConfirmP24PaymentData
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? paymentMethod = freezed,
+    Object? returnUrl = freezed,
+    Object? setupFutureUsage = freezed,
+  }) {
+    return _then(_value.copyWith(
+      paymentMethod: freezed == paymentMethod
+          ? _value.paymentMethod
+          : paymentMethod // ignore: cast_nullable_to_non_nullable
+              as P24PaymentMethodDetails?,
+      returnUrl: freezed == returnUrl
+          ? _value.returnUrl
+          : returnUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      setupFutureUsage: freezed == setupFutureUsage
+          ? _value.setupFutureUsage
+          : setupFutureUsage // ignore: cast_nullable_to_non_nullable
+              as PaymentIntentSetupFutureUsage?,
+    ) as $Val);
+  }
+
+  /// Create a copy of ConfirmP24PaymentData
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $P24PaymentMethodDetailsCopyWith<$Res>? get paymentMethod {
+    if (_value.paymentMethod == null) {
+      return null;
+    }
+
+    return $P24PaymentMethodDetailsCopyWith<$Res>(_value.paymentMethod!,
+        (value) {
+      return _then(_value.copyWith(paymentMethod: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ConfirmP24PaymentDataImplCopyWith<$Res>
+    implements $ConfirmP24PaymentDataCopyWith<$Res> {
+  factory _$$ConfirmP24PaymentDataImplCopyWith(
+          _$ConfirmP24PaymentDataImpl value,
+          $Res Function(_$ConfirmP24PaymentDataImpl) then) =
+      __$$ConfirmP24PaymentDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@paymentMethodDetailJsonKey P24PaymentMethodDetails? paymentMethod,
+      @JsonKey(name: "return_url") String? returnUrl,
+      @JsonKey(name: "setup_future_usage")
+      PaymentIntentSetupFutureUsage? setupFutureUsage});
+
+  @override
+  $P24PaymentMethodDetailsCopyWith<$Res>? get paymentMethod;
+}
+
+/// @nodoc
+class __$$ConfirmP24PaymentDataImplCopyWithImpl<$Res>
+    extends _$ConfirmP24PaymentDataCopyWithImpl<$Res,
+        _$ConfirmP24PaymentDataImpl>
+    implements _$$ConfirmP24PaymentDataImplCopyWith<$Res> {
+  __$$ConfirmP24PaymentDataImplCopyWithImpl(_$ConfirmP24PaymentDataImpl _value,
+      $Res Function(_$ConfirmP24PaymentDataImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ConfirmP24PaymentData
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? paymentMethod = freezed,
+    Object? returnUrl = freezed,
+    Object? setupFutureUsage = freezed,
+  }) {
+    return _then(_$ConfirmP24PaymentDataImpl(
+      paymentMethod: freezed == paymentMethod
+          ? _value.paymentMethod
+          : paymentMethod // ignore: cast_nullable_to_non_nullable
+              as P24PaymentMethodDetails?,
+      returnUrl: freezed == returnUrl
+          ? _value.returnUrl
+          : returnUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      setupFutureUsage: freezed == setupFutureUsage
+          ? _value.setupFutureUsage
+          : setupFutureUsage // ignore: cast_nullable_to_non_nullable
+              as PaymentIntentSetupFutureUsage?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ConfirmP24PaymentDataImpl implements _ConfirmP24PaymentData {
+  const _$ConfirmP24PaymentDataImpl(
+      {@paymentMethodDetailJsonKey this.paymentMethod,
+      @JsonKey(name: "return_url") this.returnUrl,
+      @JsonKey(name: "setup_future_usage") this.setupFutureUsage});
+
+  factory _$ConfirmP24PaymentDataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ConfirmP24PaymentDataImplFromJson(json);
+
+  /// Either the id of an existing PaymentMethod, or an object containing
+  /// data to create a PaymentMethod with.
+  /// See the use case sections below for details.
+  @override
+  @paymentMethodDetailJsonKey
+  final P24PaymentMethodDetails? paymentMethod;
+
+  /// The url your customer will be directed to after they complete authentication.
+  @override
+  @JsonKey(name: "return_url")
+  final String? returnUrl;
+
+  /// To set up a SEPA Direct Debit payment method using the bank details
+  ///  from this iDEAL payment, set this parameter to off_session.
+  /// When using this parameter, a customer will need to be set on the
+  /// PaymentIntent. The newly created SEPA Direct Debit PaymentMethod
+  /// will be attached to this customer.
+  @override
+  @JsonKey(name: "setup_future_usage")
+  final PaymentIntentSetupFutureUsage? setupFutureUsage;
+
+  @override
+  String toString() {
+    return 'ConfirmP24PaymentData(paymentMethod: $paymentMethod, returnUrl: $returnUrl, setupFutureUsage: $setupFutureUsage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ConfirmP24PaymentDataImpl &&
+            (identical(other.paymentMethod, paymentMethod) ||
+                other.paymentMethod == paymentMethod) &&
+            (identical(other.returnUrl, returnUrl) ||
+                other.returnUrl == returnUrl) &&
+            (identical(other.setupFutureUsage, setupFutureUsage) ||
+                other.setupFutureUsage == setupFutureUsage));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, paymentMethod, returnUrl, setupFutureUsage);
+
+  /// Create a copy of ConfirmP24PaymentData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ConfirmP24PaymentDataImplCopyWith<_$ConfirmP24PaymentDataImpl>
+      get copyWith => __$$ConfirmP24PaymentDataImplCopyWithImpl<
+          _$ConfirmP24PaymentDataImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ConfirmP24PaymentDataImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ConfirmP24PaymentData implements ConfirmP24PaymentData {
+  const factory _ConfirmP24PaymentData(
+      {@paymentMethodDetailJsonKey final P24PaymentMethodDetails? paymentMethod,
+      @JsonKey(name: "return_url") final String? returnUrl,
+      @JsonKey(name: "setup_future_usage")
+      final PaymentIntentSetupFutureUsage?
+          setupFutureUsage}) = _$ConfirmP24PaymentDataImpl;
+
+  factory _ConfirmP24PaymentData.fromJson(Map<String, dynamic> json) =
+      _$ConfirmP24PaymentDataImpl.fromJson;
+
+  /// Either the id of an existing PaymentMethod, or an object containing
+  /// data to create a PaymentMethod with.
+  /// See the use case sections below for details.
+  @override
+  @paymentMethodDetailJsonKey
+  P24PaymentMethodDetails? get paymentMethod;
+
+  /// The url your customer will be directed to after they complete authentication.
+  @override
+  @JsonKey(name: "return_url")
+  String? get returnUrl;
+
+  /// To set up a SEPA Direct Debit payment method using the bank details
+  ///  from this iDEAL payment, set this parameter to off_session.
+  /// When using this parameter, a customer will need to be set on the
+  /// PaymentIntent. The newly created SEPA Direct Debit PaymentMethod
+  /// will be attached to this customer.
+  @override
+  @JsonKey(name: "setup_future_usage")
+  PaymentIntentSetupFutureUsage? get setupFutureUsage;
+
+  /// Create a copy of ConfirmP24PaymentData
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ConfirmP24PaymentDataImplCopyWith<_$ConfirmP24PaymentDataImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_data.g.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_data.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'confirm_p24_payment_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ConfirmP24PaymentDataImpl _$$ConfirmP24PaymentDataImplFromJson(Map json) =>
+    _$ConfirmP24PaymentDataImpl(
+      paymentMethod: json['payment_method'] == null
+          ? null
+          : P24PaymentMethodDetails.fromJson(
+              Map<String, dynamic>.from(json['payment_method'] as Map)),
+      returnUrl: json['return_url'] as String?,
+      setupFutureUsage: $enumDecodeNullable(
+          _$PaymentIntentSetupFutureUsageEnumMap, json['setup_future_usage']),
+    );
+
+Map<String, dynamic> _$$ConfirmP24PaymentDataImplToJson(
+        _$ConfirmP24PaymentDataImpl instance) =>
+    <String, dynamic>{
+      if (PaymentMethodDetails.toJsonConverter(instance.paymentMethod)
+          case final value?)
+        'payment_method': value,
+      if (instance.returnUrl case final value?) 'return_url': value,
+      if (_$PaymentIntentSetupFutureUsageEnumMap[instance.setupFutureUsage]
+          case final value?)
+        'setup_future_usage': value,
+    };
+
+const _$PaymentIntentSetupFutureUsageEnumMap = {
+  PaymentIntentSetupFutureUsage.onSession: 'on_session',
+  PaymentIntentSetupFutureUsage.offSession: 'off_session',
+};

--- a/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_options.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_options.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'confirm_p24_payment_options.freezed.dart';
+part 'confirm_p24_payment_options.g.dart';
+
+@freezed
+class ConfirmP24PaymentOptions with _$ConfirmP24PaymentOptions {
+  const factory ConfirmP24PaymentOptions({
+    /// Set this to false if you want to manually handle
+    /// the authorization redirect. Default is true.
+    @Default(true) bool? handleActions,
+  }) = _ConfirmP24PaymentOptions;
+
+  factory ConfirmP24PaymentOptions.fromJson(Map<String, dynamic> json) =>
+      _$ConfirmP24PaymentOptionsFromJson(json);
+}

--- a/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_options.freezed.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_options.freezed.dart
@@ -1,0 +1,179 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'confirm_p24_payment_options.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ConfirmP24PaymentOptions _$ConfirmP24PaymentOptionsFromJson(
+    Map<String, dynamic> json) {
+  return _ConfirmP24PaymentOptions.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ConfirmP24PaymentOptions {
+  /// Set this to false if you want to manually handle
+  /// the authorization redirect. Default is true.
+  bool? get handleActions => throw _privateConstructorUsedError;
+
+  /// Serializes this ConfirmP24PaymentOptions to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ConfirmP24PaymentOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ConfirmP24PaymentOptionsCopyWith<ConfirmP24PaymentOptions> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ConfirmP24PaymentOptionsCopyWith<$Res> {
+  factory $ConfirmP24PaymentOptionsCopyWith(ConfirmP24PaymentOptions value,
+          $Res Function(ConfirmP24PaymentOptions) then) =
+      _$ConfirmP24PaymentOptionsCopyWithImpl<$Res, ConfirmP24PaymentOptions>;
+  @useResult
+  $Res call({bool? handleActions});
+}
+
+/// @nodoc
+class _$ConfirmP24PaymentOptionsCopyWithImpl<$Res,
+        $Val extends ConfirmP24PaymentOptions>
+    implements $ConfirmP24PaymentOptionsCopyWith<$Res> {
+  _$ConfirmP24PaymentOptionsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ConfirmP24PaymentOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? handleActions = freezed,
+  }) {
+    return _then(_value.copyWith(
+      handleActions: freezed == handleActions
+          ? _value.handleActions
+          : handleActions // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ConfirmP24PaymentOptionsImplCopyWith<$Res>
+    implements $ConfirmP24PaymentOptionsCopyWith<$Res> {
+  factory _$$ConfirmP24PaymentOptionsImplCopyWith(
+          _$ConfirmP24PaymentOptionsImpl value,
+          $Res Function(_$ConfirmP24PaymentOptionsImpl) then) =
+      __$$ConfirmP24PaymentOptionsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool? handleActions});
+}
+
+/// @nodoc
+class __$$ConfirmP24PaymentOptionsImplCopyWithImpl<$Res>
+    extends _$ConfirmP24PaymentOptionsCopyWithImpl<$Res,
+        _$ConfirmP24PaymentOptionsImpl>
+    implements _$$ConfirmP24PaymentOptionsImplCopyWith<$Res> {
+  __$$ConfirmP24PaymentOptionsImplCopyWithImpl(
+      _$ConfirmP24PaymentOptionsImpl _value,
+      $Res Function(_$ConfirmP24PaymentOptionsImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ConfirmP24PaymentOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? handleActions = freezed,
+  }) {
+    return _then(_$ConfirmP24PaymentOptionsImpl(
+      handleActions: freezed == handleActions
+          ? _value.handleActions
+          : handleActions // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ConfirmP24PaymentOptionsImpl implements _ConfirmP24PaymentOptions {
+  const _$ConfirmP24PaymentOptionsImpl({this.handleActions = true});
+
+  factory _$ConfirmP24PaymentOptionsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ConfirmP24PaymentOptionsImplFromJson(json);
+
+  /// Set this to false if you want to manually handle
+  /// the authorization redirect. Default is true.
+  @override
+  @JsonKey()
+  final bool? handleActions;
+
+  @override
+  String toString() {
+    return 'ConfirmP24PaymentOptions(handleActions: $handleActions)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ConfirmP24PaymentOptionsImpl &&
+            (identical(other.handleActions, handleActions) ||
+                other.handleActions == handleActions));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, handleActions);
+
+  /// Create a copy of ConfirmP24PaymentOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ConfirmP24PaymentOptionsImplCopyWith<_$ConfirmP24PaymentOptionsImpl>
+      get copyWith => __$$ConfirmP24PaymentOptionsImplCopyWithImpl<
+          _$ConfirmP24PaymentOptionsImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ConfirmP24PaymentOptionsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ConfirmP24PaymentOptions implements ConfirmP24PaymentOptions {
+  const factory _ConfirmP24PaymentOptions({final bool? handleActions}) =
+      _$ConfirmP24PaymentOptionsImpl;
+
+  factory _ConfirmP24PaymentOptions.fromJson(Map<String, dynamic> json) =
+      _$ConfirmP24PaymentOptionsImpl.fromJson;
+
+  /// Set this to false if you want to manually handle
+  /// the authorization redirect. Default is true.
+  @override
+  bool? get handleActions;
+
+  /// Create a copy of ConfirmP24PaymentOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ConfirmP24PaymentOptionsImplCopyWith<_$ConfirmP24PaymentOptionsImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_options.g.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/confirm_p24_payment_options.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'confirm_p24_payment_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ConfirmP24PaymentOptionsImpl _$$ConfirmP24PaymentOptionsImplFromJson(
+        Map json) =>
+    _$ConfirmP24PaymentOptionsImpl(
+      handleActions: json['handleActions'] as bool? ?? true,
+    );
+
+Map<String, dynamic> _$$ConfirmP24PaymentOptionsImplToJson(
+        _$ConfirmP24PaymentOptionsImpl instance) =>
+    <String, dynamic>{
+      if (instance.handleActions case final value?) 'handleActions': value,
+    };

--- a/packages/stripe_js/lib/src/api/payment_intents/payment_intents.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/payment_intents.dart
@@ -6,6 +6,8 @@ export 'confirm_card_payment_data.dart';
 export 'confirm_card_payment_options.dart';
 export 'confirm_ideal_payment_data.dart';
 export 'confirm_ideal_payment_options.dart';
+export 'confirm_p24_payment_data.dart';
+export 'confirm_p24_payment_options.dart';
 export 'confirm_payment_options.dart';
 export 'confirm_sepa_debit_payment_data.dart';
 export 'payment_intent.dart';

--- a/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.dart
+++ b/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.dart
@@ -1,7 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:meta/meta_meta.dart';
 import 'package:stripe_js/src/api/converters/js_converter.dart';
 import 'package:stripe_js/stripe_api.dart';
-import 'package:meta/meta_meta.dart';
 
 part 'payment_method_details.freezed.dart';
 part 'payment_method_details.g.dart';
@@ -116,6 +116,31 @@ class IdealPaymentMethodDetails
 
   factory IdealPaymentMethodDetails.fromJson(Map<String, dynamic> json) =>
       _$IdealPaymentMethodDetailsFromJson(json);
+}
+
+@Freezed(unionKey: 'type')
+class P24PaymentMethodDetails
+    with _$P24PaymentMethodDetails
+    implements PaymentMethodDetails {
+  @FreezedUnionValue('p24')
+  @Implements<IdPaymentMethodDetails>()
+  const factory P24PaymentMethodDetails.id(String id) =
+      _IdP24PaymentMethodDetails;
+
+  /// Use stripe.confirmCardPayment with payment data from an Element by
+  /// passing a card or cardNumber Element as payment_method[card] in the
+  /// data argument.
+  ///
+  /// The new PaymentMethod will be created with data collected by the
+  /// Element and will be used to confirm the PaymentIntent.
+  @FreezedUnionValue('p24')
+  const factory P24PaymentMethodDetails({
+    /// The billing_details associated with the card.
+    @JsonKey(name: "billing_details") required BillingDetails? billingDetails,
+  }) = _P24PaymentMethodDetails;
+
+  factory P24PaymentMethodDetails.fromJson(Map<String, dynamic> json) =>
+      _$P24PaymentMethodDetailsFromJson(json);
 }
 
 /// An object detailing the customer's iDEAL bank.

--- a/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.freezed.dart
+++ b/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.freezed.dart
@@ -1512,6 +1512,457 @@ abstract class _IdealPaymentMethodDetailsSelfCollect
       get copyWith => throw _privateConstructorUsedError;
 }
 
+P24PaymentMethodDetails _$P24PaymentMethodDetailsFromJson(
+    Map<String, dynamic> json) {
+  switch (json['type']) {
+    case 'p24':
+      return _IdP24PaymentMethodDetails.fromJson(json);
+    case 'p24':
+      return _P24PaymentMethodDetails.fromJson(json);
+
+    default:
+      throw CheckedFromJsonException(json, 'type', 'P24PaymentMethodDetails',
+          'Invalid union type "${json['type']}"!');
+  }
+}
+
+/// @nodoc
+mixin _$P24PaymentMethodDetails {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: "billing_details") BillingDetails? billingDetails)
+        $default, {
+    required TResult Function(String id) id,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @JsonKey(name: "billing_details") BillingDetails? billingDetails)?
+        $default, {
+    TResult? Function(String id)? id,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: "billing_details") BillingDetails? billingDetails)?
+        $default, {
+    TResult Function(String id)? id,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_P24PaymentMethodDetails value) $default, {
+    required TResult Function(_IdP24PaymentMethodDetails value) id,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_P24PaymentMethodDetails value)? $default, {
+    TResult? Function(_IdP24PaymentMethodDetails value)? id,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_P24PaymentMethodDetails value)? $default, {
+    TResult Function(_IdP24PaymentMethodDetails value)? id,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+
+  /// Serializes this P24PaymentMethodDetails to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $P24PaymentMethodDetailsCopyWith<$Res> {
+  factory $P24PaymentMethodDetailsCopyWith(P24PaymentMethodDetails value,
+          $Res Function(P24PaymentMethodDetails) then) =
+      _$P24PaymentMethodDetailsCopyWithImpl<$Res, P24PaymentMethodDetails>;
+}
+
+/// @nodoc
+class _$P24PaymentMethodDetailsCopyWithImpl<$Res,
+        $Val extends P24PaymentMethodDetails>
+    implements $P24PaymentMethodDetailsCopyWith<$Res> {
+  _$P24PaymentMethodDetailsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of P24PaymentMethodDetails
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$IdP24PaymentMethodDetailsImplCopyWith<$Res> {
+  factory _$$IdP24PaymentMethodDetailsImplCopyWith(
+          _$IdP24PaymentMethodDetailsImpl value,
+          $Res Function(_$IdP24PaymentMethodDetailsImpl) then) =
+      __$$IdP24PaymentMethodDetailsImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String id});
+}
+
+/// @nodoc
+class __$$IdP24PaymentMethodDetailsImplCopyWithImpl<$Res>
+    extends _$P24PaymentMethodDetailsCopyWithImpl<$Res,
+        _$IdP24PaymentMethodDetailsImpl>
+    implements _$$IdP24PaymentMethodDetailsImplCopyWith<$Res> {
+  __$$IdP24PaymentMethodDetailsImplCopyWithImpl(
+      _$IdP24PaymentMethodDetailsImpl _value,
+      $Res Function(_$IdP24PaymentMethodDetailsImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of P24PaymentMethodDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+  }) {
+    return _then(_$IdP24PaymentMethodDetailsImpl(
+      null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$IdP24PaymentMethodDetailsImpl implements _IdP24PaymentMethodDetails {
+  const _$IdP24PaymentMethodDetailsImpl(this.id, {final String? $type})
+      : $type = $type ?? 'p24';
+
+  factory _$IdP24PaymentMethodDetailsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$IdP24PaymentMethodDetailsImplFromJson(json);
+
+  @override
+  final String id;
+
+  @JsonKey(name: 'type')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'P24PaymentMethodDetails.id(id: $id)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$IdP24PaymentMethodDetailsImpl &&
+            (identical(other.id, id) || other.id == id));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id);
+
+  /// Create a copy of P24PaymentMethodDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$IdP24PaymentMethodDetailsImplCopyWith<_$IdP24PaymentMethodDetailsImpl>
+      get copyWith => __$$IdP24PaymentMethodDetailsImplCopyWithImpl<
+          _$IdP24PaymentMethodDetailsImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: "billing_details") BillingDetails? billingDetails)
+        $default, {
+    required TResult Function(String id) id,
+  }) {
+    return id(this.id);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @JsonKey(name: "billing_details") BillingDetails? billingDetails)?
+        $default, {
+    TResult? Function(String id)? id,
+  }) {
+    return id?.call(this.id);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: "billing_details") BillingDetails? billingDetails)?
+        $default, {
+    TResult Function(String id)? id,
+    required TResult orElse(),
+  }) {
+    if (id != null) {
+      return id(this.id);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_P24PaymentMethodDetails value) $default, {
+    required TResult Function(_IdP24PaymentMethodDetails value) id,
+  }) {
+    return id(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_P24PaymentMethodDetails value)? $default, {
+    TResult? Function(_IdP24PaymentMethodDetails value)? id,
+  }) {
+    return id?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_P24PaymentMethodDetails value)? $default, {
+    TResult Function(_IdP24PaymentMethodDetails value)? id,
+    required TResult orElse(),
+  }) {
+    if (id != null) {
+      return id(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$IdP24PaymentMethodDetailsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _IdP24PaymentMethodDetails
+    implements P24PaymentMethodDetails, IdPaymentMethodDetails {
+  const factory _IdP24PaymentMethodDetails(final String id) =
+      _$IdP24PaymentMethodDetailsImpl;
+
+  factory _IdP24PaymentMethodDetails.fromJson(Map<String, dynamic> json) =
+      _$IdP24PaymentMethodDetailsImpl.fromJson;
+
+  String get id;
+
+  /// Create a copy of P24PaymentMethodDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$IdP24PaymentMethodDetailsImplCopyWith<_$IdP24PaymentMethodDetailsImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$P24PaymentMethodDetailsImplCopyWith<$Res> {
+  factory _$$P24PaymentMethodDetailsImplCopyWith(
+          _$P24PaymentMethodDetailsImpl value,
+          $Res Function(_$P24PaymentMethodDetailsImpl) then) =
+      __$$P24PaymentMethodDetailsImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({@JsonKey(name: "billing_details") BillingDetails? billingDetails});
+
+  $BillingDetailsCopyWith<$Res>? get billingDetails;
+}
+
+/// @nodoc
+class __$$P24PaymentMethodDetailsImplCopyWithImpl<$Res>
+    extends _$P24PaymentMethodDetailsCopyWithImpl<$Res,
+        _$P24PaymentMethodDetailsImpl>
+    implements _$$P24PaymentMethodDetailsImplCopyWith<$Res> {
+  __$$P24PaymentMethodDetailsImplCopyWithImpl(
+      _$P24PaymentMethodDetailsImpl _value,
+      $Res Function(_$P24PaymentMethodDetailsImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of P24PaymentMethodDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? billingDetails = freezed,
+  }) {
+    return _then(_$P24PaymentMethodDetailsImpl(
+      billingDetails: freezed == billingDetails
+          ? _value.billingDetails
+          : billingDetails // ignore: cast_nullable_to_non_nullable
+              as BillingDetails?,
+    ));
+  }
+
+  /// Create a copy of P24PaymentMethodDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $BillingDetailsCopyWith<$Res>? get billingDetails {
+    if (_value.billingDetails == null) {
+      return null;
+    }
+
+    return $BillingDetailsCopyWith<$Res>(_value.billingDetails!, (value) {
+      return _then(_value.copyWith(billingDetails: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$P24PaymentMethodDetailsImpl implements _P24PaymentMethodDetails {
+  const _$P24PaymentMethodDetailsImpl(
+      {@JsonKey(name: "billing_details") required this.billingDetails,
+      final String? $type})
+      : $type = $type ?? 'p24';
+
+  factory _$P24PaymentMethodDetailsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$P24PaymentMethodDetailsImplFromJson(json);
+
+  /// The billing_details associated with the card.
+  @override
+  @JsonKey(name: "billing_details")
+  final BillingDetails? billingDetails;
+
+  @JsonKey(name: 'type')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'P24PaymentMethodDetails(billingDetails: $billingDetails)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$P24PaymentMethodDetailsImpl &&
+            (identical(other.billingDetails, billingDetails) ||
+                other.billingDetails == billingDetails));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, billingDetails);
+
+  /// Create a copy of P24PaymentMethodDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$P24PaymentMethodDetailsImplCopyWith<_$P24PaymentMethodDetailsImpl>
+      get copyWith => __$$P24PaymentMethodDetailsImplCopyWithImpl<
+          _$P24PaymentMethodDetailsImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: "billing_details") BillingDetails? billingDetails)
+        $default, {
+    required TResult Function(String id) id,
+  }) {
+    return $default(billingDetails);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @JsonKey(name: "billing_details") BillingDetails? billingDetails)?
+        $default, {
+    TResult? Function(String id)? id,
+  }) {
+    return $default?.call(billingDetails);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: "billing_details") BillingDetails? billingDetails)?
+        $default, {
+    TResult Function(String id)? id,
+    required TResult orElse(),
+  }) {
+    if ($default != null) {
+      return $default(billingDetails);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_P24PaymentMethodDetails value) $default, {
+    required TResult Function(_IdP24PaymentMethodDetails value) id,
+  }) {
+    return $default(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_P24PaymentMethodDetails value)? $default, {
+    TResult? Function(_IdP24PaymentMethodDetails value)? id,
+  }) {
+    return $default?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_P24PaymentMethodDetails value)? $default, {
+    TResult Function(_IdP24PaymentMethodDetails value)? id,
+    required TResult orElse(),
+  }) {
+    if ($default != null) {
+      return $default(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$P24PaymentMethodDetailsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _P24PaymentMethodDetails implements P24PaymentMethodDetails {
+  const factory _P24PaymentMethodDetails(
+          {@JsonKey(name: "billing_details")
+          required final BillingDetails? billingDetails}) =
+      _$P24PaymentMethodDetailsImpl;
+
+  factory _P24PaymentMethodDetails.fromJson(Map<String, dynamic> json) =
+      _$P24PaymentMethodDetailsImpl.fromJson;
+
+  /// The billing_details associated with the card.
+  @JsonKey(name: "billing_details")
+  BillingDetails? get billingDetails;
+
+  /// Create a copy of P24PaymentMethodDetails
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$P24PaymentMethodDetailsImplCopyWith<_$P24PaymentMethodDetailsImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
 IdealBankData _$IdealBankDataFromJson(Map<String, dynamic> json) {
   return _IdealBankData.fromJson(json);
 }

--- a/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.g.dart
+++ b/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.g.dart
@@ -31,20 +31,14 @@ _$CardPaymentMethodDefaultImpl _$$CardPaymentMethodDefaultImplFromJson(
     );
 
 Map<String, dynamic> _$$CardPaymentMethodDefaultImplToJson(
-    _$CardPaymentMethodDefaultImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('card', const ElementConverter().toJson(instance.card));
-  writeNotNull('billing_details', instance.billingDetails?.toJson());
-  val['type'] = instance.$type;
-  return val;
-}
+        _$CardPaymentMethodDefaultImpl instance) =>
+    <String, dynamic>{
+      if (const ElementConverter().toJson(instance.card) case final value?)
+        'card': value,
+      if (instance.billingDetails?.toJson() case final value?)
+        'billing_details': value,
+      'type': instance.$type,
+    };
 
 _$CardPaymentMethodDetailsTokenImpl
     _$$CardPaymentMethodDetailsTokenImplFromJson(Map json) =>
@@ -59,21 +53,13 @@ _$CardPaymentMethodDetailsTokenImpl
         );
 
 Map<String, dynamic> _$$CardPaymentMethodDetailsTokenImplToJson(
-    _$CardPaymentMethodDetailsTokenImpl instance) {
-  final val = <String, dynamic>{
-    'card': instance.card.toJson(),
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('billing_details', instance.billingDetails?.toJson());
-  val['type'] = instance.$type;
-  return val;
-}
+        _$CardPaymentMethodDetailsTokenImpl instance) =>
+    <String, dynamic>{
+      'card': instance.card.toJson(),
+      if (instance.billingDetails?.toJson() case final value?)
+        'billing_details': value,
+      'type': instance.$type,
+    };
 
 _$IdIdealPaymentMethodDetailsImpl _$$IdIdealPaymentMethodDetailsImplFromJson(
         Map json) =>
@@ -101,20 +87,14 @@ _$IdealPaymentMethodDetailsImpl _$$IdealPaymentMethodDetailsImplFromJson(
     );
 
 Map<String, dynamic> _$$IdealPaymentMethodDetailsImplToJson(
-    _$IdealPaymentMethodDetailsImpl instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('ideal', const ElementConverter().toJson(instance.ideal));
-  writeNotNull('billing_details', instance.billingDetails?.toJson());
-  val['type'] = instance.$type;
-  return val;
-}
+        _$IdealPaymentMethodDetailsImpl instance) =>
+    <String, dynamic>{
+      if (const ElementConverter().toJson(instance.ideal) case final value?)
+        'ideal': value,
+      if (instance.billingDetails?.toJson() case final value?)
+        'billing_details': value,
+      'type': instance.$type,
+    };
 
 _$IdealPaymentMethodDetailsSelfCollectImpl
     _$$IdealPaymentMethodDetailsSelfCollectImplFromJson(Map json) =>
@@ -129,21 +109,45 @@ _$IdealPaymentMethodDetailsSelfCollectImpl
         );
 
 Map<String, dynamic> _$$IdealPaymentMethodDetailsSelfCollectImplToJson(
-    _$IdealPaymentMethodDetailsSelfCollectImpl instance) {
-  final val = <String, dynamic>{
-    'ideal': instance.ideal.toJson(),
-  };
+        _$IdealPaymentMethodDetailsSelfCollectImpl instance) =>
+    <String, dynamic>{
+      'ideal': instance.ideal.toJson(),
+      if (instance.billingDetails?.toJson() case final value?)
+        'billing_details': value,
+      'type': instance.$type,
+    };
 
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
+_$IdP24PaymentMethodDetailsImpl _$$IdP24PaymentMethodDetailsImplFromJson(
+        Map json) =>
+    _$IdP24PaymentMethodDetailsImpl(
+      json['id'] as String,
+      $type: json['type'] as String?,
+    );
 
-  writeNotNull('billing_details', instance.billingDetails?.toJson());
-  val['type'] = instance.$type;
-  return val;
-}
+Map<String, dynamic> _$$IdP24PaymentMethodDetailsImplToJson(
+        _$IdP24PaymentMethodDetailsImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.$type,
+    };
+
+_$P24PaymentMethodDetailsImpl _$$P24PaymentMethodDetailsImplFromJson(
+        Map json) =>
+    _$P24PaymentMethodDetailsImpl(
+      billingDetails: json['billing_details'] == null
+          ? null
+          : BillingDetails.fromJson(
+              Map<String, dynamic>.from(json['billing_details'] as Map)),
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$$P24PaymentMethodDetailsImplToJson(
+        _$P24PaymentMethodDetailsImpl instance) =>
+    <String, dynamic>{
+      if (instance.billingDetails?.toJson() case final value?)
+        'billing_details': value,
+      'type': instance.$type,
+    };
 
 _$IdealBankDataImpl _$$IdealBankDataImplFromJson(Map json) =>
     _$IdealBankDataImpl(

--- a/packages/stripe_js/lib/src/js/payment_intents/confirm_p24_payment.dart
+++ b/packages/stripe_js/lib/src/js/payment_intents/confirm_p24_payment.dart
@@ -1,0 +1,45 @@
+import 'dart:js_interop';
+
+import 'package:stripe_js/stripe_api.dart';
+import 'package:stripe_js/stripe_js.dart';
+
+import '../utils/utils.dart';
+
+extension ExtensionP24Payment on Stripe {
+  /// Use stripe.confirmP24Payment in the Przelewy24 (P24) Payments flow when the customer
+  /// submits your payment form. When called, it will confirm the PaymentIntent with the
+  /// data you provide and will automatically redirect the customer to authorize the
+  /// transaction. Once authorization is complete, the customer will be redirected
+  /// back to your specified return_url.
+  ///
+  /// When you confirm a PaymentIntent, it needs to have an attached PaymentMethod of type P24.
+  /// In addition to confirming the PaymentIntent, this method can automatically create
+  /// and attach a new PaymentMethod for you. If you have already attached a PaymentMethod,
+  /// you can call this method without needing to provide any additional data. These use cases
+  /// are detailed in the sections that follow.
+  ///
+  /// https://docs.stripe.com/js/payment_intents/confirm_p24_payment
+  ///
+  /// Note that stripe.confirmP24Payment may take several seconds to complete. During that
+  /// time, you should disable your form from being resubmitted and show a waiting indicator
+  /// like a spinner. If you receive an error result, you should be sure to show that error
+  /// to the customer, re-enable the form, and hide the waiting indicator.
+  Future<PaymentIntentResponse> confirmP24Payment(
+    String clientSecret, {
+    ConfirmP24PaymentData? data,
+    ConfirmP24PaymentOptions? options,
+  }) {
+    final jsData = (data?.toJson() ?? {}).jsify();
+    final jsOptions = (options?.toJson() ?? {}).jsify();
+    return _confirmP24Payment(clientSecret, jsData, jsOptions)
+        .toDart
+        .then((response) => response.toDart);
+  }
+
+  @JS('confirmP24Payment')
+  external JSPromise<JSIntentResponse> _confirmP24Payment(
+    String clientSecret, [
+    JSAny? data,
+    JSAny? options,
+  ]);
+}

--- a/packages/stripe_js/lib/src/js/payment_intents/payment_intents.dart
+++ b/packages/stripe_js/lib/src/js/payment_intents/payment_intents.dart
@@ -2,6 +2,7 @@ export 'confirm_acss_debit_payment.dart';
 export 'confirm_alipay_payment.dart';
 export 'confirm_card_payment.dart';
 export 'confirm_ideal_payment.dart';
+export 'confirm_p24_payment.dart';
 export 'confirm_payment.dart';
 export 'confirm_sepa_debit_payment.dart';
 export 'handle_card_action.dart';

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -1,7 +1,6 @@
 //@dart=2.12
 import 'dart:async';
 import 'dart:developer' as dev;
-import 'package:web/web.dart' as web;
 import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
@@ -10,6 +9,7 @@ import 'package:flutter_stripe_web/platform_pay_button.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:stripe_js/stripe_api.dart' as stripe_js;
 import 'package:stripe_js/stripe_js.dart' as stripe_js;
+import 'package:web/web.dart' as web;
 
 import 'parser/payment_intent.dart';
 import 'parser/payment_methods.dart';
@@ -173,6 +173,19 @@ class WebStripe extends StripePlatform {
           data: stripe_js.ConfirmIdealPaymentData(
             paymentMethod: stripe_js.IdealPaymentMethodDetails.withBank(
               ideal: stripe_js.IdealBankData(bank: paymentData.bankName!),
+            ),
+            returnUrl: urlScheme,
+            // recommended
+            // setup_future_usage:
+          ),
+        );
+      },
+      p24: (paymentData) {
+        return js.confirmP24Payment(
+          paymentIntentClientSecret,
+          data: stripe_js.ConfirmP24PaymentData(
+            paymentMethod: stripe_js.P24PaymentMethodDetails(
+              billingDetails: paymentData.billingDetails!.toJs(),
             ),
             returnUrl: urlScheme,
             // recommended


### PR DESCRIPTION
This pull request introduces support for confirming Przelewy24 (P24) payments in Flutter Web using the flutter_stripe and flutter_stripe_web packages. 

Key changes include:
* Implemented confirmP24Payment API for web integration.
* Ensured compatibility across flutter_stripe, stripe_js, and flutter_stripe_web.

Tested:
* Payment flow for P24 on web with redirection and return URL handling.