### PR TITLE
Fix Typos Across Multiple Files

### DIFF
--- a/docs/customer_sheet.mdx
+++ b/docs/customer_sheet.mdx
@@ -132,7 +132,7 @@ First initialize the customer sheet
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-              'Payment succesfully modified option selected: ${result?.paymentOption?.label}}'),
+              'Payment successfully modified option selected: ${result?.paymentOption?.label}}'),
         ),
       );
     } on Exception catch (e) {

--- a/docs/google_pay.mdx
+++ b/docs/google_pay.mdx
@@ -112,7 +112,7 @@ Then add the `startGooglePay` method to your screen.
           );
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-            content: Text('Google Pay payment succesfully completed')),
+            content: Text('Google Pay payment successfully completed')),
       );
     } catch (e) {
       if (e is StripeException) {
@@ -200,7 +200,7 @@ In the callback generate the correct stripe token and confirm the payment.
     );
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(
-          content: Text('Google Pay payment succesfully completed')),
+          content: Text('Google Pay payment successfully completed')),
     );
   } catch (e) {
     ScaffoldMessenger.of(context).showSnackBar(

--- a/docs/ideal.mdx
+++ b/docs/ideal.mdx
@@ -147,7 +147,7 @@ Future<void> _pay(BuildContext context) async{
       );
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Payment succesfully completed'),
+          content: Text('Payment successfully completed'),
         ),
       );
     } on Exception catch (e) {

--- a/example/lib/screens/payment_sheet/payment_sheet_deffered_screen.dart
+++ b/example/lib/screens/payment_sheet/payment_sheet_deffered_screen.dart
@@ -299,7 +299,7 @@ class _PaymentSheetScreenState extends State<PaymentSheetDefferedScreen> {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/payment_sheet/payment_sheet_screen.dart
+++ b/example/lib/screens/payment_sheet/payment_sheet_screen.dart
@@ -158,7 +158,7 @@ class _PaymentSheetScreenState extends State<PaymentSheetScreen> {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/payment_sheet/payment_sheet_screen_custom_flow.dart
+++ b/example/lib/screens/payment_sheet/payment_sheet_screen_custom_flow.dart
@@ -143,7 +143,7 @@ class _PaymentSheetScreenState extends State<PaymentSheetScreenWithCustomFlow> {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/regional_payment_methods/affirm_screen.dart
+++ b/example/lib/screens/regional_payment_methods/affirm_screen.dart
@@ -47,7 +47,7 @@ class AffirmScreen extends StatelessWidget {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/regional_payment_methods/ali_pay_screen.dart
+++ b/example/lib/screens/regional_payment_methods/ali_pay_screen.dart
@@ -49,7 +49,7 @@ class AliPayScreen extends StatelessWidget {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/regional_payment_methods/aubecs_debit.dart
+++ b/example/lib/screens/regional_payment_methods/aubecs_debit.dart
@@ -109,7 +109,7 @@ class _AubecsExampleState extends State<AubecsExample> {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/regional_payment_methods/cash_app_screen.dart
+++ b/example/lib/screens/regional_payment_methods/cash_app_screen.dart
@@ -50,7 +50,7 @@ class CashAppScreen extends StatelessWidget {
       if (!context.mounted) return;
       scaffoldMessenger.showSnackBar(
         const SnackBar(
-          content: Text('Payment succesfully completed'),
+          content: Text('Payment successfully completed'),
         ),
       );
     } on Exception catch (e) {

--- a/example/lib/screens/regional_payment_methods/fpx_screen.dart
+++ b/example/lib/screens/regional_payment_methods/fpx_screen.dart
@@ -51,7 +51,7 @@ class FpxScreen extends StatelessWidget {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/regional_payment_methods/grab_pay_screen.dart
+++ b/example/lib/screens/regional_payment_methods/grab_pay_screen.dart
@@ -66,7 +66,7 @@ class GrabPayScreen extends StatelessWidget {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/regional_payment_methods/ideal_screen.dart
+++ b/example/lib/screens/regional_payment_methods/ideal_screen.dart
@@ -54,7 +54,7 @@ class IdealScreen extends StatelessWidget {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/regional_payment_methods/klarna_screen.dart
+++ b/example/lib/screens/regional_payment_methods/klarna_screen.dart
@@ -64,7 +64,7 @@ class KlarnaScreen extends StatelessWidget {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/regional_payment_methods/paypal_screen.dart
+++ b/example/lib/screens/regional_payment_methods/paypal_screen.dart
@@ -82,7 +82,7 @@ class _PayPalScreenState extends State<PayPalScreen> {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/regional_payment_methods/sofort_screen.dart
+++ b/example/lib/screens/regional_payment_methods/sofort_screen.dart
@@ -49,7 +49,7 @@ class SofortScreen extends StatelessWidget {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/regional_payment_methods/us_bank_account_direct_debit_screen.dart
+++ b/example/lib/screens/regional_payment_methods/us_bank_account_direct_debit_screen.dart
@@ -166,7 +166,7 @@ class _UsBankAccountDirectDebitScreenState
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/example/lib/screens/regional_payment_methods/wechat_pay_screen.dart
+++ b/example/lib/screens/regional_payment_methods/wechat_pay_screen.dart
@@ -50,7 +50,7 @@ class WeChatPayScreen extends StatelessWidget {
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Payment succesfully completed'),
+          content: Text('Payment successfully completed'),
         ),
       );
     } on Exception catch (e) {

--- a/example/lib/screens/wallets/apple_pay_screen.dart
+++ b/example/lib/screens/wallets/apple_pay_screen.dart
@@ -150,7 +150,7 @@ class _ApplePayScreenState extends State<ApplePayScreen> {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           const SnackBar(
-              content: Text('Apple Pay payment succesfully completed')),
+              content: Text('Apple Pay payment successfully completed')),
         );
       }
     } catch (e) {

--- a/example/lib/screens/wallets/apple_pay_screen_plugin.dart
+++ b/example/lib/screens/wallets/apple_pay_screen_plugin.dart
@@ -96,7 +96,7 @@ class _ApplePayExternalPluginScreenState
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           const SnackBar(
-              content: Text('Apple Pay payment succesfully completed')),
+              content: Text('Apple Pay payment successfully completed')),
         );
       }
     } catch (e) {

--- a/example/lib/screens/wallets/google_pay_screen.dart
+++ b/example/lib/screens/wallets/google_pay_screen.dart
@@ -98,7 +98,7 @@ class _GooglePayScreenState extends State<GooglePayScreen> {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           const SnackBar(
-              content: Text('Google Pay payment succesfully completed')),
+              content: Text('Google Pay payment successfully completed')),
         );
       }
     } catch (e) {

--- a/example/lib/screens/wallets/google_pay_stripe_screen.dart
+++ b/example/lib/screens/wallets/google_pay_stripe_screen.dart
@@ -44,7 +44,7 @@ class _GooglePayStripeScreenState extends State<GooglePayStripeScreen> {
         if (context.mounted) {
           scaffoldMessenger.showSnackBar(
             const SnackBar(
-                content: Text('Google Pay payment succesfully completed')),
+                content: Text('Google Pay payment successfully completed')),
           );
         }
       } catch (e) {

--- a/example/lib/screens/wallets/payment_sheet_screen_subscription.dart
+++ b/example/lib/screens/wallets/payment_sheet_screen_subscription.dart
@@ -178,7 +178,7 @@ class _PaymentSheetScreenState extends State<ApplePayPaymentSheetScreen> {
       if (context.mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text('Payment succesfully completed'),
+            content: Text('Payment successfully completed'),
           ),
         );
       }

--- a/packages/stripe_checkout/lib/src/platforms/checkout.dart
+++ b/packages/stripe_checkout/lib/src/platforms/checkout.dart
@@ -9,7 +9,7 @@ class CheckoutResponse with _$CheckoutResponse {
   /// Web only
   const factory CheckoutResponse.redirected() = _Redirect;
 
-  /// The checkout payment has been completed succesfully
+  /// The checkout payment has been completed successfully
   /// Mobile only
   const factory CheckoutResponse.success() = _Success;
 


### PR DESCRIPTION
This PR addresses minor typos ("succesfully" -> "successfully") found in multiple files. 