### PR TITLE
Add missing setReturnUrlSchemeOnAndroid parameter passing to StripePlatform.

### DIFF
--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -100,7 +100,7 @@ class Stripe {
 
   /// Reconfigures the Stripe platform by applying the current values for
   /// [publishableKey], [merchantIdentifier], [stripeAccountId],
-  /// [threeDSecureParams], [urlScheme]
+  /// [threeDSecureParams], [urlScheme], [setReturnUrlSchemeOnAndroid]
   Future<void> applySettings() => _initialise(
         publishableKey: publishableKey,
         merchantIdentifier: merchantIdentifier,
@@ -716,6 +716,7 @@ class Stripe {
       threeDSecureParams: threeDSecureParams,
       merchantIdentifier: merchantIdentifier,
       urlScheme: urlScheme,
+      setReturnUrlSchemeOnAndroid: setReturnUrlSchemeOnAndroid,
     );
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter-stripe/flutter_stripe/issues/2061

- Adds missing `setReturnUrlSchemeOnAndroid` parameter passing to `StripePlatform` when calling `Stripe.instance.applySettings()`
- Updates `applySettings` function's docs