### PR TITLE
Fix: move getClientSecret invocation after first frame

### DIFF
--- a/example/lib/screens/payment_sheet/express_checkout/express_checkout_element.dart
+++ b/example/lib/screens/payment_sheet/express_checkout/express_checkout_element.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:http/http.dart' as http;
 import 'package:stripe_example/config.dart';
 import 'package:stripe_example/widgets/loading_button.dart';
@@ -21,7 +22,9 @@ class ThemeCardExampleState extends State<ExpressCheckoutElementExample> {
   @override
   void initState() {
     super.initState();
-    getClientSecret();
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      getClientSecret();
+    });
   }
 
   Future<void> getClientSecret() async {

--- a/example/lib/screens/payment_sheet/payment_element/payment_element.dart
+++ b/example/lib/screens/payment_sheet/payment_element/payment_element.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:http/http.dart' as http;
 import 'package:stripe_example/config.dart';
 import 'package:stripe_example/widgets/loading_button.dart';
@@ -20,8 +21,10 @@ class _ThemeCardExampleState extends State<PaymentElementExample> {
 
   @override
   void initState() {
-    getClientSecret();
     super.initState();
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      getClientSecret();
+    });
   }
 
   Future<void> getClientSecret() async {


### PR DESCRIPTION
### Why
Trying the app on web, `Express checkout` and `Web Payment Element` has infinite loading due to an exception from `ScaffoldMessenger.of(context);` of `getClientSecret` method.

### What
Invoke `getClientSecret` after first frame. 

```
@override
  void initState() {
    super.initState();
    SchedulerBinding.instance.addPostFrameCallback((_) {
      getClientSecret();
    });
  }
```

### Video

https://github.com/user-attachments/assets/e22fda96-fe7c-4be9-af4a-99c5640b6855


