### PR TITLE
Make iDEAL bank property optional.

### DIFF
--- a/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.dart
+++ b/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.dart
@@ -148,7 +148,7 @@ class P24PaymentMethodDetails
 class IdealBankData with _$IdealBankData {
   const factory IdealBankData({
     /// The customer's bank.
-    required String bank,
+    String? bank,
   }) = _IdealBankData;
 
   factory IdealBankData.fromJson(Map<String, dynamic> json) =>

--- a/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.freezed.dart
+++ b/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.freezed.dart
@@ -1970,7 +1970,7 @@ IdealBankData _$IdealBankDataFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$IdealBankData {
   /// The customer's bank.
-  String get bank => throw _privateConstructorUsedError;
+  String? get bank => throw _privateConstructorUsedError;
 
   /// Serializes this IdealBankData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -1988,7 +1988,7 @@ abstract class $IdealBankDataCopyWith<$Res> {
           IdealBankData value, $Res Function(IdealBankData) then) =
       _$IdealBankDataCopyWithImpl<$Res, IdealBankData>;
   @useResult
-  $Res call({String bank});
+  $Res call({String? bank});
 }
 
 /// @nodoc
@@ -2006,13 +2006,13 @@ class _$IdealBankDataCopyWithImpl<$Res, $Val extends IdealBankData>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? bank = null,
+    Object? bank = freezed,
   }) {
     return _then(_value.copyWith(
-      bank: null == bank
+      bank: freezed == bank
           ? _value.bank
           : bank // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
     ) as $Val);
   }
 }
@@ -2025,7 +2025,7 @@ abstract class _$$IdealBankDataImplCopyWith<$Res>
       __$$IdealBankDataImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String bank});
+  $Res call({String? bank});
 }
 
 /// @nodoc
@@ -2041,13 +2041,13 @@ class __$$IdealBankDataImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? bank = null,
+    Object? bank = freezed,
   }) {
     return _then(_$IdealBankDataImpl(
-      bank: null == bank
+      bank: freezed == bank
           ? _value.bank
           : bank // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
     ));
   }
 }
@@ -2055,14 +2055,14 @@ class __$$IdealBankDataImplCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$IdealBankDataImpl implements _IdealBankData {
-  const _$IdealBankDataImpl({required this.bank});
+  const _$IdealBankDataImpl({this.bank});
 
   factory _$IdealBankDataImpl.fromJson(Map<String, dynamic> json) =>
       _$$IdealBankDataImplFromJson(json);
 
   /// The customer's bank.
   @override
-  final String bank;
+  final String? bank;
 
   @override
   String toString() {
@@ -2098,15 +2098,14 @@ class _$IdealBankDataImpl implements _IdealBankData {
 }
 
 abstract class _IdealBankData implements IdealBankData {
-  const factory _IdealBankData({required final String bank}) =
-      _$IdealBankDataImpl;
+  const factory _IdealBankData({final String? bank}) = _$IdealBankDataImpl;
 
   factory _IdealBankData.fromJson(Map<String, dynamic> json) =
       _$IdealBankDataImpl.fromJson;
 
   /// The customer's bank.
   @override
-  String get bank;
+  String? get bank;
 
   /// Create a copy of IdealBankData
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.g.dart
+++ b/packages/stripe_js/lib/src/api/payment_methods/payment_method_details.g.dart
@@ -151,12 +151,12 @@ Map<String, dynamic> _$$P24PaymentMethodDetailsImplToJson(
 
 _$IdealBankDataImpl _$$IdealBankDataImplFromJson(Map json) =>
     _$IdealBankDataImpl(
-      bank: json['bank'] as String,
+      bank: json['bank'] as String?,
     );
 
 Map<String, dynamic> _$$IdealBankDataImplToJson(_$IdealBankDataImpl instance) =>
     <String, dynamic>{
-      'bank': instance.bank,
+      if (instance.bank case final value?) 'bank': value,
     };
 
 _$CardTokenPaymentMethodImpl _$$CardTokenPaymentMethodImplFromJson(Map json) =>

--- a/packages/stripe_js/test/src/api/payment_intents/confirm_ideal_payment_data_test.dart
+++ b/packages/stripe_js/test/src/api/payment_intents/confirm_ideal_payment_data_test.dart
@@ -37,7 +37,7 @@ void main() {
       );
     });
 
-    test('with token parses correctly', () {
+    test('with bank parses correctly when bank is not null', () {
       expect(
         ConfirmIdealPaymentData(
           paymentMethod: IdealPaymentMethodDetails.withBank(
@@ -56,6 +56,27 @@ void main() {
         },
       );
     });
+
+    test('with bank parses correctly when bank is null', () {
+      expect(
+        ConfirmIdealPaymentData(
+          paymentMethod: IdealPaymentMethodDetails.withBank(
+            ideal: IdealBankData(bank: null),
+            billingDetails: BillingDetails(name: 'Jenny Rosen'),
+          ),
+        ).toJson(),
+        {
+          "payment_method": {
+            "ideal": {},
+            "type": "ideal",
+            "billing_details": {
+              "name": "Jenny Rosen",
+            },
+          }
+        },
+      );
+    });
+
     test('extra params parse correctly', () {
       expect(
         ConfirmIdealPaymentData(

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -165,13 +165,12 @@ class WebStripe extends StripePlatform {
         );
       },
       ideal: (paymentData) {
-        if (paymentData.bankName == null) throw 'bankName is required for web';
-        // https://stripe.com/docs/js/payment_intents/confirm_alipay_payment#stripe_confirm_alipay_payment-options
+        // https://stripe.com/docs/js/payment_intents/confirm_ideal_payment#stripe_confirm_ideal_payment-self_collected
         return js.confirmIdealPayment(
           paymentIntentClientSecret,
           data: stripe_js.ConfirmIdealPaymentData(
             paymentMethod: stripe_js.IdealPaymentMethodDetails.withBank(
-              ideal: stripe_js.IdealBankData(bank: paymentData.bankName!),
+              ideal: stripe_js.IdealBankData(bank: paymentData.bankName),
             ),
             returnUrl: urlScheme,
             // recommended
@@ -209,13 +208,12 @@ class WebStripe extends StripePlatform {
   Future<PaymentIntent> confirmIdealPayment(
       String paymentIntentClientSecret, PaymentMethodDataIdeal paymentData,
       {String? returnUrl}) async {
-    if (paymentData.bankName == null) throw 'bankName is required for web';
-    // https://stripe.com/docs/js/payment_intents/confirm_alipay_payment#stripe_confirm_alipay_payment-options
+    // https://stripe.com/docs/js/payment_intents/confirm_ideal_payment#stripe_confirm_ideal_payment-self_collected
     final response = await js.confirmIdealPayment(
       paymentIntentClientSecret,
       data: stripe_js.ConfirmIdealPaymentData(
         paymentMethod: stripe_js.IdealPaymentMethodDetails.withBank(
-          ideal: stripe_js.IdealBankData(bank: paymentData.bankName!),
+          ideal: stripe_js.IdealBankData(bank: paymentData.bankName),
         ),
         returnUrl: returnUrl ?? urlScheme,
       ),


### PR DESCRIPTION
### Context:
> https://support.stripe.com/questions/make-required-changes-to-your-ideal-api-integration
> 
> Starting July 2024, [iDEAL](https://docs.stripe.com/payments/ideal) no longer expects merchants to display a bank selector on their checkouts. Instead, as part of the new iDEAL 2.0 experience, customers will choose their bank on the new iDEAL hosted bank selection page. By the end of 2024, you should stop sending the customer’s bank on your API requests to create an iDEAL payment, unless it’s a returning customer and you already know their bank.
> What you need to change
> 
> For payments created for a customer paying with iDEAL for ** the first time**, you need to:
> - Stop requesting the customer's iDEAL bank on your checkout page
> - Stop sending the `[payment_method_data[ideal][bank]]`(https://docs.stripe.com/api/payment_intents/create#create_payment_intent-payment_method_data-ideal-bank) parameter on Payment Intent and Setup Intent confirmation requests, or the `ideal[bank]` on Sources creation requests.
> 
> For **returning customers**, you can store the bank returned by Stripe on `payment_method_data[ideal][bank]` on Payment Intents and Setup Intents, or `ideal[bank]` on Sources, and pass it on future payment confirmations. This skips the iDEAL bank selector page and takes your customer directly to their issuing bank.
> 
> If you want your customer to select a new bank, you need to create a payment without specifying the issuing bank. Only pass a different bank on future payment requests after your customer has gone to the iDEAL bank selection page again and you received the new bank from the Stripe API.
> 
> <img width=400 src="https://github.com/user-attachments/assets/5cd1e7d9-99f5-4026-a71c-75039e23d67e">

### PR description:
This PR makes the `bank` parameter of `stripe_js.IdealBankData` optional. This way, developers can decide whether to force users to use a specific bank or to allow users to select one on the iDEAL bank selection page.

| `bank` parameter is null  | `bank` parameter is set |
| ------------- | ------------- |
| <img src="https://github.com/user-attachments/assets/830bbf72-e7a5-4ccb-9cdd-9a37800548da">  | <img src="https://github.com/user-attachments/assets/ee59e8aa-bb1c-4612-81d7-e4debfb45334">  |