### PR TITLE
Fix/2130 dart UI web

### DIFF
--- a/packages/stripe_web/CHANGELOG.md
+++ b/packages/stripe_web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.4.1
+- remove usage of `dart:ui` in favor of `dart:ui_web`
+
 ## 6.4.0
 
 **Features**

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -1,7 +1,6 @@
 //@dart=2.12
 import 'dart:async';
 import 'dart:developer' as dev;
-import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_stripe_web/flutter_stripe_web.dart';
@@ -471,7 +470,7 @@ class WebStripe extends StripePlatform {
   @override
   Widget buildPaymentRequestButton({
     Key? key,
-    required ui.VoidCallback onPressed,
+    required void Function() onPressed,
     required PlatformPayWebPaymentRequestCreateOptions
         paymentRequestCreateOptions,
     BoxConstraints? constraints,

--- a/packages/stripe_web/lib/src/widgets/platform_pay_button.dart
+++ b/packages/stripe_web/lib/src/widgets/platform_pay_button.dart
@@ -1,5 +1,5 @@
 import 'dart:js_interop';
-import 'dart:ui' as ui;
+import 'dart:ui_web' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_stripe_web/flutter_stripe_web.dart';
@@ -23,7 +23,7 @@ class WebPlatformPayButton extends StatefulWidget {
   final PlatformButtonType? type;
   final PlatformButtonStyle? style;
   final BoxConstraints? constraints;
-  final ui.VoidCallback onPressed;
+  final void Function() onPressed;
 
   @override
   State<StatefulWidget> createState() {
@@ -70,7 +70,6 @@ class _WebPlatformPayButtonState extends State<WebPlatformPayButton> {
 
   @override
   void initState() {
-    // ignore: undefined_prefixed_name
     ui.platformViewRegistry.registerViewFactory(
         'stripe_platform_pay_button', (int viewId) => _divElement);
 

--- a/packages/stripe_web/pubspec.yaml
+++ b/packages/stripe_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_stripe_web
 description: Stripe sdk bindings for the Flutter web platform. This package contains the implementation of the platform interface for web.
-version: 6.4.0
+version: 6.4.1
 homepage: https://github.com/flutter-stripe/flutter_stripe
 
 environment:


### PR DESCRIPTION
uses `dart:ui_web` instead of `dart:ui`

should fix #2130
