### PR TITLE
patch(setup intent):Add support for cardFromMethodId in confirmSetupI…

### DIFF
--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -254,21 +254,35 @@ class WebStripe extends StripePlatform {
     PaymentMethodParams data,
     PaymentMethodOptions? options,
   ) async {
-    final response = await data
-        .maybeWhen<Future<stripe_js.SetupIntentResponse>>(card: (params) {
-      final data = stripe_js.ConfirmCardSetupData(
-        paymentMethod: stripe_js.CardPaymentMethodDetails(
-          card: element!,
-          billingDetails: params.billingDetails?.toJs(),
-        ),
-      );
-      return js.confirmCardSetup(
-        setupIntentClientSecret,
-        data: data,
-      );
-    }, orElse: () {
-      throw UnimplementedError();
-    });
+    final response =
+        await data.maybeWhen<Future<stripe_js.SetupIntentResponse>>(
+      card: (params) {
+        final data = stripe_js.ConfirmCardSetupData(
+          paymentMethod: stripe_js.CardPaymentMethodDetails(
+            card: element!,
+            billingDetails: params.billingDetails?.toJs(),
+          ),
+        );
+        return js.confirmCardSetup(
+          setupIntentClientSecret,
+          data: data,
+        );
+      },
+      cardFromMethodId: (params) {
+        final data = stripe_js.ConfirmCardSetupData(
+          paymentMethod: stripe_js.CardPaymentMethodDetails.id(
+            params.paymentMethodId,
+          ),
+        );
+        return js.confirmCardSetup(
+          setupIntentClientSecret,
+          data: data,
+        );
+      },
+      orElse: () {
+        throw UnimplementedError();
+      },
+    );
     if (response.error != null) {
       throw response.error!;
     }


### PR DESCRIPTION
The flutter_stripe package provides robust support for mobile platforms but has limited functionality on the web. Notably, methods like confirmCardSetup are not implemented for Flutter Web, leading to errors when invoked.