### PR TITLE
fix: changed type of create from string to num in payment_intents model

### DIFF
--- a/packages/stripe_platform_interface/lib/src/models/payment_intents.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_intents.dart
@@ -25,7 +25,7 @@ class PaymentIntent with _$PaymentIntent {
     required num amount,
 
     /// Timestamp since epoch that represents the time the intent is created.
-    required String created,
+    required num created,
 
     /// The three letter ISO 4217 code for the currency.
     required String currency,


### PR DESCRIPTION
From API response we got num type of create variable, not String

https://docs.stripe.com/api/payment_intents/create?lang=curl