### PR TITLE
fix: changed type of created from string to num in payment_intent.dart

### DIFF
--- a/packages/stripe_platform_interface/lib/src/models/payment_intents.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_intents.dart
@@ -25,7 +25,7 @@ class PaymentIntent with _$PaymentIntent {
     required num amount,
 
     /// Timestamp since epoch that represents the time the intent is created.
-    required String created,
+    required num created,
 
     /// The three letter ISO 4217 code for the currency.
     required String currency,


### PR DESCRIPTION
Hi, while deserializing the response from the Stripe API using fromJson, an error occurred because the created field is returned as a number (UNIX timestamp), not a string. According to the Stripe documentation: https://docs.stripe.com/api/payment_intents/create?lang=curl the created field is of type number.

This change updates the created variable to use num instead of string, ensuring compatibility with the API response and preventing deserialization errors.