### PR TITLE
fixed: incorrect to register cancel callback in PaymentRequest

### DIFF
--- a/packages/stripe_js/lib/src/js/payment_requests/payment_request.dart
+++ b/packages/stripe_js/lib/src/js/payment_requests/payment_request.dart
@@ -36,7 +36,7 @@ class PaymentRequest {
   }
 
   void onCancel(void Function() callback) {
-    _js.on('cancel', ([_]) => callback);
+    _js.on('cancel', ([_]) => callback());
   }
 }
 


### PR DESCRIPTION
When cancel Google Pay in chrome, never show the native payment sheet again.
After use the correct invoke, the issue has gone.