### PR TITLE
fix: add missing param to collectBankAccountToken method channel

### DIFF
--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -619,7 +619,10 @@ class Stripe {
     CollectBankAccountTokenParams? params,
   }) async {
     try {
-      return _platform.collectBankAccountToken(clientSecret: clientSecret);
+      return _platform.collectBankAccountToken(
+        clientSecret: clientSecret,
+        params: params,
+      );
     } on StripeError {
       rethrow;
     }


### PR DESCRIPTION
Should fix the main issue reported on #2180. 