### PR TITLE
docs: makes Recommend Usage linkable in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Stripe Flutter SDK allows you to build delightful payment experiences in you
 
 **Pre-built payments UI**: Learn how to integrate Payment Sheet, the new pre-built payments UI for mobile apps. This pre-built UI lets you accept cards, Apple Pay, and Google Pay out of the box, and includes support for saving & reusing cards.
 
-#### Recommended usage
+### Recommended usage
 
 If you're selling digital products or services within your app, (e.g. subscriptions, in-game currencies, game levels, access to premium content, or unlocking a full version), you must use the app store's in-app purchase APIs. This does not apply to app developers in the USA as they are excluded by new court ruling in 2025. See [Apple's](https://developer.apple.com/app-store/review/guidelines/#payments) and [Google's](https://support.google.com/googleplay/android-developer/answer/9858738?hl=en&ref_topic=9857752) guidelines for more information. For all other scenarios you can use this SDK to process payments via Stripe.
 


### PR DESCRIPTION
Description:
This PR updates the README file to make the section about Recommended Usage for In-App Purchases directly linkable. This allows contributors and users to share a URL that jumps straight to that part of the instructions when answering common questions.

Changes:
Added a markdown anchor for the "In-App Purchases" section in the README.
From `####` to `###`.

Why:
Users often ask about when to use in-app purchases over PSPs when developing a mobile app. This is one of the most frequently asked question in the **rFlutterDev**'s Discord channel regarding payments. Being able to share a direct link to that section in the README improves accessibility and support efficiency. If this PR was merged, we can send a link like this:

https://pub.dev/packages/flutter_stripe#recommended-usage

No functional changes to the codebase.