### PR TITLE
Fix compilation issue with the stripe_ios package when using SPM

### DIFF
--- a/packages/stripe/CHANGELOG.md
+++ b/packages/stripe/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 12.0.2
+- fix compilation issue with the stripe_ios package when using SPM
+
 ## 12.0.1
 - fix compilation issue with the stripe_android package
 

--- a/packages/stripe/pubspec.yaml
+++ b/packages/stripe/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
   meta: ^1.8.0
   stripe_android: ^12.0.1
-  stripe_ios: ^12.0.0
+  stripe_ios: ^12.0.1
   stripe_platform_interface: ^12.0.0
 dev_dependencies:
   flutter_test:

--- a/packages/stripe/pubspec.yaml
+++ b/packages/stripe/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_stripe
 description: Flutter library for Stripe. Supports PaymentSheets, Apple & Google Pay, SCA, PSD2 and much more.
-version: 12.0.1
+version: 12.0.2
 homepage: https://github.com/flutter-stripe/flutter_stripe
 repository: https://github.com/flutter-stripe/flutter_stripe
 

--- a/packages/stripe_ios/CHANGELOG.md
+++ b/packages/stripe_ios/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 12.0.1
+- fix compilation issue with the stripe_ios package when using SPM
+
 ## 12.0.0
 
 **Breaking changes**

--- a/packages/stripe_ios/ios/stripe_ios/Package.resolved
+++ b/packages/stripe_ios/ios/stripe_ios/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stripe/stripe-ios-spm",
       "state" : {
-        "revision" : "f61cacd2da96a72cb0e454e58ed90b12182e5b98",
-        "version" : "24.7.0"
+        "revision" : "4f322eb59a7f49a239a36078357c4cac7dac07cd",
+        "version" : "24.16.1"
       }
     }
   ],

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 @_spi(EmbeddedPaymentElementPrivateBeta) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(CustomPaymentMethodsBeta) import StripePaymentSheet
+import UIKit
 
 @objc(StripeSdkImpl)
 extension StripeSdkImpl {

--- a/packages/stripe_ios/pubspec.yaml
+++ b/packages/stripe_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stripe_ios
 description: Stripe platform implementation for iOS
-version: 12.0.0
+version: 12.0.1
 repository: https://github.com/flutter-stripe/flutter_stripe
 homepage: https://pub.dev/packages/flutter_stripe
 


### PR DESCRIPTION
### DESCRIPTION

- This PR adds a missing `UIKit` import to resolve a compilation issue that occurs with the `stripe_ios` package when using SPM.