### PR TITLE
Add EmbeddedPaymentElement support for Flutter

### DIFF
--- a/packages/stripe/lib/flutter_stripe.dart
+++ b/packages/stripe/lib/flutter_stripe.dart
@@ -7,5 +7,7 @@ export 'src/widgets/adress_sheet.dart';
 export 'src/widgets/aubecs_debit_form.dart';
 export 'src/widgets/card_field.dart';
 export 'src/widgets/card_form_field.dart';
+export 'src/widgets/embedded_payment_element.dart';
+export 'src/widgets/embedded_payment_element_controller.dart';
 // export 'src/widgets/google_pay_button.dart';
 export 'src/widgets/platform_pay_button.dart';

--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -568,6 +568,12 @@ class Stripe {
     return await _platform.confirmationTokenCreationCallback(params);
   }
 
+  /// Registers a callback that the native embedded element invokes when it
+  /// needs the app to create an intent client secret.
+  void setConfirmHandler(ConfirmHandler? handler) {
+    _platform.setConfirmHandler(handler);
+  }
+
   /// Call this method when the user logs out from your app.
   ///
   /// This will ensure that any persisted authentication state in the

--- a/packages/stripe/lib/src/widgets/embedded_payment_element.dart
+++ b/packages/stripe/lib/src/widgets/embedded_payment_element.dart
@@ -1,0 +1,305 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_stripe/flutter_stripe.dart';
+
+/// Called when the user selects or clears a payment method.
+typedef PaymentOptionChangedCallback =
+    void Function(PaymentSheetPaymentOption? paymentOption);
+
+/// Called when the embedded payment element's height changes.
+typedef HeightChangedCallback = void Function(double height);
+
+/// Called when the embedded payment element fails to load.
+typedef LoadingFailedCallback = void Function(String message);
+
+/// Called when form sheet confirmation completes.
+typedef FormSheetConfirmCompleteCallback =
+    void Function(Map<String, dynamic> result);
+
+/// Called when a row is selected with immediate action behavior.
+typedef RowSelectionImmediateActionCallback = void Function();
+
+/// A widget that displays Stripe's Embedded Payment Element.
+///
+/// Allows users to select and configure payment methods inline within your app.
+/// Supports saved payment methods, new cards, Apple Pay, Google Pay, and more.
+///
+/// Only supported on iOS and Android platforms.
+class EmbeddedPaymentElement extends StatefulWidget {
+  /// Creates an embedded payment element.
+  const EmbeddedPaymentElement({
+    required this.intentConfiguration,
+    required this.configuration,
+    this.controller,
+    this.onPaymentOptionChanged,
+    this.onHeightChanged,
+    this.onLoadingFailed,
+    this.onFormSheetConfirmComplete,
+    this.onRowSelectionImmediateAction,
+    super.key,
+    this.androidPlatformViewRenderType =
+        AndroidPlatformViewRenderType.expensiveAndroidView,
+  });
+
+  /// Configuration for creating the payment or setup intent.
+  final IntentConfiguration intentConfiguration;
+
+  /// Configuration for appearance and behavior.
+  final SetupPaymentSheetParameters configuration;
+
+  /// Optional controller for programmatic control.
+  final EmbeddedPaymentElementController? controller;
+
+  /// Called when payment method selection changes.
+  final PaymentOptionChangedCallback? onPaymentOptionChanged;
+
+  /// Called when the element's height changes.
+  final HeightChangedCallback? onHeightChanged;
+
+  /// Called when loading fails.
+  final LoadingFailedCallback? onLoadingFailed;
+
+  /// Called when form sheet confirmation completes.
+  final FormSheetConfirmCompleteCallback? onFormSheetConfirmComplete;
+
+  /// Called when row selection triggers immediate action.
+  final RowSelectionImmediateActionCallback? onRowSelectionImmediateAction;
+
+  /// Android platform view rendering mode.
+  final AndroidPlatformViewRenderType androidPlatformViewRenderType;
+
+  @override
+  State<EmbeddedPaymentElement> createState() => _EmbeddedPaymentElementState();
+}
+
+class _EmbeddedPaymentElementState extends State<EmbeddedPaymentElement>
+    implements EmbeddedPaymentElementContext {
+  EmbeddedPaymentElementController? _fallbackController;
+  EmbeddedPaymentElementController get controller {
+    if (widget.controller != null) return widget.controller!;
+    _fallbackController ??= EmbeddedPaymentElementController();
+    return _fallbackController!;
+  }
+
+  MethodChannel? _methodChannel;
+  double _currentHeight = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    controller.attach(this);
+    if (widget.intentConfiguration.confirmHandler != null) {
+      Stripe.instance.setConfirmHandler(
+        widget.intentConfiguration.confirmHandler!,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    controller.detach(this);
+    _fallbackController?.dispose();
+    if (widget.intentConfiguration.confirmHandler != null) {
+      Stripe.instance.setConfirmHandler(null);
+    }
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(EmbeddedPaymentElement oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.controller != oldWidget.controller) {
+      oldWidget.controller?.detach(this);
+      controller.attach(this);
+    }
+  }
+
+  @override
+  Future<Map<String, dynamic>?> confirm() async {
+    final result = await _methodChannel?.invokeMethod('confirm');
+    if (result is Map) {
+      return Map<String, dynamic>.from(result);
+    }
+    return null;
+  }
+
+  @override
+  Future<void> clearPaymentOption() async {
+    await _methodChannel?.invokeMethod('clearPaymentOption');
+  }
+
+  void _onPlatformViewCreated(int viewId) {
+    _methodChannel = MethodChannel(
+      'flutter.stripe/embedded_payment_element/$viewId',
+    );
+    _methodChannel?.setMethodCallHandler(_handleMethodCall);
+  }
+
+  Future<void> _handleMethodCall(MethodCall call) async {
+    try {
+      switch (call.method) {
+        case 'onPaymentOptionChanged':
+          final arguments = call.arguments as Map?;
+          if (arguments != null) {
+            final paymentOptionMap = Map<String, dynamic>.from(
+              arguments['paymentOption'] ?? {},
+            );
+            if (paymentOptionMap.isNotEmpty) {
+              final paymentOption = PaymentSheetPaymentOption.fromJson(
+                paymentOptionMap,
+              );
+              widget.onPaymentOptionChanged?.call(paymentOption);
+            } else {
+              widget.onPaymentOptionChanged?.call(null);
+            }
+          }
+          break;
+        case 'onHeightChanged':
+          final arguments = call.arguments as Map?;
+          if (arguments != null) {
+            final height = (arguments['height'] as num?)?.toDouble() ?? 0;
+            setState(() {
+              _currentHeight = height;
+            });
+            widget.onHeightChanged?.call(height);
+          }
+          break;
+        case 'embeddedPaymentElementLoadingFailed':
+          final arguments = call.arguments as Map?;
+          final message = arguments?['message'] as String? ?? 'Unknown error';
+          widget.onLoadingFailed?.call(message);
+          break;
+        case 'embeddedPaymentElementFormSheetConfirmComplete':
+          final arguments = call.arguments as Map?;
+          if (arguments != null) {
+            final result = Map<String, dynamic>.from(arguments);
+            widget.onFormSheetConfirmComplete?.call(result);
+          }
+          break;
+        case 'embeddedPaymentElementRowSelectionImmediateAction':
+          widget.onRowSelectionImmediateAction?.call();
+          break;
+      }
+    } catch (e) {
+      debugPrint('Error handling method call ${call.method}: $e');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final creationParams = <String, dynamic>{
+      'intentConfiguration': widget.intentConfiguration.toJson(),
+      'configuration': widget.configuration.toJson(),
+    };
+
+    Widget platformView;
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      platformView = _AndroidEmbeddedPaymentElement(
+        viewType: 'flutter.stripe/embedded_payment_element',
+        creationParams: creationParams,
+        onPlatformViewCreated: _onPlatformViewCreated,
+        androidPlatformViewRenderType: widget.androidPlatformViewRenderType,
+      );
+    } else if (defaultTargetPlatform == TargetPlatform.iOS) {
+      platformView = _UiKitEmbeddedPaymentElement(
+        viewType: 'flutter.stripe/embedded_payment_element',
+        creationParams: creationParams,
+        onPlatformViewCreated: _onPlatformViewCreated,
+      );
+    } else {
+      throw UnsupportedError(
+        'Embedded Payment Element is not supported on this platform',
+      );
+    }
+
+    return SizedBox(
+      height: _currentHeight > 0 ? _currentHeight : 400,
+      child: platformView,
+    );
+  }
+}
+
+class _AndroidEmbeddedPaymentElement extends StatelessWidget {
+  const _AndroidEmbeddedPaymentElement({
+    required this.viewType,
+    required this.creationParams,
+    required this.onPlatformViewCreated,
+    required this.androidPlatformViewRenderType,
+  });
+
+  final String viewType;
+  final Map<String, dynamic> creationParams;
+  final PlatformViewCreatedCallback onPlatformViewCreated;
+  final AndroidPlatformViewRenderType androidPlatformViewRenderType;
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: PlatformViewLink(
+        viewType: viewType,
+        surfaceFactory: (context, controller) => AndroidViewSurface(
+          controller: controller as AndroidViewController,
+          gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+          hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+        ),
+        onCreatePlatformView: (params) {
+          onPlatformViewCreated(params.id);
+          switch (androidPlatformViewRenderType) {
+            case AndroidPlatformViewRenderType.expensiveAndroidView:
+              return PlatformViewsService.initExpensiveAndroidView(
+                  id: params.id,
+                  viewType: viewType,
+                  layoutDirection: Directionality.of(context),
+                  creationParams: creationParams,
+                  creationParamsCodec: const StandardMessageCodec(),
+                  onFocus: () => params.onFocusChanged(true),
+                )
+                ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+                ..create();
+            case AndroidPlatformViewRenderType.androidView:
+              return PlatformViewsService.initAndroidView(
+                  id: params.id,
+                  viewType: viewType,
+                  layoutDirection: Directionality.of(context),
+                  creationParams: creationParams,
+                  creationParamsCodec: const StandardMessageCodec(),
+                  onFocus: () => params.onFocusChanged(true),
+                )
+                ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+                ..create();
+          }
+        },
+      ),
+    );
+  }
+}
+
+class _UiKitEmbeddedPaymentElement extends StatelessWidget {
+  const _UiKitEmbeddedPaymentElement({
+    required this.viewType,
+    required this.creationParams,
+    required this.onPlatformViewCreated,
+  });
+
+  final String viewType;
+  final Map<String, dynamic> creationParams;
+  final PlatformViewCreatedCallback onPlatformViewCreated;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRect(
+      clipBehavior: Clip.hardEdge,
+      child: RepaintBoundary(
+        child: UiKitView(
+          viewType: viewType,
+          creationParamsCodec: const StandardMessageCodec(),
+          creationParams: creationParams,
+          onPlatformViewCreated: onPlatformViewCreated,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/stripe/lib/src/widgets/embedded_payment_element.dart
+++ b/packages/stripe/lib/src/widgets/embedded_payment_element.dart
@@ -111,6 +111,7 @@ class _EmbeddedPaymentElementState extends State<EmbeddedPaymentElement>
 
   MethodChannel? _methodChannel;
   double _currentHeight = 0;
+  bool _showPlatformView = true;
 
   @override
   void initState() {
@@ -154,6 +155,14 @@ class _EmbeddedPaymentElementState extends State<EmbeddedPaymentElement>
   @override
   Future<void> clearPaymentOption() async {
     await _methodChannel?.invokeMethod('clearPaymentOption');
+  }
+
+  @override
+  Future<void> disposeView() async {
+    if (!_showPlatformView || !mounted) return;
+    setState(() => _showPlatformView = false);
+    await WidgetsBinding.instance.endOfFrame;
+    _methodChannel = null;
   }
 
   void _onPlatformViewCreated(int viewId) {
@@ -258,6 +267,8 @@ class _EmbeddedPaymentElementState extends State<EmbeddedPaymentElement>
 
   @override
   Widget build(BuildContext context) {
+    if (!_showPlatformView) return const SizedBox.shrink();
+
     final creationParams = <String, dynamic>{
       'intentConfiguration': widget.intentConfiguration.toJson(),
       'configuration': widget.configuration.toJson(),

--- a/packages/stripe/lib/src/widgets/embedded_payment_element.dart
+++ b/packages/stripe/lib/src/widgets/embedded_payment_element.dart
@@ -161,6 +161,8 @@ class _EmbeddedPaymentElementState extends State<EmbeddedPaymentElement>
           final arguments = call.arguments as Map?;
           if (arguments != null) {
             final height = (arguments['height'] as num?)?.toDouble() ?? 0;
+            if (height <= 0) return;
+
             setState(() {
               _currentHeight = height;
             });
@@ -215,9 +217,14 @@ class _EmbeddedPaymentElementState extends State<EmbeddedPaymentElement>
       );
     }
 
-    return SizedBox(
-      height: _currentHeight > 0 ? _currentHeight : 400,
-      child: platformView,
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+      alignment: Alignment.topCenter,
+      child: SizedBox(
+        height: _currentHeight > 0 ? _currentHeight : 400,
+        child: platformView,
+      ),
     );
   }
 }

--- a/packages/stripe/lib/src/widgets/embedded_payment_element.dart
+++ b/packages/stripe/lib/src/widgets/embedded_payment_element.dart
@@ -354,6 +354,17 @@ class _AndroidEmbeddedPaymentElement extends StatelessWidget {
                 )
                 ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
                 ..create();
+            case AndroidPlatformViewRenderType.surfaceAndroidView:
+              return PlatformViewsService.initSurfaceAndroidView(
+                  id: params.id,
+                  viewType: viewType,
+                  layoutDirection: Directionality.of(context),
+                  creationParams: creationParams,
+                  creationParamsCodec: const StandardMessageCodec(),
+                  onFocus: () => params.onFocusChanged(true),
+                )
+                ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+                ..create();
           }
         },
       ),

--- a/packages/stripe/lib/src/widgets/embedded_payment_element_controller.dart
+++ b/packages/stripe/lib/src/widgets/embedded_payment_element_controller.dart
@@ -37,6 +37,14 @@ class EmbeddedPaymentElementController extends ChangeNotifier {
     await _context?.clearPaymentOption();
   }
 
+  /// Unmounts the platform view before navigation.
+  /// Must be awaited to ensure the UiKitView is fully disposed.
+  /// This is irreversible for the widget's lifetime.
+  Future<void> disposeView() async {
+    if (!hasEmbeddedPaymentElement) return;
+    await _context?.disposeView();
+  }
+
   @override
   void dispose() {
     _context = null;
@@ -47,4 +55,5 @@ class EmbeddedPaymentElementController extends ChangeNotifier {
 abstract class EmbeddedPaymentElementContext {
   Future<Map<String, dynamic>?> confirm();
   Future<void> clearPaymentOption();
+  Future<void> disposeView();
 }

--- a/packages/stripe/lib/src/widgets/embedded_payment_element_controller.dart
+++ b/packages/stripe/lib/src/widgets/embedded_payment_element_controller.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/foundation.dart';
+
+class EmbeddedPaymentElementController extends ChangeNotifier {
+  EmbeddedPaymentElementController();
+
+  EmbeddedPaymentElementContext? _context;
+
+  bool get hasEmbeddedPaymentElement => _context != null;
+
+  void attach(EmbeddedPaymentElementContext context) {
+    assert(
+      !hasEmbeddedPaymentElement,
+      'Controller is already attached to an EmbeddedPaymentElement',
+    );
+    _context = context;
+  }
+
+  void detach(EmbeddedPaymentElementContext context) {
+    if (_context == context) {
+      _context = null;
+    }
+  }
+
+  Future<Map<String, dynamic>?> confirm() async {
+    assert(
+      hasEmbeddedPaymentElement,
+      'Controller must be attached to an EmbeddedPaymentElement',
+    );
+    return await _context?.confirm();
+  }
+
+  Future<void> clearPaymentOption() async {
+    assert(
+      hasEmbeddedPaymentElement,
+      'Controller must be attached to an EmbeddedPaymentElement',
+    );
+    await _context?.clearPaymentOption();
+  }
+
+  @override
+  void dispose() {
+    _context = null;
+    super.dispose();
+  }
+}
+
+abstract class EmbeddedPaymentElementContext {
+  Future<Map<String, dynamic>?> confirm();
+  Future<void> clearPaymentOption();
+}

--- a/packages/stripe_android/android/build.gradle
+++ b/packages/stripe_android/android/build.gradle
@@ -41,6 +41,14 @@ android {
         jvmTarget = '17'
     }
 
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = '1.5.1'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -69,6 +77,13 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:5.3.2'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
+
+    // Jetpack Compose dependencies for EmbeddedPaymentElement
+    implementation platform('androidx.compose:compose-bom:2023.10.01')
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.foundation:foundation'
+    implementation 'androidx.compose.runtime:runtime'
+    implementation 'androidx.activity:activity-compose:1.8.0'
 
     // play-services-wallet is already included in stripe-android
     compileOnly "com.google.android.gms:play-services-wallet:19.3.0"

--- a/packages/stripe_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/stripe_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
@@ -10,6 +10,7 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.reactnativestripesdk.*
 import com.reactnativestripesdk.addresssheet.AddressSheetViewManager
 import com.reactnativestripesdk.pushprovisioning.AddToWalletButtonManager
+import com.reactnativestripesdk.EmbeddedPaymentElementViewManager
 import com.reactnativestripesdk.utils.getIntOrNull
 import com.reactnativestripesdk.utils.getValOr
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -56,6 +57,10 @@ class StripeAndroidPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         AddressSheetViewManager()
     }
 
+    private val embeddedPaymentElementViewManager: EmbeddedPaymentElementViewManager by lazy {
+        EmbeddedPaymentElementViewManager()
+    }
+
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(flutterPluginBinding.applicationContext)
 
@@ -77,6 +82,9 @@ class StripeAndroidPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             .platformViewRegistry
             .registerViewFactory("flutter.stripe/add_to_wallet", StripeAddToWalletPlatformViewFactory(flutterPluginBinding, AddToWalletButtonManager()){stripeSdk})
         flutterPluginBinding.platformViewRegistry.registerViewFactory("flutter.stripe/address_sheet", StripeAddressSheetPlatformViewFactory(flutterPluginBinding, addressSheetFormViewManager ){stripeSdk})
+        flutterPluginBinding
+            .platformViewRegistry
+            .registerViewFactory("flutter.stripe/embedded_payment_element", StripeSdkEmbeddedPaymentElementPlatformViewFactory(flutterPluginBinding, embeddedPaymentElementViewManager){stripeSdk})
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
@@ -29,10 +29,10 @@ class StripeSdkEmbeddedPaymentElementPlatformView(
         creationParams?.convertToReadables()?.forEach { entry ->
             when (entry.key) {
                 "configuration" -> {
-                    viewManager.setConfiguration(embeddedView, entry.value)
+                    entry.value?.let { viewManager.setConfiguration(embeddedView, it as com.facebook.react.bridge.Dynamic) }
                 }
                 "intentConfiguration" -> {
-                    viewManager.setIntentConfiguration(embeddedView, entry.value)
+                    entry.value?.let { viewManager.setIntentConfiguration(embeddedView, it as com.facebook.react.bridge.Dynamic) }
                 }
             }
         }

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
@@ -2,8 +2,8 @@ package com.flutter.stripe
 
 import android.content.Context
 import android.view.View
-import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.ThemedReactContext
+import com.reactnativestripesdk.EmbeddedPaymentElementLoadingError
 import com.reactnativestripesdk.EmbeddedPaymentElementView
 import com.reactnativestripesdk.EmbeddedPaymentElementViewManager
 import com.reactnativestripesdk.StripeSdkModule
@@ -34,8 +34,8 @@ class StripeSdkEmbeddedPaymentElementPlatformView(
             channel.invokeMethod("onPaymentOptionChanged", mapOf("paymentOption" to paymentOption))
         }
 
-        embeddedView.onLoadingFailed = { message ->
-            channel.invokeMethod("embeddedPaymentElementLoadingFailed", mapOf("message" to message))
+        embeddedView.onLoadingFailed = { error: EmbeddedPaymentElementLoadingError ->
+            channel.invokeMethod("embeddedPaymentElementLoadingFailed", error.toMap())
         }
 
         embeddedView.onRowSelectionImmediateAction = {

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
@@ -49,8 +49,11 @@ class StripeSdkEmbeddedPaymentElementPlatformView(
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
             "confirm" -> {
+                embeddedView.onConfirmResult = { resultMap ->
+                    result.success(resultMap)
+                    embeddedView.onConfirmResult = null
+                }
                 viewManager.confirm(embeddedView)
-                result.success(null)
             }
             "clearPaymentOption" -> {
                 viewManager.clearPaymentOption(embeddedView)

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
@@ -26,6 +26,26 @@ class StripeSdkEmbeddedPaymentElementPlatformView(
     init {
         channel.setMethodCallHandler(this)
 
+        embeddedView.onHeightChanged = { height ->
+            channel.invokeMethod("onHeightChanged", mapOf("height" to height.toDouble()))
+        }
+
+        embeddedView.onPaymentOptionChanged = { paymentOption ->
+            channel.invokeMethod("onPaymentOptionChanged", mapOf("paymentOption" to paymentOption))
+        }
+
+        embeddedView.onLoadingFailed = { message ->
+            channel.invokeMethod("embeddedPaymentElementLoadingFailed", mapOf("message" to message))
+        }
+
+        embeddedView.onRowSelectionImmediateAction = {
+            channel.invokeMethod("embeddedPaymentElementRowSelectionImmediateAction", null)
+        }
+
+        embeddedView.onFormSheetConfirmComplete = { result ->
+            channel.invokeMethod("embeddedPaymentElementFormSheetConfirmComplete", result)
+        }
+
         creationParams?.let { params ->
             val configMap = params["configuration"] as? Map<*, *>
             val intentConfigMap = params["intentConfiguration"] as? Map<*, *>

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
@@ -59,16 +59,6 @@ class StripeSdkEmbeddedPaymentElementPlatformView(
                 viewManager.clearPaymentOption(embeddedView)
                 result.success(null)
             }
-            "updateConfiguration" -> {
-                val config = call.arguments.convertToReadable()
-                viewManager.setConfiguration(embeddedView, config)
-                result.success(null)
-            }
-            "updateIntentConfiguration" -> {
-                val intentConfig = call.arguments.convertToReadable()
-                viewManager.setIntentConfiguration(embeddedView, intentConfig)
-                result.success(null)
-            }
             else -> {
                 result.notImplemented()
             }

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformView.kt
@@ -2,6 +2,7 @@ package com.flutter.stripe
 
 import android.content.Context
 import android.view.View
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.reactnativestripesdk.EmbeddedPaymentElementLoadingError
 import com.reactnativestripesdk.EmbeddedPaymentElementView
@@ -52,17 +53,19 @@ class StripeSdkEmbeddedPaymentElementPlatformView(
 
             if (configMap != null) {
                 @Suppress("UNCHECKED_CAST")
-                val configBundle = mapToBundle(configMap as Map<String?, Any?>)
-                val rowSelectionBehaviorType = viewManager.parseRowSelectionBehavior(configBundle)
+                val configReadableMap =
+                    ReadableMap(configMap as Map<String, Any>)
+                val rowSelectionBehaviorType = viewManager.parseRowSelectionBehavior(configReadableMap)
                 embeddedView.rowSelectionBehaviorType.value = rowSelectionBehaviorType
-                val elementConfig = viewManager.parseElementConfiguration(configBundle, context)
+                val elementConfig = viewManager.parseElementConfiguration(configReadableMap, context)
                 embeddedView.latestElementConfig = elementConfig
             }
 
             if (intentConfigMap != null) {
                 @Suppress("UNCHECKED_CAST")
-                val intentConfigBundle = mapToBundle(intentConfigMap as Map<String?, Any?>)
-                val intentConfig = viewManager.parseIntentConfiguration(intentConfigBundle)
+                val intentConfigReadableMap =
+                    ReadableMap(intentConfigMap as Map<String, Any>)
+                val intentConfig = viewManager.parseIntentConfiguration(intentConfigReadableMap)
                 embeddedView.latestIntentConfig = intentConfig
             }
 

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformViewFactory.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkEmbeddedPaymentElementPlatformViewFactory.kt
@@ -1,0 +1,36 @@
+package com.flutter.stripe
+
+import android.content.Context
+import com.reactnativestripesdk.EmbeddedPaymentElementViewManager
+import com.reactnativestripesdk.StripeSdkModule
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.StandardMessageCodec
+import io.flutter.plugin.platform.PlatformView
+import io.flutter.plugin.platform.PlatformViewFactory
+
+class StripeSdkEmbeddedPaymentElementPlatformViewFactory(
+    private val flutterPluginBinding: FlutterPlugin.FlutterPluginBinding,
+    private val embeddedPaymentElementViewManager: EmbeddedPaymentElementViewManager,
+    private val sdkAccessor: () -> StripeSdkModule
+) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+
+    override fun create(context: Context?, viewId: Int, args: Any?): PlatformView {
+        val channel = MethodChannel(
+            flutterPluginBinding.binaryMessenger,
+            "flutter.stripe/embedded_payment_element/${viewId}"
+        )
+        val creationParams = args as? Map<String?, Any?>?
+        if (context == null) {
+            throw AssertionError("Context is not allowed to be null when launching embedded payment element view.")
+        }
+        return StripeSdkEmbeddedPaymentElementPlatformView(
+            context,
+            channel,
+            viewId,
+            creationParams,
+            embeddedPaymentElementViewManager,
+            sdkAccessor
+        )
+    }
+}

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkModuleExtensions.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkModuleExtensions.kt
@@ -61,3 +61,49 @@ fun Any.convertToReadable(): Any {
         else -> this
     }
 }
+
+fun mapToBundle(map: Map<String?, Any?>?): android.os.Bundle {
+    val result = android.os.Bundle()
+    if (map == null) {
+        return result
+    }
+
+    for ((key, value) in map) {
+        if (key == null) continue
+
+        when (value) {
+            null -> result.putString(key, null)
+            is Boolean -> result.putBoolean(key, value)
+            is Int -> result.putInt(key, value)
+            is Long -> result.putLong(key, value)
+            is Double -> result.putDouble(key, value)
+            is String -> result.putString(key, value)
+            is Map<*, *> -> {
+                @Suppress("UNCHECKED_CAST")
+                result.putBundle(key, mapToBundle(value as Map<String?, Any?>))
+            }
+            is List<*> -> {
+                val list = value as List<*>
+                if (list.isEmpty()) {
+                    result.putStringArrayList(key, ArrayList())
+                } else {
+                    when (list.first()) {
+                        is String -> {
+                            @Suppress("UNCHECKED_CAST")
+                            result.putStringArrayList(key, ArrayList(list as List<String>))
+                        }
+                        is Int -> {
+                            @Suppress("UNCHECKED_CAST")
+                            result.putIntegerArrayList(key, ArrayList(list as List<Int>))
+                        }
+                        else -> {
+                            android.util.Log.e("mapToBundle", "Cannot put arrays of objects into bundles. Failed on: $key.")
+                        }
+                    }
+                }
+            }
+            else -> android.util.Log.e("mapToBundle", "Could not convert object with key: $key, type: ${value::class.java}")
+        }
+    }
+    return result
+}

--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
@@ -1,0 +1,368 @@
+package com.reactnativestripesdk
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.uimanager.ThemedReactContext
+import com.reactnativestripesdk.toWritableMap
+import com.reactnativestripesdk.utils.KeepJsAwakeTask
+import com.reactnativestripesdk.utils.mapFromCustomPaymentMethod
+import com.reactnativestripesdk.utils.mapFromPaymentMethod
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.CustomPaymentMethodResult
+import com.stripe.android.paymentelement.CustomPaymentMethodResultHandler
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
+import com.stripe.android.paymentelement.rememberEmbeddedPaymentElement
+import com.stripe.android.paymentsheet.CreateIntentResult
+import com.stripe.android.paymentsheet.PaymentSheet
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.launch
+
+enum class RowSelectionBehaviorType {
+  Default,
+  ImmediateAction,
+}
+
+@OptIn(ExperimentalCustomPaymentMethodsApi::class)
+class EmbeddedPaymentElementView(
+  context: Context,
+) : StripeAbstractComposeView(context) {
+  private sealed interface Event {
+    data class Configure(
+      val configuration: EmbeddedPaymentElement.Configuration,
+      val intentConfiguration: PaymentSheet.IntentConfiguration,
+    ) : Event
+
+    data object Confirm : Event
+
+    data object ClearPaymentOption : Event
+  }
+
+  var latestIntentConfig: PaymentSheet.IntentConfiguration? = null
+  var latestElementConfig: EmbeddedPaymentElement.Configuration? = null
+
+  val rowSelectionBehaviorType = mutableStateOf<RowSelectionBehaviorType?>(null)
+
+  private val reactContext get() = context as ThemedReactContext
+  private val events = Channel<Event>(Channel.UNLIMITED)
+
+  @OptIn(ExperimentalCustomPaymentMethodsApi::class)
+  @Composable
+  override fun Content() {
+    val type by remember { rowSelectionBehaviorType }
+    val coroutineScope = rememberCoroutineScope()
+
+    val confirmCustomPaymentMethodCallback =
+      remember(coroutineScope) {
+        {
+          customPaymentMethod: PaymentSheet.CustomPaymentMethod,
+          billingDetails: PaymentMethod.BillingDetails,
+          ->
+          // Launch a transparent Activity to ensure React Native UI can appear on top of the Stripe proxy activity.
+          try {
+            val intent =
+              Intent(reactContext, CustomPaymentMethodActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+              }
+            reactContext.startActivity(intent)
+          } catch (e: Exception) {
+            Log.e("StripeReactNative", "Failed to start CustomPaymentMethodActivity", e)
+          }
+
+          val stripeSdkModule =
+            try {
+              requireStripeSdkModule()
+            } catch (ex: IllegalArgumentException) {
+              Log.e("StripeReactNative", "StripeSdkModule not found for CPM callback", ex)
+              CustomPaymentMethodActivity.finishCurrent()
+              return@remember
+            }
+
+          // Keep JS awake while React Native is backgrounded by Stripe SDK.
+          val keepJsAwakeTask =
+            KeepJsAwakeTask(reactContext.reactApplicationContext).apply { start() }
+
+          // Run on coroutine scope.
+          coroutineScope.launch {
+            try {
+              // Give the CustomPaymentMethodActivity a moment to fully initialize
+              delay(100)
+
+              // Emit event so JS can show the Alert and eventually respond via `customPaymentMethodResultCallback`.
+              stripeSdkModule.eventEmitter.emitOnCustomPaymentMethodConfirmHandlerCallback(
+                mapFromCustomPaymentMethod(customPaymentMethod, billingDetails),
+              )
+
+              // Await JS result.
+              val resultFromJs = stripeSdkModule.customPaymentMethodResultCallback.await()
+
+              keepJsAwakeTask.stop()
+
+              val status = resultFromJs.getString("status")
+
+              val nativeResult =
+                when (status) {
+                  "completed" ->
+                    CustomPaymentMethodResult
+                      .completed()
+                  "canceled" ->
+                    CustomPaymentMethodResult
+                      .canceled()
+                  "failed" -> {
+                    val errMsg = resultFromJs.getString("error") ?: "Custom payment failed"
+                    CustomPaymentMethodResult
+                      .failed(displayMessage = errMsg)
+                  }
+                  else ->
+                    CustomPaymentMethodResult
+                      .failed(displayMessage = "Unknown status")
+                }
+
+              // Return result to Stripe SDK.
+              CustomPaymentMethodResultHandler.handleCustomPaymentMethodResult(
+                reactContext,
+                nativeResult,
+              )
+            } finally {
+              // Clean up the transparent activity
+              CustomPaymentMethodActivity.finishCurrent()
+            }
+          }
+        }
+      }
+
+    val builder =
+      remember(type) {
+        EmbeddedPaymentElement
+          .Builder(
+            createIntentCallback = { paymentMethod, shouldSavePaymentMethod ->
+              val stripeSdkModule =
+                try {
+                  requireStripeSdkModule()
+                } catch (ex: IllegalArgumentException) {
+                  return@Builder CreateIntentResult.Failure(
+                    cause =
+                      Exception(
+                        "Tried to call confirmHandler, but no callback was found. Please file an issue: https://github.com/stripe/stripe-react-native/issues",
+                      ),
+                    displayMessage = "An unexpected error occurred",
+                  )
+                }
+
+              // Make sure that JS is active since the activity will be paused when stripe ui is presented.
+              val keepJsAwakeTask =
+                KeepJsAwakeTask(reactContext.reactApplicationContext).apply { start() }
+
+              val params =
+                Arguments.createMap().apply {
+                  putMap("paymentMethod", mapFromPaymentMethod(paymentMethod))
+                  putBoolean("shouldSavePaymentMethod", shouldSavePaymentMethod)
+                }
+
+              stripeSdkModule.eventEmitter.emitOnConfirmHandlerCallback(params)
+
+              val resultFromJavascript = stripeSdkModule.embeddedIntentCreationCallback.await()
+              // reset the completable
+              stripeSdkModule.embeddedIntentCreationCallback = CompletableDeferred()
+
+              keepJsAwakeTask.stop()
+
+              resultFromJavascript.getString("clientSecret")?.let {
+                CreateIntentResult.Success(clientSecret = it)
+              } ?: run {
+                val errorMap = resultFromJavascript.getMap("error")
+                CreateIntentResult.Failure(
+                  cause = Exception(errorMap?.getString("message")),
+                  displayMessage = errorMap?.getString("localizedMessage"),
+                )
+              }
+            },
+            resultCallback = { result ->
+              val map =
+                Arguments.createMap().apply {
+                  when (result) {
+                    is EmbeddedPaymentElement.Result.Completed -> {
+                      putString("status", "completed")
+                    }
+
+                    is EmbeddedPaymentElement.Result.Canceled -> {
+                      putString("status", "canceled")
+                    }
+
+                    is EmbeddedPaymentElement.Result.Failed -> {
+                      putString("status", "failed")
+                      putString("error", result.error.message ?: "Unknown error")
+                    }
+                  }
+                }
+              requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementFormSheetConfirmComplete(map)
+            },
+          ).confirmCustomPaymentMethodCallback(confirmCustomPaymentMethodCallback)
+          .rowSelectionBehavior(
+            if (type == RowSelectionBehaviorType.Default) {
+              EmbeddedPaymentElement.RowSelectionBehavior.default()
+            } else {
+              EmbeddedPaymentElement.RowSelectionBehavior.immediateAction {
+                requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementRowSelectionImmediateAction()
+              }
+            },
+          )
+      }
+
+    val embedded = rememberEmbeddedPaymentElement(builder)
+    var height by remember {
+      mutableIntStateOf(0)
+    }
+
+    // collect events: configure, confirm, clear
+    LaunchedEffect(Unit) {
+      events.consumeAsFlow().collect { ev ->
+        when (ev) {
+          is Event.Configure -> {
+            // call configure and grab the result
+            val result =
+              embedded.configure(
+                intentConfiguration = ev.intentConfiguration,
+                configuration = ev.configuration,
+              )
+
+            when (result) {
+              is EmbeddedPaymentElement.ConfigureResult.Succeeded -> reportHeightChange(1f)
+              is EmbeddedPaymentElement.ConfigureResult.Failed -> {
+                // send the error back to JS
+                val err = result.error
+                val msg = err.localizedMessage ?: err.toString()
+                // build a RN map
+                val payload =
+                  Arguments.createMap().apply {
+                    putString("message", msg)
+                  }
+                requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementLoadingFailed(payload)
+              }
+            }
+          }
+
+          is Event.Confirm -> {
+            embedded.confirm()
+          }
+          is Event.ClearPaymentOption -> {
+            embedded.clearPaymentOption()
+          }
+        }
+      }
+    }
+
+    LaunchedEffect(embedded) {
+      embedded.paymentOption.collect { opt ->
+        val optMap = opt?.toWritableMap()
+        val payload =
+          Arguments.createMap().apply {
+            putMap("paymentOption", optMap)
+          }
+        requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementDidUpdatePaymentOption(payload)
+      }
+    }
+
+    val density = LocalDensity.current
+
+    Box {
+      measuredEmbeddedElement(
+        reportHeightChange = { h -> reportHeightChange(h) },
+      ) {
+        embedded.Content()
+      }
+    }
+  }
+
+  @Composable
+  private fun measuredEmbeddedElement(
+    reportHeightChange: (Float) -> Unit,
+    content: @Composable () -> Unit,
+  ) {
+    val density = LocalDensity.current
+    var heightDp by remember { mutableStateOf(1.dp) } // non-zero sentinel
+
+    Box(
+      Modifier
+        // Clamp the host Android view height; drive it in Dp
+        .requiredHeight(heightDp)
+        // Post-layout: convert px -> dp, update RN & our dp state
+        .onSizeChanged { size ->
+          val h = with(density) { size.height.toDp() }
+          if (h != heightDp) {
+            heightDp = h
+            reportHeightChange(h.value) // send dp as Float to RN
+          }
+        }
+        // Custom measure path: force child to its min intrinsic height (in *px*)
+        .layout { measurable, constraints ->
+          val widthPx = constraints.maxWidth
+          val minHpx = measurable.minIntrinsicHeight(widthPx).coerceAtLeast(1)
+
+          // Measure the child with a tight height equal to min intrinsic
+          val placeable =
+            measurable.measure(
+              constraints.copy(
+                minHeight = minHpx,
+                maxHeight = minHpx,
+              ),
+            )
+
+          // Our own size: use the child’s measured size
+          layout(constraints.maxWidth, placeable.height) {
+            placeable.placeRelative(IntOffset.Zero)
+          }
+        },
+    ) {
+      content()
+    }
+  }
+
+  private fun reportHeightChange(height: Float) {
+    val params =
+      Arguments.createMap().apply {
+        putDouble("height", height.toDouble())
+      }
+    requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementDidUpdateHeight(params)
+  }
+
+  // APIs
+  fun configure(
+    config: EmbeddedPaymentElement.Configuration,
+    intentConfig: PaymentSheet.IntentConfiguration,
+  ) {
+    events.trySend(Event.Configure(config, intentConfig))
+  }
+
+  fun confirm() {
+    events.trySend(Event.Confirm)
+  }
+
+  fun clearPaymentOption() {
+    events.trySend(Event.ClearPaymentOption)
+  }
+
+  private fun requireStripeSdkModule() = requireNotNull(reactContext.getNativeModule(StripeSdkModule::class.java))
+}

--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
@@ -64,6 +64,8 @@ class EmbeddedPaymentElementView(
 
   val rowSelectionBehaviorType = mutableStateOf<RowSelectionBehaviorType?>(null)
 
+  var onConfirmResult: ((Map<String, Any?>) -> Unit)? = null
+
   private val reactContext get() = context as ThemedReactContext
   private val events = Channel<Event>(Channel.UNLIMITED)
 
@@ -217,6 +219,19 @@ class EmbeddedPaymentElementView(
                     }
                   }
                 }
+
+              // Call Flutter method channel result callback
+              onConfirmResult?.invoke(
+                when (result) {
+                  is EmbeddedPaymentElement.Result.Completed ->
+                    mapOf("status" to "completed")
+                  is EmbeddedPaymentElement.Result.Canceled ->
+                    mapOf("status" to "canceled")
+                  is EmbeddedPaymentElement.Result.Failed ->
+                    mapOf("status" to "failed", "error" to (result.error.message ?: "Unknown error"))
+                }
+              )
+
               requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementFormSheetConfirmComplete(map)
             },
           ).confirmCustomPaymentMethodCallback(confirmCustomPaymentMethodCallback)

--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
@@ -31,7 +31,6 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.CustomPaymentMethodResult
 import com.stripe.android.paymentelement.CustomPaymentMethodResultHandler
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.rememberEmbeddedPaymentElement
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -71,7 +70,6 @@ data class EmbeddedPaymentElementLoadingError(
   }
 }
 
-@OptIn(ExperimentalCustomPaymentMethodsApi::class)
 class EmbeddedPaymentElementView(
   context: Context,
 ) : StripeAbstractComposeView(context) {
@@ -101,7 +99,6 @@ class EmbeddedPaymentElementView(
   private val reactContext get() = context as ThemedReactContext
   private val events = Channel<Event>(Channel.UNLIMITED)
 
-  @OptIn(ExperimentalCustomPaymentMethodsApi::class)
   @Composable
   override fun Content() {
     val type by remember { rowSelectionBehaviorType }

--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
@@ -154,7 +154,11 @@ class EmbeddedPaymentElementViewManager :
         email = mapToCollectionMode(billingConfigParams?.getString("email")),
         address = mapToAddressCollectionMode(billingConfigParams?.getString("address")),
         attachDefaultsToPaymentMethod =
-          billingConfigParams?.getBooleanOr("attachDefaultsToPaymentMethod", false) ?: false,
+          if (billingConfigParams?.containsKey("attachDefaultsToPaymentMethod") == true) {
+            billingConfigParams.getBoolean("attachDefaultsToPaymentMethod")
+          } else {
+            false
+          },
       )
     val allowsRemovalOfLastSavedPaymentMethod =
       if (bundle.containsKey("allowsRemovalOfLastSavedPaymentMethod")) {
@@ -206,11 +210,7 @@ class EmbeddedPaymentElementViewManager :
         )
         .customPaymentMethods(
           parseCustomPaymentMethods(
-            bundle.getBundle("customPaymentMethodConfiguration").apply {
-              bundle.getBundle("customPaymentMethodConfiguration")?.let { readable ->
-                putSerializable("customPaymentMethodConfigurationReadableMap", readable)
-              }
-            },
+            bundle.getBundle("customPaymentMethodConfiguration") ?: Bundle(),
           ),
         )
 

--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
@@ -260,7 +260,7 @@ fun ReadableMap.getStringArrayList(key: String): List<String>? {
   val array: ReadableArray = getArray(key) ?: return null
 
   val result = mutableListOf<String>()
-  for (i in 0 until array.size()) {
+  for (i in 0 until array.size) {
     // getString returns null if the element isn't actually a string
     array.getString(i)?.let { result.add(it) }
   }
@@ -275,7 +275,7 @@ fun ReadableMap.getIntegerArrayList(key: String): List<Int>? {
   val array: ReadableArray = getArray(key) ?: return null
 
   val result = mutableListOf<Int>()
-  for (i in 0 until array.size()) {
+  for (i in 0 until array.size) {
     // getType check to skip non-number entries
     if (array.getType(i) == ReadableType.Number) {
       // if it's actually a float/double, this will truncate; adjust as needed

--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
@@ -1,0 +1,286 @@
+package com.reactnativestripesdk
+
+import android.annotation.SuppressLint
+import android.content.Context
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewGroupManager
+import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.EmbeddedPaymentElementViewManagerDelegate
+import com.facebook.react.viewmanagers.EmbeddedPaymentElementViewManagerInterface
+import com.reactnativestripesdk.PaymentSheetFragment.Companion.buildCustomerConfiguration
+import com.reactnativestripesdk.PaymentSheetFragment.Companion.buildGooglePayConfig
+import com.reactnativestripesdk.addresssheet.AddressSheetView
+import com.reactnativestripesdk.utils.PaymentSheetAppearanceException
+import com.reactnativestripesdk.utils.PaymentSheetException
+import com.reactnativestripesdk.utils.getBooleanOr
+import com.reactnativestripesdk.utils.mapToPreferredNetworks
+import com.reactnativestripesdk.utils.parseCustomPaymentMethods
+import com.reactnativestripesdk.utils.toBundleObject
+import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
+import com.stripe.android.paymentsheet.PaymentSheet
+
+@ReactModule(name = EmbeddedPaymentElementViewManager.NAME)
+class EmbeddedPaymentElementViewManager :
+  ViewGroupManager<EmbeddedPaymentElementView>(),
+  EmbeddedPaymentElementViewManagerInterface<EmbeddedPaymentElementView> {
+  companion object {
+    const val NAME = "EmbeddedPaymentElementView"
+  }
+
+  private val delegate = EmbeddedPaymentElementViewManagerDelegate(this)
+
+  override fun getName() = NAME
+
+  override fun getDelegate() = delegate
+
+  override fun createViewInstance(ctx: ThemedReactContext): EmbeddedPaymentElementView = EmbeddedPaymentElementView(ctx)
+
+  override fun onDropViewInstance(view: EmbeddedPaymentElementView) {
+    super.onDropViewInstance(view)
+
+    view.handleOnDropViewInstance()
+  }
+
+  override fun needsCustomLayoutForChildren(): Boolean = true
+
+  @ReactProp(name = "configuration")
+  override fun setConfiguration(
+    view: EmbeddedPaymentElementView,
+    cfg: Dynamic,
+  ) {
+    val readableMap = cfg.asMap()
+    if (readableMap == null) return
+
+    val rowSelectionBehaviorType = parseRowSelectionBehavior(readableMap)
+    view.rowSelectionBehaviorType.value = rowSelectionBehaviorType
+
+    val elementConfig = parseElementConfiguration(readableMap, view.context)
+    view.latestElementConfig = elementConfig
+    // if intentConfig is already set, configure immediately:
+    view.latestIntentConfig?.let { intentCfg ->
+      view.configure(elementConfig, intentCfg)
+      view.post {
+        view.requestLayout()
+        view.invalidate()
+      }
+    }
+  }
+
+  @ReactProp(name = "intentConfiguration")
+  override fun setIntentConfiguration(
+    view: EmbeddedPaymentElementView,
+    cfg: Dynamic,
+  ) {
+    val readableMap = cfg.asMap()
+    if (readableMap == null) return
+    val intentConfig = parseIntentConfiguration(readableMap)
+    view.latestIntentConfig = intentConfig
+    view.latestElementConfig?.let { elemCfg ->
+      view.configure(elemCfg, intentConfig)
+    }
+  }
+
+  @SuppressLint("RestrictedApi")
+  @OptIn(
+    ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi::class,
+    ExperimentalCustomPaymentMethodsApi::class,
+  )
+  private fun parseElementConfiguration(
+    map: ReadableMap,
+    context: Context,
+  ): EmbeddedPaymentElement.Configuration {
+    val merchantDisplayName = map.getString("merchantDisplayName").orEmpty()
+    val allowsDelayedPaymentMethods: Boolean =
+      if (map.hasKey("allowsDelayedPaymentMethods") &&
+        map.getType("allowsDelayedPaymentMethods") == ReadableType.Boolean
+      ) {
+        map.getBoolean("allowsDelayedPaymentMethods")
+      } else {
+        false // default
+      }
+    var defaultBillingDetails: PaymentSheet.BillingDetails? = null
+    val billingDetailsMap = map.getMap("defaultBillingDetails")
+    if (billingDetailsMap != null) {
+      val addressBundle = billingDetailsMap.getMap("address")
+      val address =
+        PaymentSheet.Address(
+          addressBundle?.getString("city"),
+          addressBundle?.getString("country"),
+          addressBundle?.getString("line1"),
+          addressBundle?.getString("line2"),
+          addressBundle?.getString("postalCode"),
+          addressBundle?.getString("state"),
+        )
+      defaultBillingDetails =
+        PaymentSheet.BillingDetails(
+          address,
+          billingDetailsMap.getString("email"),
+          billingDetailsMap.getString("name"),
+          billingDetailsMap.getString("phone"),
+        )
+    }
+
+    val customerConfiguration =
+      try {
+        buildCustomerConfiguration(toBundleObject(map))
+      } catch (error: PaymentSheetException) {
+        throw Error() // TODO handle error
+      }
+
+    val googlePayConfig = buildGooglePayConfig(toBundleObject(map.getMap("googlePay")))
+    val linkConfig = PaymentSheetFragment.buildLinkConfig(toBundleObject(map.getMap("link")))
+    val shippingDetails =
+      map.getMap("defaultShippingDetails")?.let {
+        AddressSheetView.buildAddressDetails(it)
+      }
+    val appearance =
+      try {
+        buildPaymentSheetAppearance(toBundleObject(map.getMap("appearance")), context)
+      } catch (error: PaymentSheetAppearanceException) {
+        throw Error() // TODO handle error
+      }
+    val billingConfigParams = map.getMap("billingDetailsCollectionConfiguration")
+    val billingDetailsConfig =
+      PaymentSheet.BillingDetailsCollectionConfiguration(
+        name = mapToCollectionMode(billingConfigParams?.getString("name")),
+        phone = mapToCollectionMode(billingConfigParams?.getString("phone")),
+        email = mapToCollectionMode(billingConfigParams?.getString("email")),
+        address = mapToAddressCollectionMode(billingConfigParams?.getString("address")),
+        attachDefaultsToPaymentMethod =
+          billingConfigParams?.getBooleanOr("attachDefaultsToPaymentMethod", false) ?: false,
+      )
+    val allowsRemovalOfLastSavedPaymentMethod =
+      if (map.hasKey("allowsRemovalOfLastSavedPaymentMethod")) {
+        map.getBoolean("allowsRemovalOfLastSavedPaymentMethod")
+      } else {
+        true
+      }
+    val primaryButtonLabel = map.getString("primaryButtonLabel")
+    val paymentMethodOrder = map.getStringArrayList("paymentMethodOrder")
+
+    val formSheetAction =
+      map
+        .getMap("formSheetAction")
+        ?.getString("type")
+        ?.let { type ->
+          when (type) {
+            "confirm" -> EmbeddedPaymentElement.FormSheetAction.Confirm
+            else -> EmbeddedPaymentElement.FormSheetAction.Continue
+          }
+        }
+        ?: EmbeddedPaymentElement.FormSheetAction.Continue
+
+    val configurationBuilder =
+      EmbeddedPaymentElement.Configuration
+        .Builder(merchantDisplayName)
+        .formSheetAction(formSheetAction)
+        .allowsDelayedPaymentMethods(allowsDelayedPaymentMethods ?: false)
+        .defaultBillingDetails(defaultBillingDetails)
+        .customer(customerConfiguration)
+        .googlePay(googlePayConfig)
+        .link(linkConfig)
+        .appearance(appearance)
+        .shippingDetails(shippingDetails)
+        .billingDetailsCollectionConfiguration(billingDetailsConfig)
+        .preferredNetworks(
+          mapToPreferredNetworks(
+            map
+              .getIntegerArrayList("preferredNetworks")
+              ?.let { ArrayList(it) },
+          ),
+        ).allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod)
+        .cardBrandAcceptance(mapToCardBrandAcceptance(toBundleObject(map)))
+        .embeddedViewDisplaysMandateText(
+          if (map.hasKey("embeddedViewDisplaysMandateText") &&
+            map.getType("embeddedViewDisplaysMandateText") == ReadableType.Boolean
+          ) {
+            map.getBoolean("embeddedViewDisplaysMandateText")
+          } else {
+            true // default value
+          },
+        )
+        // Serialize original ReadableMap because toBundleObject cannot keep arrays of objects
+        .customPaymentMethods(
+          parseCustomPaymentMethods(
+            toBundleObject(map.getMap("customPaymentMethodConfiguration")).apply {
+              map.getMap("customPaymentMethodConfiguration")?.let { readable ->
+                putSerializable("customPaymentMethodConfigurationReadableMap", readable.toHashMap())
+              }
+            },
+          ),
+        )
+
+    primaryButtonLabel?.let { configurationBuilder.primaryButtonLabel(it) }
+    paymentMethodOrder?.let { configurationBuilder.paymentMethodOrder(it) }
+
+    return configurationBuilder.build()
+  }
+
+  private fun parseRowSelectionBehavior(map: ReadableMap): RowSelectionBehaviorType {
+    val rowSelectionBehavior =
+      map
+        .getMap("rowSelectionBehavior")
+        ?.getString("type")
+        ?.let { type ->
+          when (type) {
+            "immediateAction" -> RowSelectionBehaviorType.ImmediateAction
+            else -> RowSelectionBehaviorType.Default
+          }
+        }
+        ?: RowSelectionBehaviorType.Default
+    return rowSelectionBehavior
+  }
+
+  private fun parseIntentConfiguration(map: ReadableMap): PaymentSheet.IntentConfiguration {
+    val intentConfig = PaymentSheetFragment.buildIntentConfiguration(toBundleObject(map))
+    return intentConfig ?: throw IllegalArgumentException("IntentConfiguration is null")
+  }
+
+  override fun confirm(view: EmbeddedPaymentElementView) {
+    view.confirm()
+  }
+
+  override fun clearPaymentOption(view: EmbeddedPaymentElementView) {
+    view.clearPaymentOption()
+  }
+}
+
+/**
+ * Returns a List of Strings if the key exists and points to an array of strings, or null otherwise.
+ */
+fun ReadableMap.getStringArrayList(key: String): List<String>? {
+  if (!hasKey(key) || getType(key) != ReadableType.Array) return null
+  val array: ReadableArray = getArray(key) ?: return null
+
+  val result = mutableListOf<String>()
+  for (i in 0 until array.size()) {
+    // getString returns null if the element isn't actually a string
+    array.getString(i)?.let { result.add(it) }
+  }
+  return result
+}
+
+/**
+ * Returns a List of Ints if the key exists and points to an array of numbers, or null otherwise.
+ */
+fun ReadableMap.getIntegerArrayList(key: String): List<Int>? {
+  if (!hasKey(key) || getType(key) != ReadableType.Array) return null
+  val array: ReadableArray = getArray(key) ?: return null
+
+  val result = mutableListOf<Int>()
+  for (i in 0 until array.size()) {
+    // getType check to skip non-number entries
+    if (array.getType(i) == ReadableType.Number) {
+      // if it's actually a float/double, this will truncate; adjust as needed
+      result.add(array.getInt(i))
+    }
+  }
+  return result
+}

--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
@@ -2,29 +2,24 @@ package com.reactnativestripesdk
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.os.Bundle
 import com.facebook.react.bridge.Dynamic
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.ReadableType
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.EmbeddedPaymentElementViewManagerDelegate
 import com.facebook.react.viewmanagers.EmbeddedPaymentElementViewManagerInterface
-import com.reactnativestripesdk.PaymentSheetFragment.Companion.buildCustomerConfiguration
-import com.reactnativestripesdk.PaymentSheetFragment.Companion.buildGooglePayConfig
 import com.reactnativestripesdk.addresssheet.AddressSheetView
 import com.reactnativestripesdk.utils.PaymentSheetAppearanceException
 import com.reactnativestripesdk.utils.PaymentSheetException
 import com.reactnativestripesdk.utils.getBooleanOr
+import com.reactnativestripesdk.utils.getIntegerList
+import com.reactnativestripesdk.utils.getStringList
 import com.reactnativestripesdk.utils.mapToPreferredNetworks
 import com.reactnativestripesdk.utils.parseCustomPaymentMethods
-import com.reactnativestripesdk.utils.toBundleObject
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentsheet.PaymentSheet
 
 @ReactModule(name = EmbeddedPaymentElementViewManager.NAME)
@@ -59,11 +54,10 @@ class EmbeddedPaymentElementViewManager :
     val readableMap = cfg.asMap()
     if (readableMap == null) return
 
-    val bundle = toBundleObject(readableMap)
-    val rowSelectionBehaviorType = parseRowSelectionBehavior(bundle)
+    val rowSelectionBehaviorType = parseRowSelectionBehavior(readableMap)
     view.rowSelectionBehaviorType.value = rowSelectionBehaviorType
 
-    val elementConfig = parseElementConfiguration(bundle, view.context)
+    val elementConfig = parseElementConfiguration(readableMap, view.context)
     view.latestElementConfig = elementConfig
     view.latestIntentConfig?.let { intentCfg ->
       view.configure(elementConfig, intentCfg)
@@ -81,8 +75,7 @@ class EmbeddedPaymentElementViewManager :
   ) {
     val readableMap = cfg.asMap()
     if (readableMap == null) return
-    val bundle = toBundleObject(readableMap)
-    val intentConfig = parseIntentConfiguration(bundle)
+    val intentConfig = parseIntentConfiguration(readableMap)
     view.latestIntentConfig = intentConfig
     view.latestElementConfig?.let { elemCfg ->
       view.configure(elemCfg, intentConfig)
@@ -92,86 +85,46 @@ class EmbeddedPaymentElementViewManager :
   @SuppressLint("RestrictedApi")
   @OptIn(
     ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi::class,
-    ExperimentalCustomPaymentMethodsApi::class,
   )
   internal fun parseElementConfiguration(
-    bundle: Bundle,
+    readableMap: ReadableMap?,
     context: Context,
   ): EmbeddedPaymentElement.Configuration {
-    val merchantDisplayName = bundle.getString("merchantDisplayName").orEmpty()
-    val allowsDelayedPaymentMethods: Boolean =
-      if (bundle.containsKey("allowsDelayedPaymentMethods")) {
-        bundle.getBoolean("allowsDelayedPaymentMethods")
-      } else {
-        false
-      }
-    var defaultBillingDetails: PaymentSheet.BillingDetails? = null
-    val billingDetailsMap = bundle.getBundle("defaultBillingDetails")
-    if (billingDetailsMap != null) {
-      val addressBundle = billingDetailsMap.getBundle("address")
-      val address =
-        PaymentSheet.Address(
-          addressBundle?.getString("city"),
-          addressBundle?.getString("country"),
-          addressBundle?.getString("line1"),
-          addressBundle?.getString("line2"),
-          addressBundle?.getString("postalCode"),
-          addressBundle?.getString("state"),
-        )
-      defaultBillingDetails =
-        PaymentSheet.BillingDetails(
-          address,
-          billingDetailsMap.getString("email"),
-          billingDetailsMap.getString("name"),
-          billingDetailsMap.getString("phone"),
-        )
-    }
+    val merchantDisplayName = readableMap?.getString("merchantDisplayName").orEmpty()
+    val allowsDelayedPaymentMethods = readableMap.getBooleanOr("allowsDelayedPaymentMethods", false)
+    val defaultBillingDetails = buildBillingDetails(readableMap?.getMap("defaultBillingDetails"))
 
     val customerConfiguration =
       try {
-        buildCustomerConfiguration(bundle)
+        buildCustomerConfiguration(readableMap)
       } catch (error: PaymentSheetException) {
         throw Error()
       }
 
-    val googlePayConfig = buildGooglePayConfig(bundle.getBundle("googlePay"))
-    val linkConfig = PaymentSheetFragment.buildLinkConfig(bundle.getBundle("link"))
+    val googlePayConfig = buildGooglePayConfig(readableMap?.getMap("googlePay"))
+    val linkConfig = buildLinkConfig(readableMap?.getMap("link"))
     val shippingDetails =
-      bundle.getBundle("defaultShippingDetails")?.let {
+      readableMap?.getMap("defaultShippingDetails")?.let {
         AddressSheetView.buildAddressDetails(it)
       }
     val appearance =
       try {
-        buildPaymentSheetAppearance(bundle.getBundle("appearance"), context)
+        buildPaymentSheetAppearance(readableMap?.getMap("appearance"), context)
       } catch (error: PaymentSheetAppearanceException) {
         throw Error()
       }
-    val billingConfigParams = bundle.getBundle("billingDetailsCollectionConfiguration")
     val billingDetailsConfig =
-      PaymentSheet.BillingDetailsCollectionConfiguration(
-        name = mapToCollectionMode(billingConfigParams?.getString("name")),
-        phone = mapToCollectionMode(billingConfigParams?.getString("phone")),
-        email = mapToCollectionMode(billingConfigParams?.getString("email")),
-        address = mapToAddressCollectionMode(billingConfigParams?.getString("address")),
-        attachDefaultsToPaymentMethod =
-          if (billingConfigParams?.containsKey("attachDefaultsToPaymentMethod") == true) {
-            billingConfigParams.getBoolean("attachDefaultsToPaymentMethod")
-          } else {
-            false
-          },
+      buildBillingDetailsCollectionConfiguration(
+        readableMap?.getMap("billingDetailsCollectionConfiguration"),
       )
     val allowsRemovalOfLastSavedPaymentMethod =
-      if (bundle.containsKey("allowsRemovalOfLastSavedPaymentMethod")) {
-        bundle.getBoolean("allowsRemovalOfLastSavedPaymentMethod")
-      } else {
-        true
-      }
-    val primaryButtonLabel = bundle.getString("primaryButtonLabel")
-    val paymentMethodOrder = bundle.getStringArrayList("paymentMethodOrder")
+      readableMap.getBooleanOr("allowsRemovalOfLastSavedPaymentMethod", true)
+    val primaryButtonLabel = readableMap?.getString("primaryButtonLabel")
+    val paymentMethodOrder = readableMap?.getStringList("paymentMethodOrder")
 
     val formSheetAction =
-      bundle
-        .getBundle("formSheetAction")
+      readableMap
+        ?.getMap("formSheetAction")
         ?.getString("type")
         ?.let { type ->
           when (type) {
@@ -195,22 +148,16 @@ class EmbeddedPaymentElementViewManager :
         .billingDetailsCollectionConfiguration(billingDetailsConfig)
         .preferredNetworks(
           mapToPreferredNetworks(
-            bundle
-              .getIntegerArrayList("preferredNetworks")
-              ?.let { ArrayList(it) },
+            readableMap?.getIntegerList("preferredNetworks"),
           ),
         ).allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod)
-        .cardBrandAcceptance(mapToCardBrandAcceptance(bundle))
+        .cardBrandAcceptance(mapToCardBrandAcceptance(readableMap))
         .embeddedViewDisplaysMandateText(
-          if (bundle.containsKey("embeddedViewDisplaysMandateText")) {
-            bundle.getBoolean("embeddedViewDisplaysMandateText")
-          } else {
-            true
-          },
+          readableMap.getBooleanOr("embeddedViewDisplaysMandateText", true),
         )
         .customPaymentMethods(
           parseCustomPaymentMethods(
-            bundle.getBundle("customPaymentMethodConfiguration") ?: Bundle(),
+            readableMap?.getMap("customPaymentMethodConfiguration"),
           ),
         )
 
@@ -220,10 +167,10 @@ class EmbeddedPaymentElementViewManager :
     return configurationBuilder.build()
   }
 
-  internal fun parseRowSelectionBehavior(bundle: Bundle): RowSelectionBehaviorType {
+  internal fun parseRowSelectionBehavior(readableMap: ReadableMap?): RowSelectionBehaviorType {
     val rowSelectionBehavior =
-      bundle
-        .getBundle("rowSelectionBehavior")
+      readableMap
+        ?.getMap("rowSelectionBehavior")
         ?.getString("type")
         ?.let { type ->
           when (type) {
@@ -235,8 +182,8 @@ class EmbeddedPaymentElementViewManager :
     return rowSelectionBehavior
   }
 
-  internal fun parseIntentConfiguration(bundle: Bundle): PaymentSheet.IntentConfiguration {
-    val intentConfig = PaymentSheetFragment.buildIntentConfiguration(bundle)
+  internal fun parseIntentConfiguration(readableMap: ReadableMap?): PaymentSheet.IntentConfiguration {
+    val intentConfig = buildIntentConfiguration(readableMap)
     return intentConfig ?: throw IllegalArgumentException("IntentConfiguration is null")
   }
 
@@ -247,37 +194,4 @@ class EmbeddedPaymentElementViewManager :
   override fun clearPaymentOption(view: EmbeddedPaymentElementView) {
     view.clearPaymentOption()
   }
-}
-
-/**
- * Returns a List of Strings if the key exists and points to an array of strings, or null otherwise.
- */
-fun ReadableMap.getStringArrayList(key: String): List<String>? {
-  if (!hasKey(key) || getType(key) != ReadableType.Array) return null
-  val array: ReadableArray = getArray(key) ?: return null
-
-  val result = mutableListOf<String>()
-  for (i in 0 until array.size) {
-    // getString returns null if the element isn't actually a string
-    array.getString(i)?.let { result.add(it) }
-  }
-  return result
-}
-
-/**
- * Returns a List of Ints if the key exists and points to an array of numbers, or null otherwise.
- */
-fun ReadableMap.getIntegerArrayList(key: String): List<Int>? {
-  if (!hasKey(key) || getType(key) != ReadableType.Array) return null
-  val array: ReadableArray = getArray(key) ?: return null
-
-  val result = mutableListOf<Int>()
-  for (i in 0 until array.size) {
-    // getType check to skip non-number entries
-    if (array.getType(i) == ReadableType.Number) {
-      // if it's actually a float/double, this will truncate; adjust as needed
-      result.add(array.getInt(i))
-    }
-  }
-  return result
 }

--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/PaymentElementConfig.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/PaymentElementConfig.kt
@@ -29,6 +29,8 @@ internal fun buildIntentConfiguration(intentConfigurationParams: ReadableMap?): 
     paymentMethodTypes =
       intentConfigurationParams.getStringList("paymentMethodTypes")?.toList()
         ?: emptyList(),
+    paymentMethodConfigurationId =
+      intentConfigurationParams.getString("paymentMethodConfigurationId"),
     onBehalfOf = intentConfigurationParams.getString("onBehalfOf"),
   )
 }

--- a/packages/stripe_ios/ios/stripe_ios/Package.resolved
+++ b/packages/stripe_ios/ios/stripe_ios/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stripe/stripe-ios-spm",
       "state" : {
-        "revision" : "4f322eb59a7f49a239a36078357c4cac7dac07cd",
-        "version" : "24.16.1"
+        "revision" : "bf87cb248c4a8bd5176acbf9e10e50a010977ac1",
+        "version" : "25.9.0"
       }
     }
   ],

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/EmbeddedPaymentElementFactory.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/EmbeddedPaymentElementFactory.swift
@@ -4,7 +4,12 @@ import UIKit
 import Stripe
 @_spi(EmbeddedPaymentElementPrivateBeta) import StripePaymentSheet
 
-private class FlutterEmbeddedPaymentElementContainerView: UIView {
+class FlutterEmbeddedPaymentElementContainerView: UIView {
+    weak var channel: FlutterMethodChannel?
+    weak var paymentElementView: UIView?
+    private var lastReportedHeight: CGFloat = 0
+    private var isReportingHeight = false
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .clear
@@ -13,6 +18,43 @@ private class FlutterEmbeddedPaymentElementContainerView: UIView {
 
     required init?(coder: NSCoder) {
         fatalError()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        reportHeightIfNeeded()
+    }
+
+    private func reportHeightIfNeeded() {
+        guard !isReportingHeight else { return }
+        guard let channel = channel else { return }
+        guard window != nil else { return }
+        guard let paymentView = paymentElementView else { return }
+
+        isReportingHeight = true
+        defer { isReportingHeight = false }
+
+        // Primary path: use payment view's bounds.height after layout (no extra AutoLayout pass)
+        var height = paymentView.bounds.height
+
+        // Fallback: only if payment view bounds not yet set (first layout)
+        if height == 0 {
+            let width = bounds.width > 0 ? bounds.width : paymentView.bounds.width
+            guard width > 0 else { return }
+            height = paymentView.systemLayoutSizeFitting(
+                CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+                withHorizontalFittingPriority: .required,
+                verticalFittingPriority: .fittingSizeLevel
+            ).height
+        }
+
+        guard height > 0 else { return }
+        guard abs(height - lastReportedHeight) > 1.0 else { return }
+
+        lastReportedHeight = height
+        DispatchQueue.main.async { [weak channel, height] in
+            channel?.invokeMethod("onHeightChanged", arguments: ["height": height])
+        }
     }
 }
 
@@ -123,13 +165,22 @@ class EmbeddedPaymentElementPlatformView: NSObject, FlutterPlatformView {
 
     @MainActor
     private func attachEmbeddedView(_ embeddedElement: EmbeddedPaymentElement) {
-        delegate = FlutterEmbeddedPaymentElementDelegate(channel: channel)
+        // Connect container to channel for height reporting via layoutSubviews
+        embeddedView.channel = channel
+
+        delegate = FlutterEmbeddedPaymentElementDelegate(channel: channel, containerView: embeddedView)
         embeddedElement.delegate = delegate
 
         let paymentElementView = embeddedElement.view
         embeddedView.addSubview(paymentElementView)
+        embeddedView.paymentElementView = paymentElementView
         paymentElementView.translatesAutoresizingMaskIntoConstraints = false
 
+        // Let Stripe's view size itself naturally via intrinsic content size
+        paymentElementView.setContentHuggingPriority(.required, for: .vertical)
+        paymentElementView.setContentCompressionResistancePriority(.required, for: .vertical)
+
+        // Only pin 3 edges - no bottom constraint so height is driven by content
         NSLayoutConstraint.activate([
             paymentElementView.topAnchor.constraint(equalTo: embeddedView.topAnchor),
             paymentElementView.leadingAnchor.constraint(equalTo: embeddedView.leadingAnchor),
@@ -140,7 +191,9 @@ class EmbeddedPaymentElementPlatformView: NSObject, FlutterPlatformView {
             embeddedElement.presentingViewController = viewController
         }
 
-        delegate?.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: embeddedElement)
+        // Trigger initial layout to report height (async to avoid synchronous layout)
+        embeddedView.setNeedsLayout()
+
         delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: embeddedElement)
     }
 
@@ -170,38 +223,18 @@ class EmbeddedPaymentElementPlatformView: NSObject, FlutterPlatformView {
 
 class FlutterEmbeddedPaymentElementDelegate: EmbeddedPaymentElementDelegate {
     weak var channel: FlutterMethodChannel?
-    private var lastReportedHeight: CGFloat = 0
-    private var isReportingHeight = false
+    weak var containerView: FlutterEmbeddedPaymentElementContainerView?
 
-    init(channel: FlutterMethodChannel) {
+    init(channel: FlutterMethodChannel, containerView: FlutterEmbeddedPaymentElementContainerView) {
         self.channel = channel
+        self.containerView = containerView
     }
 
     func embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: StripePaymentSheet.EmbeddedPaymentElement) {
-        guard channel != nil else { return }
-        guard !isReportingHeight else { return }
-
-        isReportingHeight = true
-        DispatchQueue.main.async { [weak self, weak embeddedPaymentElement] in
-            guard let self else { return }
-            defer { self.isReportingHeight = false }
-            guard
-                let embeddedPaymentElement,
-                let channel = self.channel,
-                embeddedPaymentElement.view.window != nil
-            else { return }
-
-            let targetSize = embeddedPaymentElement.view.systemLayoutSizeFitting(
-                UIView.layoutFittingCompressedSize
-            )
-            let newHeight = targetSize.height
-
-            guard newHeight > 0 else { return }
-            guard abs(newHeight - self.lastReportedHeight) > 1.0 else { return }
-
-            // Simulator was getting stuck because CA re-enters this callback; keep it guarded.
-            self.lastReportedHeight = newHeight
-            channel.invokeMethod("onHeightChanged", arguments: ["height": newHeight])
+        // Mark layout as dirty - the container's layoutSubviews will report the height
+        // No synchronous layoutIfNeeded() to avoid forcing layout passes
+        DispatchQueue.main.async { [weak self] in
+            self?.containerView?.setNeedsLayout()
         }
     }
 

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/EmbeddedPaymentElementFactory.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/EmbeddedPaymentElementFactory.swift
@@ -1,0 +1,188 @@
+import Flutter
+import Foundation
+import UIKit
+import Stripe
+@_spi(EmbeddedPaymentElementPrivateBeta) import StripePaymentSheet
+
+private class FlutterEmbeddedPaymentElementContainerView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        clipsToBounds = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+}
+
+public class EmbeddedPaymentElementViewFactory: NSObject, FlutterPlatformViewFactory {
+    private var messenger: FlutterBinaryMessenger
+
+    init(messenger: FlutterBinaryMessenger) {
+        self.messenger = messenger
+        super.init()
+    }
+
+    public func create(
+        withFrame frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?
+    ) -> FlutterPlatformView {
+        return EmbeddedPaymentElementPlatformView(
+            frame: frame,
+            viewIdentifier: viewId,
+            arguments: args,
+            binaryMessenger: messenger
+        )
+    }
+
+    public func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+        return FlutterStandardMessageCodec.sharedInstance()
+    }
+}
+
+class EmbeddedPaymentElementPlatformView: NSObject, FlutterPlatformView {
+
+    private let embeddedView: FlutterEmbeddedPaymentElementContainerView
+    private let channel: FlutterMethodChannel
+    private var delegate: FlutterEmbeddedPaymentElementDelegate?
+
+    init(
+        frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?,
+        binaryMessenger messenger: FlutterBinaryMessenger
+    ) {
+        embeddedView = FlutterEmbeddedPaymentElementContainerView(frame: frame)
+        channel = FlutterMethodChannel(
+            name: "flutter.stripe/embedded_payment_element/\(viewId)",
+            binaryMessenger: messenger
+        )
+
+        super.init()
+        channel.setMethodCallHandler(handle)
+
+        if let arguments = args as? [String: Any] {
+            initializeEmbeddedPaymentElement(arguments)
+        }
+    }
+
+    private func initializeEmbeddedPaymentElement(_ arguments: [String: Any]) {
+        guard let intentConfiguration = arguments["intentConfiguration"] as? NSDictionary,
+              let configuration = arguments["configuration"] as? NSDictionary else {
+            channel.invokeMethod("embeddedPaymentElementLoadingFailed", arguments: ["message": "Invalid configuration"])
+            return
+        }
+
+        let mutableIntentConfig = intentConfiguration.mutableCopy() as! NSMutableDictionary
+        mutableIntentConfig["confirmHandler"] = true
+
+        StripeSdkImpl.shared.createEmbeddedPaymentElement(
+            intentConfig: mutableIntentConfig,
+            configuration: configuration,
+            resolve: { [weak self] result in
+                Task { @MainActor in
+                    guard let self = self else { return }
+
+                    if let resultDict = result as? NSDictionary,
+                       let error = resultDict["error"] as? NSDictionary,
+                       let message = error["message"] as? String {
+                        self.channel.invokeMethod("embeddedPaymentElementLoadingFailed", arguments: ["message": message])
+                        return
+                    }
+
+                    if let embeddedElement = StripeSdkImpl.shared.embeddedInstance {
+                        self.attachEmbeddedView(embeddedElement)
+                    } else {
+                        self.channel.invokeMethod("embeddedPaymentElementLoadingFailed", arguments: ["message": "Failed to create embedded payment element"])
+                    }
+                }
+            },
+            reject: { [weak self] code, message, error in
+                guard let self = self else { return }
+                let errorMessage = message ?? error?.localizedDescription ?? "Unknown error"
+                self.channel.invokeMethod("embeddedPaymentElementLoadingFailed", arguments: ["message": errorMessage])
+            }
+        )
+    }
+
+    @MainActor
+    private func attachEmbeddedView(_ embeddedElement: EmbeddedPaymentElement) {
+        delegate = FlutterEmbeddedPaymentElementDelegate(channel: channel, embeddedView: embeddedView)
+        embeddedElement.delegate = delegate
+
+        let paymentElementView = embeddedElement.view
+        embeddedView.addSubview(paymentElementView)
+        paymentElementView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            paymentElementView.topAnchor.constraint(equalTo: embeddedView.topAnchor),
+            paymentElementView.leadingAnchor.constraint(equalTo: embeddedView.leadingAnchor),
+            paymentElementView.trailingAnchor.constraint(equalTo: embeddedView.trailingAnchor),
+        ])
+
+        if let viewController = embeddedView.window?.rootViewController {
+            embeddedElement.presentingViewController = viewController
+        }
+
+        delegate?.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: embeddedElement)
+        delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: embeddedElement)
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "confirm":
+            StripeSdkImpl.shared.confirmEmbeddedPaymentElement(
+                resolve: { confirmResult in
+                    result(confirmResult)
+                },
+                reject: { code, message, error in
+                    result(FlutterError(code: code ?? "Failed", message: message, details: error))
+                }
+            )
+        case "clearPaymentOption":
+            StripeSdkImpl.shared.clearEmbeddedPaymentOption()
+            result(nil)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    func view() -> UIView {
+        return embeddedView
+    }
+}
+
+class FlutterEmbeddedPaymentElementDelegate: EmbeddedPaymentElementDelegate {
+    weak var channel: FlutterMethodChannel?
+    weak var embeddedView: UIView?
+
+    init(channel: FlutterMethodChannel, embeddedView: UIView) {
+        self.channel = channel
+        self.embeddedView = embeddedView
+    }
+
+    func embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: StripePaymentSheet.EmbeddedPaymentElement) {
+        guard let channel = channel else { return }
+
+        let newHeight = embeddedPaymentElement.view.systemLayoutSizeFitting(
+            CGSize(width: embeddedPaymentElement.view.bounds.width, height: UIView.layoutFittingCompressedSize.height)
+        ).height
+
+        channel.invokeMethod("onHeightChanged", arguments: ["height": newHeight])
+    }
+
+    func embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: EmbeddedPaymentElement) {
+        guard let channel = channel else { return }
+
+        let displayDataDict = embeddedPaymentElement.paymentOption?.toDictionary()
+        channel.invokeMethod("onPaymentOptionChanged", arguments: ["paymentOption": displayDataDict as Any])
+    }
+
+    func embeddedPaymentElementWillPresent(embeddedPaymentElement: EmbeddedPaymentElement) {
+        if let viewController = embeddedView?.window?.rootViewController {
+            embeddedPaymentElement.presentingViewController = viewController
+        }
+    }
+}

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/EmbeddedPaymentElementView.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/EmbeddedPaymentElementView.swift
@@ -1,33 +1,14 @@
-//
-//  EmbeddedPaymentElementView.swift
-//  stripe-react-native
-//
-//  Created by Nick Porter on 4/16/25.
-//
-
 import Foundation
 @_spi(EmbeddedPaymentElementPrivateBeta) import StripePaymentSheet
 import UIKit
 
-@objc(EmbeddedPaymentElementView)
-class EmbeddedPaymentElementView: RCTViewManager {
-
-    override static func requiresMainQueueSetup() -> Bool {
-        return true
-    }
-
-    override func view() -> UIView! {
-        return EmbeddedPaymentElementContainerView(frame: .zero)
-    }
-}
-
-@objc(EmbeddedPaymentElementContainerView)
-public class EmbeddedPaymentElementContainerView: UIView, UIGestureRecognizerDelegate {
+public class EmbeddedPaymentElementContainerView: UIView {
     private var embeddedPaymentElementView: UIView?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .clear
+        clipsToBounds = true
     }
 
     required init?(coder: NSCoder) {
@@ -37,7 +18,6 @@ public class EmbeddedPaymentElementContainerView: UIView, UIGestureRecognizerDel
     public override func didMoveToWindow() {
         super.didMoveToWindow()
         if window != nil {
-            // Only attach when we have a valid window
             attachPaymentElementIfAvailable()
         }
     }
@@ -45,13 +25,11 @@ public class EmbeddedPaymentElementContainerView: UIView, UIGestureRecognizerDel
     public override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
         if newWindow == nil {
-            // Remove the embedded view when moving away from window
             removePaymentElement()
         }
     }
 
     private func attachPaymentElementIfAvailable() {
-        // Don't attach if already attached
         guard embeddedPaymentElementView == nil,
               let embeddedElement = StripeSdkImpl.shared.embeddedInstance else {
             return
@@ -69,8 +47,6 @@ public class EmbeddedPaymentElementContainerView: UIView, UIGestureRecognizerDel
         ])
 
         self.embeddedPaymentElementView = paymentElementView
-
-        // Update the presenting view controller whenever we attach
         updatePresentingViewController()
     }
 
@@ -82,7 +58,9 @@ public class EmbeddedPaymentElementContainerView: UIView, UIGestureRecognizerDel
     private func updatePresentingViewController() {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            StripeSdkImpl.shared.embeddedInstance?.presentingViewController = RCTPresentedViewController()
+            if let viewController = self.window?.rootViewController {
+                StripeSdkImpl.shared.embeddedInstance?.presentingViewController = viewController
+            }
         }
     }
 }

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
@@ -82,15 +82,20 @@ extension StripeSdkImpl {
         embeddedInstanceDelegate.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: embeddedPaymentElement)
         embeddedInstanceDelegate.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: embeddedPaymentElement)
       } catch {
-        let msg = error.localizedDescription
-
-        if self.emitter != nil {
-          self.emitter?.emitEmbeddedPaymentElementLoadingFailed(["message": msg])
-        } else {
-          //TODO HANDLE emitter nil
-        }
-
-        resolve(nil)
+        let errorPayload = Errors.createError(ErrorType.Failed, error)
+        let errorDetails = errorPayload["error"] as? NSDictionary
+        let (message, code) = extractEmbeddedPaymentElementErrorInfo(
+          from: errorDetails,
+          fallbackMessage: error.localizedDescription,
+          fallbackCode: ErrorType.Failed
+        )
+        dispatchEmbeddedPaymentElementLoadingFailed(
+          message: message,
+          code: code,
+          details: errorDetails
+        )
+        resolve(errorPayload)
+        return
       }
     }
 
@@ -176,7 +181,18 @@ extension StripeSdkImpl {
       case .canceled:
         resolve(["status": "canceled"])
       case .failed(let error):
-        self.emitter?.emitEmbeddedPaymentElementLoadingFailed(["message": error.localizedDescription])
+        let errorPayload = Errors.createError(ErrorType.Failed, error)
+        let errorDetails = errorPayload["error"] as? NSDictionary
+        let (message, code) = extractEmbeddedPaymentElementErrorInfo(
+          from: errorDetails,
+          fallbackMessage: error.localizedDescription,
+          fallbackCode: ErrorType.Failed
+        )
+        dispatchEmbeddedPaymentElementLoadingFailed(
+          message: message,
+          code: code,
+          details: errorDetails
+        )
         // We don't resolve with an error b/c loading errors are handled via the embeddedPaymentElementLoadingFailed event
         resolve(nil)
       }
@@ -187,6 +203,37 @@ extension StripeSdkImpl {
   public func clearEmbeddedPaymentOption() {
     DispatchQueue.main.async {
       self.embeddedInstance?.clearPaymentOption()
+    }
+  }
+
+  private func extractEmbeddedPaymentElementErrorInfo(
+    from details: NSDictionary?,
+    fallbackMessage: String,
+    fallbackCode: String
+  ) -> (message: String, code: String) {
+    let message = (details?["localizedMessage"] as? String)
+      ?? (details?["message"] as? String)
+      ?? fallbackMessage
+    let code = (details?["code"] as? String) ?? fallbackCode
+    return (message, code)
+  }
+
+  private func dispatchEmbeddedPaymentElementLoadingFailed(
+    message: String,
+    code: String?,
+    details: NSDictionary?
+  ) {
+    guard self.emitter != nil else { return }
+    DispatchQueue.main.async { [weak self] in
+      guard let emitter = self?.emitter else { return }
+      var payload: [String: Any] = ["message": message]
+      if let code = code {
+        payload["code"] = code
+      }
+      if let details = details {
+        payload["details"] = details
+      }
+      emitter.emitEmbeddedPaymentElementLoadingFailed(payload)
     }
   }
 

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
@@ -44,8 +44,25 @@ extension StripeSdkImpl {
       useConfirmationTokenCallback: hasConfirmationTokenHandler
     )
 
-    guard let configuration = buildEmbeddedPaymentElementConfiguration(params: configuration).configuration else {
+    let configResult = buildEmbeddedPaymentElementConfiguration(params: configuration)
+    if let error = configResult.error {
+      resolve(error)
+      return
+    }
+    guard let configuration = configResult.configuration else {
       resolve(Errors.createError(ErrorType.Failed, "Invalid configuration"))
+      return
+    }
+
+    if STPAPIClient.shared.publishableKey == nil || STPAPIClient.shared.publishableKey?.isEmpty == true {
+      let errorMsg = "Stripe publishableKey is not set"
+      resolve(Errors.createError(ErrorType.Failed, errorMsg))
+      return
+    }
+
+    if configuration.returnURL == nil || configuration.returnURL?.isEmpty == true {
+      let errorMsg = "returnURL is required for EmbeddedPaymentElement"
+      resolve(Errors.createError(ErrorType.Failed, errorMsg))
       return
     }
 
@@ -59,19 +76,20 @@ extension StripeSdkImpl {
         embeddedPaymentElement.presentingViewController = RCTPresentedViewController()
         self.embeddedInstance = embeddedPaymentElement
 
-        // success: resolve promise
         resolve(nil)
 
-        // publish initial state
         embeddedInstanceDelegate.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: embeddedPaymentElement)
         embeddedInstanceDelegate.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: embeddedPaymentElement)
       } catch {
-        // 1) still resolve the promise so JS hook can finish loading
-        resolve(nil)
-
-        // 2) emit a loading‐failed event with the error message
         let msg = error.localizedDescription
-        self.emitter?.emitEmbeddedPaymentElementLoadingFailed(["message": msg])
+
+        if self.emitter != nil {
+          self.emitter?.emitEmbeddedPaymentElementLoadingFailed(["message": msg])
+        } else {
+          //TODO HANDLE emitter nil
+        }
+
+        resolve(nil)
       }
     }
 
@@ -81,8 +99,14 @@ extension StripeSdkImpl {
   public func confirmEmbeddedPaymentElement(resolve: @escaping RCTPromiseResolveBlock,
                                             reject: @escaping RCTPromiseRejectBlock) {
       DispatchQueue.main.async { [weak self] in
-          self?.embeddedInstance?.presentingViewController = RCTPresentedViewController()
-          self?.embeddedInstance?.confirm { result in
+          guard let embeddedInstance = self?.embeddedInstance else {
+              resolve([
+                "status": "failed",
+                "error": "Embedded payment element not available"
+              ])
+              return
+          }
+          embeddedInstance.confirm { result in
               switch result {
               case .completed:
                   // Return an object with { status: 'completed' }

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
@@ -196,14 +196,34 @@ extension StripeSdkImpl {
 
 class StripeSdkEmbeddedPaymentElementDelegate: EmbeddedPaymentElementDelegate {
   weak var sdkImpl: StripeSdkImpl?
+  // Simulator was getting stuck because CA re-enters this callback; keep it guarded.
+  private var isUpdatingHeight = false
+  private var lastReportedHeight: CGFloat = 0
 
   init(sdkImpl: StripeSdkImpl) {
     self.sdkImpl = sdkImpl
   }
 
   func embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: StripePaymentSheet.EmbeddedPaymentElement) {
-    let newHeight = embeddedPaymentElement.view.systemLayoutSizeFitting(CGSize(width: embeddedPaymentElement.view.bounds.width, height: UIView.layoutFittingCompressedSize.height)).height
-    self.sdkImpl?.emitter?.emitEmbeddedPaymentElementDidUpdateHeight(["height": newHeight])
+    guard !isUpdatingHeight else { return }
+    guard embeddedPaymentElement.view.window != nil else { return }
+
+    isUpdatingHeight = true
+    DispatchQueue.main.async { [weak self, weak embeddedPaymentElement] in
+      defer { self?.isUpdatingHeight = false }
+
+      guard let self, let embeddedPaymentElement,
+            embeddedPaymentElement.view.window != nil else { return }
+
+      let newHeight = embeddedPaymentElement.view.systemLayoutSizeFitting(
+        CGSize(width: embeddedPaymentElement.view.bounds.width,
+               height: UIView.layoutFittingCompressedSize.height)
+      ).height
+
+      guard newHeight > 0, abs(newHeight - self.lastReportedHeight) > 1 else { return }
+      self.lastReportedHeight = newHeight
+      self.sdkImpl?.emitter?.emitEmbeddedPaymentElementDidUpdateHeight(["height": newHeight])
+    }
   }
 
   func embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: EmbeddedPaymentElement) {

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
@@ -206,6 +206,7 @@ extension StripeSdkImpl {
     }
   }
 
+  @nonobjc
   private func extractEmbeddedPaymentElementErrorInfo(
     from details: NSDictionary?,
     fallbackMessage: String,
@@ -218,6 +219,7 @@ extension StripeSdkImpl {
     return (message, code)
   }
 
+  @nonobjc
   private func dispatchEmbeddedPaymentElementLoadingFailed(
     message: String,
     code: String?,

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
@@ -40,6 +40,7 @@ extension StripeSdkImpl {
       modeParams: modeParams,
       paymentMethodTypes: intentConfig["paymentMethodTypes"] as? [String],
       onBehalfOf: intentConfig["onBehalfOf"] as? String,
+      paymentMethodConfigurationId: intentConfig["paymentMethodConfigurationId"] as? String,
       captureMethod: StripeSdkImpl.mapCaptureMethod(captureMethodString),
       useConfirmationTokenCallback: hasConfirmationTokenHandler
     )
@@ -155,6 +156,7 @@ extension StripeSdkImpl {
       modeParams: modeParams,
       paymentMethodTypes: intentConfig["paymentMethodTypes"] as? [String],
       onBehalfOf: intentConfig["onBehalfOf"] as? String,
+      paymentMethodConfigurationId: intentConfig["paymentMethodConfigurationId"] as? String,
       captureMethod: StripeSdkImpl.mapCaptureMethod(captureMethodString),
       useConfirmationTokenCallback: hasConfirmationTokenHandler
     )

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+PaymentSheet.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+PaymentSheet.swift
@@ -239,6 +239,7 @@ extension StripeSdkImpl {
                 modeParams: modeParams,
                 paymentMethodTypes: intentConfiguration["paymentMethodTypes"] as? [String],
                 onBehalfOf: intentConfiguration["onBehalfOf"] as? String,
+                paymentMethodConfigurationId: intentConfiguration["paymentMethodConfigurationId"] as? String,
                 captureMethod: StripeSdkImpl.mapCaptureMethod(captureMethodString),
                 useConfirmationTokenCallback: hasConfirmationTokenHandler
             )
@@ -337,6 +338,7 @@ extension StripeSdkImpl {
         modeParams: NSDictionary,
         paymentMethodTypes: [String]?,
         onBehalfOf: String?,
+        paymentMethodConfigurationId: String?,
         captureMethod: PaymentSheet.IntentConfiguration.CaptureMethod,
         useConfirmationTokenCallback: Bool
     ) -> PaymentSheet.IntentConfiguration {
@@ -361,6 +363,7 @@ extension StripeSdkImpl {
                 mode: mode,
                 paymentMethodTypes: paymentMethodTypes,
                 onBehalfOf: onBehalfOf,
+                paymentMethodConfigurationId: paymentMethodConfigurationId,
                 confirmationTokenConfirmHandler: { confirmationToken in
                     return try await withCheckedThrowingContinuation { continuation in
                         self.paymentSheetConfirmationTokenIntentCreationCallback = { result in
@@ -381,6 +384,7 @@ extension StripeSdkImpl {
                 mode: mode,
                 paymentMethodTypes: paymentMethodTypes,
                 onBehalfOf: onBehalfOf,
+                paymentMethodConfigurationId: paymentMethodConfigurationId,
                 confirmHandler: { paymentMethod, shouldSavePaymentMethod, intentCreationCallback in
                     self.paymentSheetIntentCreationCallback = intentCreationCallback
                     self.emitter?.emitOnConfirmHandlerCallback([

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl.swift
@@ -159,6 +159,7 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
 
         STPAPIClient.shared.appInfo = STPAppInfo(name: name, partnerId: partnerId, version: version, url: url)
         self.merchantIdentifier = merchantIdentifier
+        StripeSdkImpl.shared.merchantIdentifier = merchantIdentifier
         resolve(NSNull())
     }
 

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
@@ -64,6 +64,7 @@ class StripePlugin: StripeSdkImpl, FlutterPlugin, ViewManagerDelegate {
 
         let instance = StripePlugin(channel: channel)
         instance.emitter = instance
+        StripeSdkImpl.shared.emitter = instance
         registrar.addMethodCallDelegate(instance, channel: channel)
         registrar.addApplicationDelegate(instance)
 
@@ -86,6 +87,10 @@ class StripePlugin: StripeSdkImpl, FlutterPlugin, ViewManagerDelegate {
         // Addressheet
         let addressSheetFactory = AddressSheetViewFactory(messenger: registrar.messenger(), delegate: instance)
         registrar.register(addressSheetFactory, withId: "flutter.stripe/address_sheet")
+
+        // Embedded Payment Element
+        let embeddedPaymentElementFactory = EmbeddedPaymentElementViewFactory(messenger: registrar.messenger())
+        registrar.register(embeddedPaymentElementFactory, withId: "flutter.stripe/embedded_payment_element")
 
     }
 
@@ -853,7 +858,11 @@ extension  StripePlugin {
             return
         }
 
-        intentCreationCallback(result: params, resolver: resolver(for: result), rejecter: rejecter(for: result))
+        StripeSdkImpl.shared.intentCreationCallback(
+            result: params,
+            resolver: resolver(for: result),
+            rejecter: rejecter(for: result)
+        )
         result(nil)
     }
 

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -1,6 +1,3 @@
-import 'dart:io';
-
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:stripe_platform_interface/src/models/ach_params.dart';
@@ -79,9 +76,6 @@ class MethodChannelStripe extends StripePlatform {
         _confirmHandler!(
           method,
           call.arguments['shouldSavePaymentMethod'] as bool,
-          (params) {
-            intentCreationCallback(params);
-          },
         );
       } else if (call.method == 'onConfirmationTokenHandlerCallback' &&
           _confirmTokenHandler != null) {

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:stripe_platform_interface/src/models/ach_params.dart';
@@ -76,6 +79,9 @@ class MethodChannelStripe extends StripePlatform {
         _confirmHandler!(
           method,
           call.arguments['shouldSavePaymentMethod'] as bool,
+          (params) {
+            intentCreationCallback(params);
+          },
         );
       } else if (call.method == 'onConfirmationTokenHandlerCallback' &&
           _confirmTokenHandler != null) {
@@ -741,6 +747,11 @@ class MethodChannelStripe extends StripePlatform {
     await _methodChannel.invokeMethod('confirmationTokenCreationCallback', {
       'params': params.toJson(),
     });
+  }
+
+  @override
+  void setConfirmHandler(ConfirmHandler? handler) {
+    _confirmHandler = handler;
   }
 
   @override

--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.dart
@@ -653,11 +653,7 @@ enum IntentFutureUsage {
 }
 
 typedef ConfirmHandler =
-    void Function(
-      PaymentMethod result,
-      bool shouldSavePaymentMethod,
-      void Function(IntentCreationCallbackParams) intentCreationCallback,
-    );
+    void Function(PaymentMethod result, bool shouldSavePaymentMethod);
 
 typedef ConfirmTokenHandler = void Function(ConfirmationTokenResult result);
 

--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.dart
@@ -162,6 +162,10 @@ abstract class IntentConfiguration with _$IntentConfiguration {
     /// If not set, the payment sheet will display all the payment methods enabled in your Stripe dashboard.
     List<String>? paymentMethodTypes,
 
+    /// Configuration ID for the selected payment method configuration.
+    /// See https://stripe.com/docs/payments/multiple-payment-method-configs
+    String? paymentMethodConfigurationId,
+
     /// Called when the customer confirms payment. Your implementation should create
     /// a payment intent or setupintent on your server and call the intent creation callback with its client secret or an error if one occurred.
     @JsonKey(includeFromJson: false, includeToJson: false)

--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.dart
@@ -649,7 +649,11 @@ enum IntentFutureUsage {
 }
 
 typedef ConfirmHandler =
-    void Function(PaymentMethod result, bool shouldSavePaymentMethod);
+    void Function(
+      PaymentMethod result,
+      bool shouldSavePaymentMethod,
+      void Function(IntentCreationCallbackParams) intentCreationCallback,
+    );
 
 typedef ConfirmTokenHandler = void Function(ConfirmationTokenResult result);
 
@@ -878,6 +882,7 @@ abstract class FlatConfig with _$FlatConfig {
 /// Describes the appearance of the floating button style payment method row
 @freezed
 abstract class FloatingConfig with _$FloatingConfig {
+  @JsonSerializable(explicitToJson: true)
   const factory FloatingConfig({
     /// The spacing between payment method rows.
     double? spacing,
@@ -890,6 +895,7 @@ abstract class FloatingConfig with _$FloatingConfig {
 /// Describes the appearance of the row in the Embedded Mobile Payment Element
 @freezed
 abstract class RowConfig with _$RowConfig {
+  @JsonSerializable(explicitToJson: true)
   const factory RowConfig({
     /// The display style of the row.
     RowStyle? style,
@@ -914,6 +920,7 @@ abstract class RowConfig with _$RowConfig {
 @freezed
 abstract class EmbeddedPaymentElementAppearance
     with _$EmbeddedPaymentElementAppearance {
+  @JsonSerializable(explicitToJson: true)
   const factory EmbeddedPaymentElementAppearance({RowConfig? row}) =
       _EmbeddedPaymentElementAppearance;
 

--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.freezed.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.freezed.dart
@@ -790,7 +790,9 @@ mixin _$IntentConfiguration {
  IntentMode get mode;/// The list of payment method types that the customer can use in the payment sheet.
 ///
 /// If not set, the payment sheet will display all the payment methods enabled in your Stripe dashboard.
- List<String>? get paymentMethodTypes;/// Called when the customer confirms payment. Your implementation should create
+ List<String>? get paymentMethodTypes;/// Configuration ID for the selected payment method configuration.
+/// See https://stripe.com/docs/payments/multiple-payment-method-configs
+ String? get paymentMethodConfigurationId;/// Called when the customer confirms payment. Your implementation should create
 /// a payment intent or setupintent on your server and call the intent creation callback with its client secret or an error if one occurred.
 @JsonKey(includeFromJson: false, includeToJson: false) ConfirmHandler? get confirmHandler;/// Called when the customer confirms token payment.
 @JsonKey(includeFromJson: false, includeToJson: false) ConfirmTokenHandler? get confirmTokenHandler;
@@ -806,16 +808,16 @@ $IntentConfigurationCopyWith<IntentConfiguration> get copyWith => _$IntentConfig
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is IntentConfiguration&&(identical(other.mode, mode) || other.mode == mode)&&const DeepCollectionEquality().equals(other.paymentMethodTypes, paymentMethodTypes)&&(identical(other.confirmHandler, confirmHandler) || other.confirmHandler == confirmHandler)&&(identical(other.confirmTokenHandler, confirmTokenHandler) || other.confirmTokenHandler == confirmTokenHandler));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is IntentConfiguration&&(identical(other.mode, mode) || other.mode == mode)&&const DeepCollectionEquality().equals(other.paymentMethodTypes, paymentMethodTypes)&&(identical(other.paymentMethodConfigurationId, paymentMethodConfigurationId) || other.paymentMethodConfigurationId == paymentMethodConfigurationId)&&(identical(other.confirmHandler, confirmHandler) || other.confirmHandler == confirmHandler)&&(identical(other.confirmTokenHandler, confirmTokenHandler) || other.confirmTokenHandler == confirmTokenHandler));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,mode,const DeepCollectionEquality().hash(paymentMethodTypes),confirmHandler,confirmTokenHandler);
+int get hashCode => Object.hash(runtimeType,mode,const DeepCollectionEquality().hash(paymentMethodTypes),paymentMethodConfigurationId,confirmHandler,confirmTokenHandler);
 
 @override
 String toString() {
-  return 'IntentConfiguration(mode: $mode, paymentMethodTypes: $paymentMethodTypes, confirmHandler: $confirmHandler, confirmTokenHandler: $confirmTokenHandler)';
+  return 'IntentConfiguration(mode: $mode, paymentMethodTypes: $paymentMethodTypes, paymentMethodConfigurationId: $paymentMethodConfigurationId, confirmHandler: $confirmHandler, confirmTokenHandler: $confirmTokenHandler)';
 }
 
 
@@ -826,7 +828,7 @@ abstract mixin class $IntentConfigurationCopyWith<$Res>  {
   factory $IntentConfigurationCopyWith(IntentConfiguration value, $Res Function(IntentConfiguration) _then) = _$IntentConfigurationCopyWithImpl;
 @useResult
 $Res call({
- IntentMode mode, List<String>? paymentMethodTypes,@JsonKey(includeFromJson: false, includeToJson: false) ConfirmHandler? confirmHandler,@JsonKey(includeFromJson: false, includeToJson: false) ConfirmTokenHandler? confirmTokenHandler
+ IntentMode mode, List<String>? paymentMethodTypes, String? paymentMethodConfigurationId,@JsonKey(includeFromJson: false, includeToJson: false) ConfirmHandler? confirmHandler,@JsonKey(includeFromJson: false, includeToJson: false) ConfirmTokenHandler? confirmTokenHandler
 });
 
 
@@ -843,11 +845,12 @@ class _$IntentConfigurationCopyWithImpl<$Res>
 
 /// Create a copy of IntentConfiguration
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mode = null,Object? paymentMethodTypes = freezed,Object? confirmHandler = freezed,Object? confirmTokenHandler = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mode = null,Object? paymentMethodTypes = freezed,Object? paymentMethodConfigurationId = freezed,Object? confirmHandler = freezed,Object? confirmTokenHandler = freezed,}) {
   return _then(_self.copyWith(
 mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
 as IntentMode,paymentMethodTypes: freezed == paymentMethodTypes ? _self.paymentMethodTypes : paymentMethodTypes // ignore: cast_nullable_to_non_nullable
-as List<String>?,confirmHandler: freezed == confirmHandler ? _self.confirmHandler : confirmHandler // ignore: cast_nullable_to_non_nullable
+as List<String>?,paymentMethodConfigurationId: freezed == paymentMethodConfigurationId ? _self.paymentMethodConfigurationId : paymentMethodConfigurationId // ignore: cast_nullable_to_non_nullable
+as String?,confirmHandler: freezed == confirmHandler ? _self.confirmHandler : confirmHandler // ignore: cast_nullable_to_non_nullable
 as ConfirmHandler?,confirmTokenHandler: freezed == confirmTokenHandler ? _self.confirmTokenHandler : confirmTokenHandler // ignore: cast_nullable_to_non_nullable
 as ConfirmTokenHandler?,
   ));
@@ -943,10 +946,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( IntentMode mode,  List<String>? paymentMethodTypes, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmHandler? confirmHandler, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmTokenHandler? confirmTokenHandler)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( IntentMode mode,  List<String>? paymentMethodTypes,  String? paymentMethodConfigurationId, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmHandler? confirmHandler, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmTokenHandler? confirmTokenHandler)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _IntentConfiguration() when $default != null:
-return $default(_that.mode,_that.paymentMethodTypes,_that.confirmHandler,_that.confirmTokenHandler);case _:
+return $default(_that.mode,_that.paymentMethodTypes,_that.paymentMethodConfigurationId,_that.confirmHandler,_that.confirmTokenHandler);case _:
   return orElse();
 
 }
@@ -964,10 +967,10 @@ return $default(_that.mode,_that.paymentMethodTypes,_that.confirmHandler,_that.c
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( IntentMode mode,  List<String>? paymentMethodTypes, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmHandler? confirmHandler, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmTokenHandler? confirmTokenHandler)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( IntentMode mode,  List<String>? paymentMethodTypes,  String? paymentMethodConfigurationId, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmHandler? confirmHandler, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmTokenHandler? confirmTokenHandler)  $default,) {final _that = this;
 switch (_that) {
 case _IntentConfiguration():
-return $default(_that.mode,_that.paymentMethodTypes,_that.confirmHandler,_that.confirmTokenHandler);case _:
+return $default(_that.mode,_that.paymentMethodTypes,_that.paymentMethodConfigurationId,_that.confirmHandler,_that.confirmTokenHandler);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -984,10 +987,10 @@ return $default(_that.mode,_that.paymentMethodTypes,_that.confirmHandler,_that.c
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( IntentMode mode,  List<String>? paymentMethodTypes, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmHandler? confirmHandler, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmTokenHandler? confirmTokenHandler)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( IntentMode mode,  List<String>? paymentMethodTypes,  String? paymentMethodConfigurationId, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmHandler? confirmHandler, @JsonKey(includeFromJson: false, includeToJson: false)  ConfirmTokenHandler? confirmTokenHandler)?  $default,) {final _that = this;
 switch (_that) {
 case _IntentConfiguration() when $default != null:
-return $default(_that.mode,_that.paymentMethodTypes,_that.confirmHandler,_that.confirmTokenHandler);case _:
+return $default(_that.mode,_that.paymentMethodTypes,_that.paymentMethodConfigurationId,_that.confirmHandler,_that.confirmTokenHandler);case _:
   return null;
 
 }
@@ -999,7 +1002,7 @@ return $default(_that.mode,_that.paymentMethodTypes,_that.confirmHandler,_that.c
 
 @JsonSerializable(explicitToJson: true)
 class _IntentConfiguration implements IntentConfiguration {
-  const _IntentConfiguration({required this.mode, final  List<String>? paymentMethodTypes, @JsonKey(includeFromJson: false, includeToJson: false) this.confirmHandler, @JsonKey(includeFromJson: false, includeToJson: false) this.confirmTokenHandler}): _paymentMethodTypes = paymentMethodTypes;
+  const _IntentConfiguration({required this.mode, final  List<String>? paymentMethodTypes, this.paymentMethodConfigurationId, @JsonKey(includeFromJson: false, includeToJson: false) this.confirmHandler, @JsonKey(includeFromJson: false, includeToJson: false) this.confirmTokenHandler}): _paymentMethodTypes = paymentMethodTypes;
   factory _IntentConfiguration.fromJson(Map<String, dynamic> json) => _$IntentConfigurationFromJson(json);
 
 /// Data related to the future payment intent
@@ -1019,6 +1022,9 @@ class _IntentConfiguration implements IntentConfiguration {
   return EqualUnmodifiableListView(value);
 }
 
+/// Configuration ID for the selected payment method configuration.
+/// See https://stripe.com/docs/payments/multiple-payment-method-configs
+@override final  String? paymentMethodConfigurationId;
 /// Called when the customer confirms payment. Your implementation should create
 /// a payment intent or setupintent on your server and call the intent creation callback with its client secret or an error if one occurred.
 @override@JsonKey(includeFromJson: false, includeToJson: false) final  ConfirmHandler? confirmHandler;
@@ -1038,16 +1044,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _IntentConfiguration&&(identical(other.mode, mode) || other.mode == mode)&&const DeepCollectionEquality().equals(other._paymentMethodTypes, _paymentMethodTypes)&&(identical(other.confirmHandler, confirmHandler) || other.confirmHandler == confirmHandler)&&(identical(other.confirmTokenHandler, confirmTokenHandler) || other.confirmTokenHandler == confirmTokenHandler));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _IntentConfiguration&&(identical(other.mode, mode) || other.mode == mode)&&const DeepCollectionEquality().equals(other._paymentMethodTypes, _paymentMethodTypes)&&(identical(other.paymentMethodConfigurationId, paymentMethodConfigurationId) || other.paymentMethodConfigurationId == paymentMethodConfigurationId)&&(identical(other.confirmHandler, confirmHandler) || other.confirmHandler == confirmHandler)&&(identical(other.confirmTokenHandler, confirmTokenHandler) || other.confirmTokenHandler == confirmTokenHandler));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,mode,const DeepCollectionEquality().hash(_paymentMethodTypes),confirmHandler,confirmTokenHandler);
+int get hashCode => Object.hash(runtimeType,mode,const DeepCollectionEquality().hash(_paymentMethodTypes),paymentMethodConfigurationId,confirmHandler,confirmTokenHandler);
 
 @override
 String toString() {
-  return 'IntentConfiguration(mode: $mode, paymentMethodTypes: $paymentMethodTypes, confirmHandler: $confirmHandler, confirmTokenHandler: $confirmTokenHandler)';
+  return 'IntentConfiguration(mode: $mode, paymentMethodTypes: $paymentMethodTypes, paymentMethodConfigurationId: $paymentMethodConfigurationId, confirmHandler: $confirmHandler, confirmTokenHandler: $confirmTokenHandler)';
 }
 
 
@@ -1058,7 +1064,7 @@ abstract mixin class _$IntentConfigurationCopyWith<$Res> implements $IntentConfi
   factory _$IntentConfigurationCopyWith(_IntentConfiguration value, $Res Function(_IntentConfiguration) _then) = __$IntentConfigurationCopyWithImpl;
 @override @useResult
 $Res call({
- IntentMode mode, List<String>? paymentMethodTypes,@JsonKey(includeFromJson: false, includeToJson: false) ConfirmHandler? confirmHandler,@JsonKey(includeFromJson: false, includeToJson: false) ConfirmTokenHandler? confirmTokenHandler
+ IntentMode mode, List<String>? paymentMethodTypes, String? paymentMethodConfigurationId,@JsonKey(includeFromJson: false, includeToJson: false) ConfirmHandler? confirmHandler,@JsonKey(includeFromJson: false, includeToJson: false) ConfirmTokenHandler? confirmTokenHandler
 });
 
 
@@ -1075,11 +1081,12 @@ class __$IntentConfigurationCopyWithImpl<$Res>
 
 /// Create a copy of IntentConfiguration
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? mode = null,Object? paymentMethodTypes = freezed,Object? confirmHandler = freezed,Object? confirmTokenHandler = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? mode = null,Object? paymentMethodTypes = freezed,Object? paymentMethodConfigurationId = freezed,Object? confirmHandler = freezed,Object? confirmTokenHandler = freezed,}) {
   return _then(_IntentConfiguration(
 mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
 as IntentMode,paymentMethodTypes: freezed == paymentMethodTypes ? _self._paymentMethodTypes : paymentMethodTypes // ignore: cast_nullable_to_non_nullable
-as List<String>?,confirmHandler: freezed == confirmHandler ? _self.confirmHandler : confirmHandler // ignore: cast_nullable_to_non_nullable
+as List<String>?,paymentMethodConfigurationId: freezed == paymentMethodConfigurationId ? _self.paymentMethodConfigurationId : paymentMethodConfigurationId // ignore: cast_nullable_to_non_nullable
+as String?,confirmHandler: freezed == confirmHandler ? _self.confirmHandler : confirmHandler // ignore: cast_nullable_to_non_nullable
 as ConfirmHandler?,confirmTokenHandler: freezed == confirmTokenHandler ? _self.confirmTokenHandler : confirmTokenHandler // ignore: cast_nullable_to_non_nullable
 as ConfirmTokenHandler?,
   ));

--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.freezed.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.freezed.dart
@@ -8491,8 +8491,8 @@ return $default(_that.spacing);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(explicitToJson: true)
 class _FloatingConfig implements FloatingConfig {
   const _FloatingConfig({this.spacing});
   factory _FloatingConfig.fromJson(Map<String, dynamic> json) => _$FloatingConfigFromJson(json);
@@ -8788,8 +8788,8 @@ return $default(_that.style,_that.additionalInsets,_that.flat,_that.floating);ca
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(explicitToJson: true)
 class _RowConfig implements RowConfig {
   const _RowConfig({this.style, this.additionalInsets, this.flat, this.floating});
   factory _RowConfig.fromJson(Map<String, dynamic> json) => _$RowConfigFromJson(json);
@@ -9099,8 +9099,8 @@ return $default(_that.row);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(explicitToJson: true)
 class _EmbeddedPaymentElementAppearance implements EmbeddedPaymentElementAppearance {
   const _EmbeddedPaymentElementAppearance({this.row});
   factory _EmbeddedPaymentElementAppearance.fromJson(Map<String, dynamic> json) => _$EmbeddedPaymentElementAppearanceFromJson(json);

--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.g.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.g.dart
@@ -147,6 +147,8 @@ _IntentConfiguration _$IntentConfigurationFromJson(Map<String, dynamic> json) =>
       paymentMethodTypes: (json['paymentMethodTypes'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
+      paymentMethodConfigurationId:
+          json['paymentMethodConfigurationId'] as String?,
     );
 
 Map<String, dynamic> _$IntentConfigurationToJson(
@@ -154,6 +156,7 @@ Map<String, dynamic> _$IntentConfigurationToJson(
 ) => <String, dynamic>{
   'mode': instance.mode.toJson(),
   'paymentMethodTypes': instance.paymentMethodTypes,
+  'paymentMethodConfigurationId': instance.paymentMethodConfigurationId,
 };
 
 _PaymentMode _$PaymentModeFromJson(Map<String, dynamic> json) => _PaymentMode(

--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.g.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.g.dart
@@ -746,8 +746,8 @@ Map<String, dynamic> _$RowConfigToJson(_RowConfig instance) =>
     <String, dynamic>{
       'style': _$RowStyleEnumMap[instance.style],
       'additionalInsets': instance.additionalInsets,
-      'flat': instance.flat,
-      'floating': instance.floating,
+      'flat': instance.flat?.toJson(),
+      'floating': instance.floating?.toJson(),
     };
 
 const _$RowStyleEnumMap = {
@@ -767,7 +767,7 @@ _EmbeddedPaymentElementAppearance _$EmbeddedPaymentElementAppearanceFromJson(
 
 Map<String, dynamic> _$EmbeddedPaymentElementAppearanceToJson(
   _EmbeddedPaymentElementAppearance instance,
-) => <String, dynamic>{'row': instance.row};
+) => <String, dynamic>{'row': instance.row?.toJson()};
 
 _CustomPaymentMethod _$CustomPaymentMethodFromJson(Map<String, dynamic> json) =>
     _CustomPaymentMethod(

--- a/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
@@ -204,6 +204,9 @@ abstract class StripePlatform extends PlatformInterface {
   /// last poll.
   Future<List<String>> pollAndClearPendingStripeConnectUrls();
 
+  /// Set the confirm handler for embedded payment elements
+  void setConfirmHandler(ConfirmHandler? handler);
+
   Widget buildCard({
     Key? key,
     required CardEditController controller,


### PR DESCRIPTION
## What This Adds
Implements the new [Embedded Payment Element](https://docs.stripe.com/payments/mobile/accept-payment-embedded?platform=react-native) from Stripe's mobile SDKs. Lets you embed the payment UI inline instead of using modal sheets.

## Changes
- New `EmbeddedPaymentElement` widget with iOS/Android platform views
- `EmbeddedPaymentElementController` to call `confirm()` and `clearPaymentOption()`
- Callbacks for payment selection, height changes, loading failures, form sheet completion, and immediate actions
- Works with both payment and setup intents

## Status

### iOS ✅
Works. Platform view renders properly, `confirm()` returns the result, all callbacks fire. Tested with cards, Apple Pay, Link, PayPal, Revolut Pay.

### Android ✅
Works. Platform view renders properly, `confirm()` returns the result, all callbacks fire. Tested with cards, Google Pay, Link, PayPal, Revolut Pay.

## Quick Example
```dart
EmbeddedPaymentElement(
  intentConfiguration: IntentConfiguration(
    mode: IntentMode.paymentMode(amount: 5000, currencyCode: 'USD'),
    confirmHandler: (paymentMethod, shouldSave, callback) async {
      // Get client secret from your backend
      callback(IntentCreationCallbackParams(clientSecret: secret));
    },
  ),
  configuration: SetupPaymentSheetParameters(
    merchantDisplayName: 'My Store',
    customerId: customerId,
    customerEphemeralKeySecret: ephemeralKey,
  ),
  controller: controller,
  onPaymentOptionChanged: (option) => print('Payment method selected'),
)
```

---

React Native docs: https://docs.stripe.com/payments/mobile/accept-payment-embedded?platform=react-native


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded Payment Element added for Flutter with native Android/iOS and React Native support
  * Controller to manage Embedded Payment Element lifecycle and actions (confirm, clear, dispose)
  * New API to register/update a confirm handler
  * Support for selecting a paymentMethodConfigurationId in intent/payment-sheet configs
  * Android: Jetpack Compose enabled for embedded element rendering
* **Stability**
  * Improved loading/error reporting and height update handling for the embedded element
<!-- end of auto-generated comment: release notes by coderabbit.ai -->