### PR TITLE
[FIX] CollectBankAccountToken

### DIFF
--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -593,16 +593,16 @@ class MethodChannelStripe extends StripePlatform {
       {'clientSecret': clientSecret, 'params': params.toJson()},
     );
 
-    // workaround for fact that created is parsed as string from Stripe android
-    final created = result?['token']['created'];
-    if (created != null && created is String) {
-      result?['token']['created'] = int.tryParse(created);
-    }
-
     _financialConnectionsEventHandler = params.onEvent;
 
     if (result!.containsKey('error')) {
       throw ResultParser<void>(parseJson: (json) => {}).parseError(result);
+    }
+
+    // workaround for fact that created is parsed as string from Stripe android
+    final created = result?['token']['created'];
+    if (created != null && created is String) {
+      result?['token']['created'] = int.tryParse(created);
     }
 
     return FinancialConnectionTokenResult.fromJson(result);


### PR DESCRIPTION
Move the created workaround logic within `collectBankAccountToken` to execute only after confirming no error occurred.

This prevents an access error that occurs when a user cancels the bank account collection flow, as the result object is incomplete and attempting to read the created property throws an exception.