### PR TITLE
docs: clarify google pay requirements

### DIFF
--- a/docs/sheet.mdx
+++ b/docs/sheet.mdx
@@ -225,14 +225,6 @@ AndroidManifest.xml
 ```
 
 This guide assumes you’re using the latest version of the Stripe Android SDK.
-
-build.gradle
-
-```
-dependencies {
-    implementation 'com.stripe:stripe-android:17.1.1'
-}
-```
 For more details, see Google Pay’s Set up Google Pay API for Android.
 
 #### Add Google Pay


### PR DESCRIPTION
The Flutter Stripe plugin already appears to include the required stripe-android SDK.
In which case, developers do not need to manually add:

```
dependencies {
    implementation 'com.stripe:stripe-android:17.1.1'
}
```

Removing this line from the docs avoids confusion and prevents potential
version conflicts. Gradle dependencies are handled automatically by the plugin,
as confirmed by `./gradlew app:dependencies`:

```
+--- project :stripe_android
|    +--- com.stripe:stripe-android:21.26.+ -> 21.26.1
|    ...
```

Would appreciate someone double checking my assumption here upon review. Thanks.