### PR TITLE
fix: add meta import for @internal annotation

### DIFF
--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:stripe_platform_interface/stripe_platform_interface.dart';
+import 'package:meta/meta.dart';
 
 /// [Stripe] is the facade of the library and exposes the operations that can be
 /// executed on the Stripe platform.


### PR DESCRIPTION
Adds missing import 'package:meta/meta.dart' for @internal annotation in packages/stripe/lib/src/stripe.dart