### PR TITLE
fix: change initCustomerSheet return type to Future<void>

### DIFF
--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -679,7 +679,7 @@ class Stripe {
   }
 
   /// Initializes the customer sheet with the provided [parameters].
-  Future<CustomerSheetResult?> initCustomerSheet({
+  Future<void> initCustomerSheet({
     required CustomerSheetInitParams customerSheetInitParams,
   }) async {
     await _awaitForSettings();

--- a/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
@@ -75,7 +75,7 @@ abstract class StripePlatform extends PlatformInterface {
   Future<void> confirmPaymentSheetPayment();
 
   /// Configure the payment sheet using [CustomerSheetInitParams] as config.
-  Future<CustomerSheetResult?> initCustomerSheet(
+  Future<void> initCustomerSheet(
     CustomerSheetInitParams params,
   );
 

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -58,7 +58,8 @@ class WebStripe extends StripePlatform {
 
     if (__stripe != null) {
       // Check if the new stripeAccountId or locale is different
-      if (__stripe!.stripeAccount != stripeAccountId || __stripe!.locale != locale) {
+      if (__stripe!.stripeAccount != stripeAccountId ||
+          __stripe!.locale != locale) {
         // Re-initialize with new stripeAccountId or locale
         await stripe_js.loadStripe();
         var stripeOption = stripe_js.StripeOptions();
@@ -636,7 +637,7 @@ class WebStripe extends StripePlatform {
   }
 
   @override
-  Future<CustomerSheetResult?> initCustomerSheet(
+  Future<void> initCustomerSheet(
       CustomerSheetInitParams params) {
     throw WebUnsupportedError.method('initCustomerSheet');
   }


### PR DESCRIPTION
## Related Issue

Fixes #2283 

## Changes

Changed return type from `Future<CustomerSheetResult?>` to `Future<void>` to match actual behavior and align with React Native SDK.

The method always returned `null` on success:

- iOS: returns empty array `[]`
- Android: returns empty map

The type `CustomerSheetResult?` was misleading. This fixes the type definition to match reality.

If there was an intentional reason for the `CustomerSheetResult?` return type that I may have missed, I'd appreciate any insights. I want to ensure this change aligns with the package's design goals.
