### PR TITLE
fix: remove giropay payment method references from codebase

### DIFF
--- a/example/server/src/index.ts
+++ b/example/server/src/index.ts
@@ -564,7 +564,6 @@ app.post('/payment-sheet', async (_, res) => {
       // 'sofort',
       // 'bancontact',
       // 'p24',
-      // 'giropay',
       // 'eps',
       // 'afterpay_clearpay',
       // 'klarna',

--- a/packages/stripe_js/lib/src/api/payment_intents/payment_intent.g.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/payment_intent.g.dart
@@ -177,7 +177,6 @@ const _$PaymentMethodTypeEnumMap = {
   PaymentMethodType.customerBalance: 'customer_balance',
   PaymentMethodType.eps: 'eps',
   PaymentMethodType.fpx: 'fpx',
-  PaymentMethodType.giropay: 'giropay',
   PaymentMethodType.grabpay: 'grabpay',
   PaymentMethodType.ideal: 'ideal',
   PaymentMethodType.interacPresent: 'interac_present',

--- a/packages/stripe_js/lib/src/api/payment_methods/payment_method.g.dart
+++ b/packages/stripe_js/lib/src/api/payment_methods/payment_method.g.dart
@@ -89,7 +89,6 @@ const _$PaymentMethodTypeEnumMap = {
   PaymentMethodType.customerBalance: 'customer_balance',
   PaymentMethodType.eps: 'eps',
   PaymentMethodType.fpx: 'fpx',
-  PaymentMethodType.giropay: 'giropay',
   PaymentMethodType.grabpay: 'grabpay',
   PaymentMethodType.ideal: 'ideal',
   PaymentMethodType.interacPresent: 'interac_present',

--- a/packages/stripe_js/lib/src/api/payment_methods/payment_method_params.freezed.dart
+++ b/packages/stripe_js/lib/src/api/payment_methods/payment_method_params.freezed.dart
@@ -43,10 +43,6 @@ PaymentMethodParams _$PaymentMethodParamsFromJson(
           return _PaymentMethodParamsBankContact.fromJson(
             json
           );
-                case 'Giropay':
-          return _PaymentMethodParamsGiroPay.fromJson(
-            json
-          );
                 case 'Eps':
           return _PaymentMethodParamsEps.fromJson(
             json
@@ -150,7 +146,7 @@ extension PaymentMethodParamsPatterns on PaymentMethodParams {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( _PaymentMethodParamsCard value)?  card,TResult Function( _PaymentMethodParamsCardWithToken value)?  cardFromToken,TResult Function( _PaymentMethodParamsCardWithMethodId value)?  cardFromMethodId,TResult Function( _PaymentMethodParamsAlipay value)?  alipay,TResult Function( _PaymentMethodParamsIdeal value)?  ideal,TResult Function( _PaymentMethodParamsAubecs value)?  aubecs,TResult Function( _PaymentMethodParamsBankContact value)?  bancontact,TResult Function( _PaymentMethodParamsGiroPay value)?  giroPay,TResult Function( _PaymentMethodParamsEps value)?  eps,TResult Function( _PaymentMethodParamsAffirm value)?  affirm,TResult Function( _PaymentMethodParamsPay value)?  grabPay,TResult Function( _PaymentMethodParamsP24 value)?  p24,TResult Function( _PaymentMethodParamsFpx value)?  fpx,TResult Function( _PaymentMethodParamsSepaDebit value)?  sepaDebit,TResult Function( _PaymentMethodParamsAfterpayClearpay value)?  afterpayClearpay,TResult Function( _PaymentMethodParamsOxxo value)?  oxxo,TResult Function( _PaymentMethodParamsKlarna value)?  klarna,TResult Function( _PaymentMethodParamsPayPal value)?  payPal,TResult Function( _PaymentMethodParamsUsBankAccount value)?  usBankAccount,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( _PaymentMethodParamsCard value)?  card,TResult Function( _PaymentMethodParamsCardWithToken value)?  cardFromToken,TResult Function( _PaymentMethodParamsCardWithMethodId value)?  cardFromMethodId,TResult Function( _PaymentMethodParamsAlipay value)?  alipay,TResult Function( _PaymentMethodParamsIdeal value)?  ideal,TResult Function( _PaymentMethodParamsAubecs value)?  aubecs,TResult Function( _PaymentMethodParamsBankContact value)?  bancontact,TResult Function( _PaymentMethodParamsEps value)?  eps,TResult Function( _PaymentMethodParamsAffirm value)?  affirm,TResult Function( _PaymentMethodParamsPay value)?  grabPay,TResult Function( _PaymentMethodParamsP24 value)?  p24,TResult Function( _PaymentMethodParamsFpx value)?  fpx,TResult Function( _PaymentMethodParamsSepaDebit value)?  sepaDebit,TResult Function( _PaymentMethodParamsAfterpayClearpay value)?  afterpayClearpay,TResult Function( _PaymentMethodParamsOxxo value)?  oxxo,TResult Function( _PaymentMethodParamsKlarna value)?  klarna,TResult Function( _PaymentMethodParamsPayPal value)?  payPal,TResult Function( _PaymentMethodParamsUsBankAccount value)?  usBankAccount,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case _PaymentMethodParamsCard() when card != null:
@@ -160,8 +156,7 @@ return cardFromMethodId(_that);case _PaymentMethodParamsAlipay() when alipay != 
 return alipay(_that);case _PaymentMethodParamsIdeal() when ideal != null:
 return ideal(_that);case _PaymentMethodParamsAubecs() when aubecs != null:
 return aubecs(_that);case _PaymentMethodParamsBankContact() when bancontact != null:
-return bancontact(_that);case _PaymentMethodParamsGiroPay() when giroPay != null:
-return giroPay(_that);case _PaymentMethodParamsEps() when eps != null:
+return bancontact(_that);case _PaymentMethodParamsEps() when eps != null:
 return eps(_that);case _PaymentMethodParamsAffirm() when affirm != null:
 return affirm(_that);case _PaymentMethodParamsPay() when grabPay != null:
 return grabPay(_that);case _PaymentMethodParamsP24() when p24 != null:
@@ -190,7 +185,7 @@ return usBankAccount(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( _PaymentMethodParamsCard value)  card,required TResult Function( _PaymentMethodParamsCardWithToken value)  cardFromToken,required TResult Function( _PaymentMethodParamsCardWithMethodId value)  cardFromMethodId,required TResult Function( _PaymentMethodParamsAlipay value)  alipay,required TResult Function( _PaymentMethodParamsIdeal value)  ideal,required TResult Function( _PaymentMethodParamsAubecs value)  aubecs,required TResult Function( _PaymentMethodParamsBankContact value)  bancontact,required TResult Function( _PaymentMethodParamsGiroPay value)  giroPay,required TResult Function( _PaymentMethodParamsEps value)  eps,required TResult Function( _PaymentMethodParamsAffirm value)  affirm,required TResult Function( _PaymentMethodParamsPay value)  grabPay,required TResult Function( _PaymentMethodParamsP24 value)  p24,required TResult Function( _PaymentMethodParamsFpx value)  fpx,required TResult Function( _PaymentMethodParamsSepaDebit value)  sepaDebit,required TResult Function( _PaymentMethodParamsAfterpayClearpay value)  afterpayClearpay,required TResult Function( _PaymentMethodParamsOxxo value)  oxxo,required TResult Function( _PaymentMethodParamsKlarna value)  klarna,required TResult Function( _PaymentMethodParamsPayPal value)  payPal,required TResult Function( _PaymentMethodParamsUsBankAccount value)  usBankAccount,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( _PaymentMethodParamsCard value)  card,required TResult Function( _PaymentMethodParamsCardWithToken value)  cardFromToken,required TResult Function( _PaymentMethodParamsCardWithMethodId value)  cardFromMethodId,required TResult Function( _PaymentMethodParamsAlipay value)  alipay,required TResult Function( _PaymentMethodParamsIdeal value)  ideal,required TResult Function( _PaymentMethodParamsAubecs value)  aubecs,required TResult Function( _PaymentMethodParamsBankContact value)  bancontact,required TResult Function( _PaymentMethodParamsEps value)  eps,required TResult Function( _PaymentMethodParamsAffirm value)  affirm,required TResult Function( _PaymentMethodParamsPay value)  grabPay,required TResult Function( _PaymentMethodParamsP24 value)  p24,required TResult Function( _PaymentMethodParamsFpx value)  fpx,required TResult Function( _PaymentMethodParamsSepaDebit value)  sepaDebit,required TResult Function( _PaymentMethodParamsAfterpayClearpay value)  afterpayClearpay,required TResult Function( _PaymentMethodParamsOxxo value)  oxxo,required TResult Function( _PaymentMethodParamsKlarna value)  klarna,required TResult Function( _PaymentMethodParamsPayPal value)  payPal,required TResult Function( _PaymentMethodParamsUsBankAccount value)  usBankAccount,}){
 final _that = this;
 switch (_that) {
 case _PaymentMethodParamsCard():
@@ -200,8 +195,7 @@ return cardFromMethodId(_that);case _PaymentMethodParamsAlipay():
 return alipay(_that);case _PaymentMethodParamsIdeal():
 return ideal(_that);case _PaymentMethodParamsAubecs():
 return aubecs(_that);case _PaymentMethodParamsBankContact():
-return bancontact(_that);case _PaymentMethodParamsGiroPay():
-return giroPay(_that);case _PaymentMethodParamsEps():
+return bancontact(_that);case _PaymentMethodParamsEps():
 return eps(_that);case _PaymentMethodParamsAffirm():
 return affirm(_that);case _PaymentMethodParamsPay():
 return grabPay(_that);case _PaymentMethodParamsP24():
@@ -229,7 +223,7 @@ return usBankAccount(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( _PaymentMethodParamsCard value)?  card,TResult? Function( _PaymentMethodParamsCardWithToken value)?  cardFromToken,TResult? Function( _PaymentMethodParamsCardWithMethodId value)?  cardFromMethodId,TResult? Function( _PaymentMethodParamsAlipay value)?  alipay,TResult? Function( _PaymentMethodParamsIdeal value)?  ideal,TResult? Function( _PaymentMethodParamsAubecs value)?  aubecs,TResult? Function( _PaymentMethodParamsBankContact value)?  bancontact,TResult? Function( _PaymentMethodParamsGiroPay value)?  giroPay,TResult? Function( _PaymentMethodParamsEps value)?  eps,TResult? Function( _PaymentMethodParamsAffirm value)?  affirm,TResult? Function( _PaymentMethodParamsPay value)?  grabPay,TResult? Function( _PaymentMethodParamsP24 value)?  p24,TResult? Function( _PaymentMethodParamsFpx value)?  fpx,TResult? Function( _PaymentMethodParamsSepaDebit value)?  sepaDebit,TResult? Function( _PaymentMethodParamsAfterpayClearpay value)?  afterpayClearpay,TResult? Function( _PaymentMethodParamsOxxo value)?  oxxo,TResult? Function( _PaymentMethodParamsKlarna value)?  klarna,TResult? Function( _PaymentMethodParamsPayPal value)?  payPal,TResult? Function( _PaymentMethodParamsUsBankAccount value)?  usBankAccount,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( _PaymentMethodParamsCard value)?  card,TResult? Function( _PaymentMethodParamsCardWithToken value)?  cardFromToken,TResult? Function( _PaymentMethodParamsCardWithMethodId value)?  cardFromMethodId,TResult? Function( _PaymentMethodParamsAlipay value)?  alipay,TResult? Function( _PaymentMethodParamsIdeal value)?  ideal,TResult? Function( _PaymentMethodParamsAubecs value)?  aubecs,TResult? Function( _PaymentMethodParamsBankContact value)?  bancontact,TResult? Function( _PaymentMethodParamsEps value)?  eps,TResult? Function( _PaymentMethodParamsAffirm value)?  affirm,TResult? Function( _PaymentMethodParamsPay value)?  grabPay,TResult? Function( _PaymentMethodParamsP24 value)?  p24,TResult? Function( _PaymentMethodParamsFpx value)?  fpx,TResult? Function( _PaymentMethodParamsSepaDebit value)?  sepaDebit,TResult? Function( _PaymentMethodParamsAfterpayClearpay value)?  afterpayClearpay,TResult? Function( _PaymentMethodParamsOxxo value)?  oxxo,TResult? Function( _PaymentMethodParamsKlarna value)?  klarna,TResult? Function( _PaymentMethodParamsPayPal value)?  payPal,TResult? Function( _PaymentMethodParamsUsBankAccount value)?  usBankAccount,}){
 final _that = this;
 switch (_that) {
 case _PaymentMethodParamsCard() when card != null:
@@ -239,8 +233,7 @@ return cardFromMethodId(_that);case _PaymentMethodParamsAlipay() when alipay != 
 return alipay(_that);case _PaymentMethodParamsIdeal() when ideal != null:
 return ideal(_that);case _PaymentMethodParamsAubecs() when aubecs != null:
 return aubecs(_that);case _PaymentMethodParamsBankContact() when bancontact != null:
-return bancontact(_that);case _PaymentMethodParamsGiroPay() when giroPay != null:
-return giroPay(_that);case _PaymentMethodParamsEps() when eps != null:
+return bancontact(_that);case _PaymentMethodParamsEps() when eps != null:
 return eps(_that);case _PaymentMethodParamsAffirm() when affirm != null:
 return affirm(_that);case _PaymentMethodParamsPay() when grabPay != null:
 return grabPay(_that);case _PaymentMethodParamsP24() when p24 != null:
@@ -268,7 +261,7 @@ return usBankAccount(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( PaymentMethodData paymentMethodData)?  card,TResult Function( PaymentMethodDataCardFromToken paymentMethodData)?  cardFromToken,TResult Function( PaymentMethodDataCardFromMethod paymentMethodData)?  cardFromMethodId,TResult Function( PaymentMethodData paymentMethodData)?  alipay,TResult Function( PaymentMethodDataIdeal paymentMethodData)?  ideal,TResult Function( PaymentMethodDataAubecs paymentMethodData)?  aubecs,TResult Function( PaymentMethodData paymentMethodData)?  bancontact,TResult Function( PaymentMethodData paymentMethodData)?  giroPay,TResult Function( PaymentMethodData paymentMethodData)?  eps,TResult Function( PaymentMethodData paymentMethodData)?  affirm,TResult Function( PaymentMethodData paymentMethodData)?  grabPay,TResult Function( PaymentMethodData paymentMethodData)?  p24,TResult Function( PaymentMethodDataFpx paymentMethodData)?  fpx,TResult Function( PaymentMethodDataSepa paymentMethodData)?  sepaDebit,TResult Function( PaymentMethodDataAfterPay paymentMethodData)?  afterpayClearpay,TResult Function( PaymentMethodData paymentMethodData)?  oxxo,TResult Function( PaymentMethodData paymentMethodData)?  klarna,TResult Function( PaymentMethodData paymentMethodData)?  payPal,TResult Function( PaymentMethodDataUsBank paymentMethodData)?  usBankAccount,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( PaymentMethodData paymentMethodData)?  card,TResult Function( PaymentMethodDataCardFromToken paymentMethodData)?  cardFromToken,TResult Function( PaymentMethodDataCardFromMethod paymentMethodData)?  cardFromMethodId,TResult Function( PaymentMethodData paymentMethodData)?  alipay,TResult Function( PaymentMethodDataIdeal paymentMethodData)?  ideal,TResult Function( PaymentMethodDataAubecs paymentMethodData)?  aubecs,TResult Function( PaymentMethodData paymentMethodData)?  bancontact,TResult Function( PaymentMethodData paymentMethodData)?  eps,TResult Function( PaymentMethodData paymentMethodData)?  affirm,TResult Function( PaymentMethodData paymentMethodData)?  grabPay,TResult Function( PaymentMethodData paymentMethodData)?  p24,TResult Function( PaymentMethodDataFpx paymentMethodData)?  fpx,TResult Function( PaymentMethodDataSepa paymentMethodData)?  sepaDebit,TResult Function( PaymentMethodDataAfterPay paymentMethodData)?  afterpayClearpay,TResult Function( PaymentMethodData paymentMethodData)?  oxxo,TResult Function( PaymentMethodData paymentMethodData)?  klarna,TResult Function( PaymentMethodData paymentMethodData)?  payPal,TResult Function( PaymentMethodDataUsBank paymentMethodData)?  usBankAccount,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _PaymentMethodParamsCard() when card != null:
 return card(_that.paymentMethodData);case _PaymentMethodParamsCardWithToken() when cardFromToken != null:
@@ -277,8 +270,7 @@ return cardFromMethodId(_that.paymentMethodData);case _PaymentMethodParamsAlipay
 return alipay(_that.paymentMethodData);case _PaymentMethodParamsIdeal() when ideal != null:
 return ideal(_that.paymentMethodData);case _PaymentMethodParamsAubecs() when aubecs != null:
 return aubecs(_that.paymentMethodData);case _PaymentMethodParamsBankContact() when bancontact != null:
-return bancontact(_that.paymentMethodData);case _PaymentMethodParamsGiroPay() when giroPay != null:
-return giroPay(_that.paymentMethodData);case _PaymentMethodParamsEps() when eps != null:
+return bancontact(_that.paymentMethodData);case _PaymentMethodParamsEps() when eps != null:
 return eps(_that.paymentMethodData);case _PaymentMethodParamsAffirm() when affirm != null:
 return affirm(_that.paymentMethodData);case _PaymentMethodParamsPay() when grabPay != null:
 return grabPay(_that.paymentMethodData);case _PaymentMethodParamsP24() when p24 != null:
@@ -307,7 +299,7 @@ return usBankAccount(_that.paymentMethodData);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( PaymentMethodData paymentMethodData)  card,required TResult Function( PaymentMethodDataCardFromToken paymentMethodData)  cardFromToken,required TResult Function( PaymentMethodDataCardFromMethod paymentMethodData)  cardFromMethodId,required TResult Function( PaymentMethodData paymentMethodData)  alipay,required TResult Function( PaymentMethodDataIdeal paymentMethodData)  ideal,required TResult Function( PaymentMethodDataAubecs paymentMethodData)  aubecs,required TResult Function( PaymentMethodData paymentMethodData)  bancontact,required TResult Function( PaymentMethodData paymentMethodData)  giroPay,required TResult Function( PaymentMethodData paymentMethodData)  eps,required TResult Function( PaymentMethodData paymentMethodData)  affirm,required TResult Function( PaymentMethodData paymentMethodData)  grabPay,required TResult Function( PaymentMethodData paymentMethodData)  p24,required TResult Function( PaymentMethodDataFpx paymentMethodData)  fpx,required TResult Function( PaymentMethodDataSepa paymentMethodData)  sepaDebit,required TResult Function( PaymentMethodDataAfterPay paymentMethodData)  afterpayClearpay,required TResult Function( PaymentMethodData paymentMethodData)  oxxo,required TResult Function( PaymentMethodData paymentMethodData)  klarna,required TResult Function( PaymentMethodData paymentMethodData)  payPal,required TResult Function( PaymentMethodDataUsBank paymentMethodData)  usBankAccount,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( PaymentMethodData paymentMethodData)  card,required TResult Function( PaymentMethodDataCardFromToken paymentMethodData)  cardFromToken,required TResult Function( PaymentMethodDataCardFromMethod paymentMethodData)  cardFromMethodId,required TResult Function( PaymentMethodData paymentMethodData)  alipay,required TResult Function( PaymentMethodDataIdeal paymentMethodData)  ideal,required TResult Function( PaymentMethodDataAubecs paymentMethodData)  aubecs,required TResult Function( PaymentMethodData paymentMethodData)  bancontact,required TResult Function( PaymentMethodData paymentMethodData)  eps,required TResult Function( PaymentMethodData paymentMethodData)  affirm,required TResult Function( PaymentMethodData paymentMethodData)  grabPay,required TResult Function( PaymentMethodData paymentMethodData)  p24,required TResult Function( PaymentMethodDataFpx paymentMethodData)  fpx,required TResult Function( PaymentMethodDataSepa paymentMethodData)  sepaDebit,required TResult Function( PaymentMethodDataAfterPay paymentMethodData)  afterpayClearpay,required TResult Function( PaymentMethodData paymentMethodData)  oxxo,required TResult Function( PaymentMethodData paymentMethodData)  klarna,required TResult Function( PaymentMethodData paymentMethodData)  payPal,required TResult Function( PaymentMethodDataUsBank paymentMethodData)  usBankAccount,}) {final _that = this;
 switch (_that) {
 case _PaymentMethodParamsCard():
 return card(_that.paymentMethodData);case _PaymentMethodParamsCardWithToken():
@@ -316,8 +308,7 @@ return cardFromMethodId(_that.paymentMethodData);case _PaymentMethodParamsAlipay
 return alipay(_that.paymentMethodData);case _PaymentMethodParamsIdeal():
 return ideal(_that.paymentMethodData);case _PaymentMethodParamsAubecs():
 return aubecs(_that.paymentMethodData);case _PaymentMethodParamsBankContact():
-return bancontact(_that.paymentMethodData);case _PaymentMethodParamsGiroPay():
-return giroPay(_that.paymentMethodData);case _PaymentMethodParamsEps():
+return bancontact(_that.paymentMethodData);case _PaymentMethodParamsEps():
 return eps(_that.paymentMethodData);case _PaymentMethodParamsAffirm():
 return affirm(_that.paymentMethodData);case _PaymentMethodParamsPay():
 return grabPay(_that.paymentMethodData);case _PaymentMethodParamsP24():
@@ -345,7 +336,7 @@ return usBankAccount(_that.paymentMethodData);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( PaymentMethodData paymentMethodData)?  card,TResult? Function( PaymentMethodDataCardFromToken paymentMethodData)?  cardFromToken,TResult? Function( PaymentMethodDataCardFromMethod paymentMethodData)?  cardFromMethodId,TResult? Function( PaymentMethodData paymentMethodData)?  alipay,TResult? Function( PaymentMethodDataIdeal paymentMethodData)?  ideal,TResult? Function( PaymentMethodDataAubecs paymentMethodData)?  aubecs,TResult? Function( PaymentMethodData paymentMethodData)?  bancontact,TResult? Function( PaymentMethodData paymentMethodData)?  giroPay,TResult? Function( PaymentMethodData paymentMethodData)?  eps,TResult? Function( PaymentMethodData paymentMethodData)?  affirm,TResult? Function( PaymentMethodData paymentMethodData)?  grabPay,TResult? Function( PaymentMethodData paymentMethodData)?  p24,TResult? Function( PaymentMethodDataFpx paymentMethodData)?  fpx,TResult? Function( PaymentMethodDataSepa paymentMethodData)?  sepaDebit,TResult? Function( PaymentMethodDataAfterPay paymentMethodData)?  afterpayClearpay,TResult? Function( PaymentMethodData paymentMethodData)?  oxxo,TResult? Function( PaymentMethodData paymentMethodData)?  klarna,TResult? Function( PaymentMethodData paymentMethodData)?  payPal,TResult? Function( PaymentMethodDataUsBank paymentMethodData)?  usBankAccount,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( PaymentMethodData paymentMethodData)?  card,TResult? Function( PaymentMethodDataCardFromToken paymentMethodData)?  cardFromToken,TResult? Function( PaymentMethodDataCardFromMethod paymentMethodData)?  cardFromMethodId,TResult? Function( PaymentMethodData paymentMethodData)?  alipay,TResult? Function( PaymentMethodDataIdeal paymentMethodData)?  ideal,TResult? Function( PaymentMethodDataAubecs paymentMethodData)?  aubecs,TResult? Function( PaymentMethodData paymentMethodData)?  bancontact,TResult? Function( PaymentMethodData paymentMethodData)?  eps,TResult? Function( PaymentMethodData paymentMethodData)?  affirm,TResult? Function( PaymentMethodData paymentMethodData)?  grabPay,TResult? Function( PaymentMethodData paymentMethodData)?  p24,TResult? Function( PaymentMethodDataFpx paymentMethodData)?  fpx,TResult? Function( PaymentMethodDataSepa paymentMethodData)?  sepaDebit,TResult? Function( PaymentMethodDataAfterPay paymentMethodData)?  afterpayClearpay,TResult? Function( PaymentMethodData paymentMethodData)?  oxxo,TResult? Function( PaymentMethodData paymentMethodData)?  klarna,TResult? Function( PaymentMethodData paymentMethodData)?  payPal,TResult? Function( PaymentMethodDataUsBank paymentMethodData)?  usBankAccount,}) {final _that = this;
 switch (_that) {
 case _PaymentMethodParamsCard() when card != null:
 return card(_that.paymentMethodData);case _PaymentMethodParamsCardWithToken() when cardFromToken != null:
@@ -354,8 +345,7 @@ return cardFromMethodId(_that.paymentMethodData);case _PaymentMethodParamsAlipay
 return alipay(_that.paymentMethodData);case _PaymentMethodParamsIdeal() when ideal != null:
 return ideal(_that.paymentMethodData);case _PaymentMethodParamsAubecs() when aubecs != null:
 return aubecs(_that.paymentMethodData);case _PaymentMethodParamsBankContact() when bancontact != null:
-return bancontact(_that.paymentMethodData);case _PaymentMethodParamsGiroPay() when giroPay != null:
-return giroPay(_that.paymentMethodData);case _PaymentMethodParamsEps() when eps != null:
+return bancontact(_that.paymentMethodData);case _PaymentMethodParamsEps() when eps != null:
 return eps(_that.paymentMethodData);case _PaymentMethodParamsAffirm() when affirm != null:
 return affirm(_that.paymentMethodData);case _PaymentMethodParamsPay() when grabPay != null:
 return grabPay(_that.paymentMethodData);case _PaymentMethodParamsP24() when p24 != null:
@@ -938,89 +928,6 @@ class __$PaymentMethodParamsBankContactCopyWithImpl<$Res>
 /// with the given fields replaced by the non-null parameter values.
 @pragma('vm:prefer-inline') $Res call({Object? paymentMethodData = null,}) {
   return _then(_PaymentMethodParamsBankContact(
-paymentMethodData: null == paymentMethodData ? _self.paymentMethodData : paymentMethodData // ignore: cast_nullable_to_non_nullable
-as PaymentMethodData,
-  ));
-}
-
-/// Create a copy of PaymentMethodParams
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$PaymentMethodDataCopyWith<$Res> get paymentMethodData {
-  
-  return $PaymentMethodDataCopyWith<$Res>(_self.paymentMethodData, (value) {
-    return _then(_self.copyWith(paymentMethodData: value));
-  });
-}
-}
-
-/// @nodoc
-
-@JsonSerializable(explicitToJson: true)
-class _PaymentMethodParamsGiroPay implements PaymentMethodParams {
-  const _PaymentMethodParamsGiroPay({required this.paymentMethodData, final  String? $type}): $type = $type ?? 'Giropay';
-  factory _PaymentMethodParamsGiroPay.fromJson(Map<String, dynamic> json) => _$PaymentMethodParamsGiroPayFromJson(json);
-
-/// Paymentmethod data for this paymentmethod.
-@override final  PaymentMethodData paymentMethodData;
-
-@JsonKey(name: 'paymentMethodType')
-final String $type;
-
-
-/// Create a copy of PaymentMethodParams
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-_$PaymentMethodParamsGiroPayCopyWith<_PaymentMethodParamsGiroPay> get copyWith => __$PaymentMethodParamsGiroPayCopyWithImpl<_PaymentMethodParamsGiroPay>(this, _$identity);
-
-@override
-Map<String, dynamic> toJson() {
-  return _$PaymentMethodParamsGiroPayToJson(this, );
-}
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PaymentMethodParamsGiroPay&&(identical(other.paymentMethodData, paymentMethodData) || other.paymentMethodData == paymentMethodData));
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => Object.hash(runtimeType,paymentMethodData);
-
-@override
-String toString() {
-  return 'PaymentMethodParams.giroPay(paymentMethodData: $paymentMethodData)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class _$PaymentMethodParamsGiroPayCopyWith<$Res> implements $PaymentMethodParamsCopyWith<$Res> {
-  factory _$PaymentMethodParamsGiroPayCopyWith(_PaymentMethodParamsGiroPay value, $Res Function(_PaymentMethodParamsGiroPay) _then) = __$PaymentMethodParamsGiroPayCopyWithImpl;
-@useResult
-$Res call({
- PaymentMethodData paymentMethodData
-});
-
-
-$PaymentMethodDataCopyWith<$Res> get paymentMethodData;
-
-}
-/// @nodoc
-class __$PaymentMethodParamsGiroPayCopyWithImpl<$Res>
-    implements _$PaymentMethodParamsGiroPayCopyWith<$Res> {
-  __$PaymentMethodParamsGiroPayCopyWithImpl(this._self, this._then);
-
-  final _PaymentMethodParamsGiroPay _self;
-  final $Res Function(_PaymentMethodParamsGiroPay) _then;
-
-/// Create a copy of PaymentMethodParams
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? paymentMethodData = null,}) {
-  return _then(_PaymentMethodParamsGiroPay(
 paymentMethodData: null == paymentMethodData ? _self.paymentMethodData : paymentMethodData // ignore: cast_nullable_to_non_nullable
 as PaymentMethodData,
   ));

--- a/packages/stripe_js/lib/src/api/payment_methods/payment_method_params.g.dart
+++ b/packages/stripe_js/lib/src/api/payment_methods/payment_method_params.g.dart
@@ -114,21 +114,6 @@ Map<String, dynamic> _$PaymentMethodParamsBankContactToJson(
   'paymentMethodType': instance.$type,
 };
 
-_PaymentMethodParamsGiroPay _$PaymentMethodParamsGiroPayFromJson(Map json) =>
-    _PaymentMethodParamsGiroPay(
-      paymentMethodData: PaymentMethodData.fromJson(
-        Map<String, dynamic>.from(json['paymentMethodData'] as Map),
-      ),
-      $type: json['paymentMethodType'] as String?,
-    );
-
-Map<String, dynamic> _$PaymentMethodParamsGiroPayToJson(
-  _PaymentMethodParamsGiroPay instance,
-) => <String, dynamic>{
-  'paymentMethodData': instance.paymentMethodData.toJson(),
-  'paymentMethodType': instance.$type,
-};
-
 _PaymentMethodParamsEps _$PaymentMethodParamsEpsFromJson(Map json) =>
     _PaymentMethodParamsEps(
       paymentMethodData: PaymentMethodData.fromJson(

--- a/packages/stripe_js/lib/src/api/setup_intents/setup_intent.g.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/setup_intent.g.dart
@@ -104,7 +104,6 @@ const _$PaymentMethodTypeEnumMap = {
   PaymentMethodType.customerBalance: 'customer_balance',
   PaymentMethodType.eps: 'eps',
   PaymentMethodType.fpx: 'fpx',
-  PaymentMethodType.giropay: 'giropay',
   PaymentMethodType.grabpay: 'grabpay',
   PaymentMethodType.ideal: 'ideal',
   PaymentMethodType.interacPresent: 'interac_present',

--- a/packages/stripe_js/types/index.ts
+++ b/packages/stripe_js/types/index.ts
@@ -1765,7 +1765,6 @@ declare namespace stripe {
             | 'bancontact'
             | 'card'
             | 'eps'
-            | 'giropay'
             | 'ideal'
             | 'multibanco'
             | 'p24'
@@ -1780,7 +1779,6 @@ declare namespace stripe {
             bancontact?: BanContactDetails | null;
             card?: PaymentMethodCard | null;
             eps?: EpsDetails | null;
-            giropay?: GiropayDetails | null;
             ideal?: IdealDetails | null;
             multibanco?: MultibancoDetails | null;
             p24?: P24Details | null;
@@ -1816,13 +1814,6 @@ declare namespace stripe {
         }
 
         interface EpsDetails {
-            verified_name: string;
-        }
-
-        interface GiropayDetails {
-            bank_code: string;
-            bank_name: string;
-            bic: string;
             verified_name: string;
         }
 

--- a/packages/stripe_web/types/index.ts
+++ b/packages/stripe_web/types/index.ts
@@ -1765,7 +1765,6 @@ declare namespace stripe {
             | 'bancontact'
             | 'card'
             | 'eps'
-            | 'giropay'
             | 'ideal'
             | 'multibanco'
             | 'p24'
@@ -1780,7 +1779,6 @@ declare namespace stripe {
             bancontact?: BanContactDetails | null;
             card?: PaymentMethodCard | null;
             eps?: EpsDetails | null;
-            giropay?: GiropayDetails | null;
             ideal?: IdealDetails | null;
             multibanco?: MultibancoDetails | null;
             p24?: P24Details | null;
@@ -1816,13 +1814,6 @@ declare namespace stripe {
         }
 
         interface EpsDetails {
-            verified_name: string;
-        }
-
-        interface GiropayDetails {
-            bank_code: string;
-            bank_name: string;
-            bic: string;
             verified_name: string;
         }
 


### PR DESCRIPTION
### Reason: Web build was failing with Giropay still present, so support is fully removed.

- Removes all remaining Giropay references across JS/Web types and generated mappings.
- Deletes Giropay payment method params variant from generated Stripe JS code.