### PR TITLE
fix: add ProGuard rules to prevent 3D Secure crash

### DIFF
--- a/packages/stripe_android/android/proguard-rules.txt
+++ b/packages/stripe_android/android/proguard-rules.txt
@@ -1,7 +1,25 @@
+# Keep all Stripe classes to prevent R8/ProGuard from stripping payment flow classes
+# This fixes crashes on 3D Secure authentication (PaymentFlowResult$Unvalidated$Companion)
+-keep class com.stripe.** { *; }
+
+# Keep Google Pay tap-and-pay classes
 -keepclassmembers class com.google.android.gms.tapandpay.** {
   public *;
 }
 
+# Keep Stripe push provisioning classes
 -keepclassmembers class com.stripe.android.pushProvisioning.** {
   public *;
 }
+
+# Suppress warnings for optional push provisioning dependency
+-dontwarn com.stripe.android.pushProvisioning.PushProvisioningActivity$g
+-dontwarn com.stripe.android.pushProvisioning.PushProvisioningActivityStarter$Args
+-dontwarn com.stripe.android.pushProvisioning.PushProvisioningActivityStarter$Error
+-dontwarn com.stripe.android.pushProvisioning.PushProvisioningActivityStarter
+-dontwarn com.stripe.android.pushProvisioning.PushProvisioningEphemeralKeyProvider
+
+# Keep Kotlin parcelize classes used by Stripe SDK
+-dontwarn kotlinx.parcelize.Parceler$DefaultImpls
+-dontwarn kotlinx.parcelize.Parceler
+-dontwarn kotlinx.parcelize.Parcelize


### PR DESCRIPTION
## Summary

- Add comprehensive ProGuard/R8 rules to the library's consumer rules to prevent `PaymentFlowResult$Unvalidated$Companion` from being stripped during minification
- This fixes the crash that occurs after completing 3D Secure authentication on Android

## Problem

When using payment methods that require 3D Secure authentication (mandatory for many cards in EU/UK), the app crashes after the WebView closes with:

```
java.lang.NoClassDefFoundError: Failed resolution of: Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated$Companion;
```

This happens because the library's `proguard-rules.txt` (distributed via `consumerProguardFiles`) was missing the critical `-keep class com.stripe.** { *; }` rule, allowing R8/ProGuard to strip essential Stripe payment flow classes.

## Solution

Enhanced `packages/stripe_android/android/proguard-rules.txt` to include:
- `-keep class com.stripe.** { *; }` - Keeps all Stripe classes
- All `-dontwarn` rules for push provisioning and kotlinx.parcelize

These rules are now automatically applied to consuming apps via `consumerProguardFiles`, so users no longer need to manually add them.

Fixes #2221

## Test plan

- [ ] Build a release APK with minification enabled
- [ ] Test payment with a 3D Secure card (e.g., `4000 0027 6000 3184`)
- [ ] Verify no crash occurs after completing 3D Secure authentication