### PR TITLE
fix: CustomerSheet cancel error type mismatch

### DIFF
--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/customersheet/CustomerSheetManager.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/customersheet/CustomerSheetManager.kt
@@ -177,7 +177,14 @@ class CustomerSheetManager(
         promiseResult = createPaymentOptionResult(result.selection)
         promiseResult.putMap(
           "error",
-          Arguments.createMap().also { it.putString("code", ErrorType.Canceled.toString()) },
+          Arguments.createMap().also {
+            it.putString("code", ErrorType.Canceled.toString())
+            it.putNull("message")
+            it.putNull("localizedMessage")
+            it.putNull("declineCode")
+            it.putNull("stripeErrorCode")
+            it.putNull("type")
+          },
         )
       }
     }
@@ -270,6 +277,11 @@ class CustomerSheetManager(
               "error",
               Arguments.createMap().also {
                 it.putString("code", ErrorType.Canceled.toString())
+                it.putNull("message")
+                it.putNull("localizedMessage")
+                it.putNull("declineCode")
+                it.putNull("stripeErrorCode")
+                it.putNull("type")
               },
             )
           }

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/CustomerSheet/CustomerSheetUtils.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/CustomerSheet/CustomerSheetUtils.swift
@@ -191,7 +191,8 @@ class CustomerSheetUtils {
             case .none:
                 break
             }
-            payload.setValue(["code": ErrorType.Canceled], forKey: "error")
+            let cancelError = Errors.createError(ErrorType.Canceled, nil as String?)
+            payload.setValue(cancelError["error"], forKey: "error")
         }
         return payload
     }


### PR DESCRIPTION
## Summary
- Fix type mismatch when CustomerSheet is canceled on iOS and Android
- iOS was sending `{"code": "Canceled"}` instead of full error structure
- Android had the same issue in both `handleResult()` and `retrievePaymentOptionSelection()`

Fixes #2302

## Test plan
- [ ] Cancel CustomerSheet on iOS and verify no type error
- [ ] Cancel CustomerSheet on Android and verify no type error