### PR TITLE
Card field delay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ lcov.info
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+**/build/


### PR DESCRIPTION
Use MutationObserver to wait for the DOM element to be inserted, matching the pattern used by PaymentElement. This is necessary because postFrameCallback timing is unreliable in deployed environments so sometimes the card field would not render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe card field initialization with enhanced timing handling for better cross-browser compatibility, particularly in Safari and post-frame rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->