### PR TITLE
fix stripe_web: store card element div globally to prevent mounting errors

### DIFF
--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 13 19:26:48 WET 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.7.3" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 

--- a/packages/stripe_android/android/src/main/kotlin/com/facebook/react/bridge/ReadableArray.java
+++ b/packages/stripe_android/android/src/main/kotlin/com/facebook/react/bridge/ReadableArray.java
@@ -50,15 +50,21 @@ public class ReadableArray extends ArrayList<Object> {
 
     @Override
     public int size() {
-        return array.length();
+        if (array.length() > 0) {
+            return array.length();
+        }
+        return super.size();
     }
 
     @Override
     public Object get(int index) {
-        if (index < 0 || index >= array.length()) {
-            throw new IndexOutOfBoundsException("Index " + index + " out of bounds for length " + array.length());
+        if (array.length() > 0) {
+            if (index < 0 || index >= array.length()) {
+                throw new IndexOutOfBoundsException("Index " + index + " out of bounds for length " + array.length());
+            }
+            return array.opt(index);
         }
-        return array.opt(index);
+        return super.get(index);
     }
 
     @NotNull

--- a/packages/stripe_android/android/src/main/kotlin/com/facebook/react/bridge/ReadableMap.java
+++ b/packages/stripe_android/android/src/main/kotlin/com/facebook/react/bridge/ReadableMap.java
@@ -43,12 +43,18 @@ public class ReadableMap extends Dynamic {
 
     @Override
     public boolean isEmpty() {
-        return map.length() == 0;
+        if (map.length() > 0) {
+            return false;
+        }
+        return super.isEmpty();
     }
 
     @Override
     public int size() {
-        return map.length();
+        if (map.length() > 0) {
+            return map.length();
+        }
+        return super.size();
     }
 
     public boolean hasKey(String key) {

--- a/packages/stripe_android/android/src/main/kotlin/com/facebook/react/uimanager/events/RCTEventEmitter.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/facebook/react/uimanager/events/RCTEventEmitter.kt
@@ -1,12 +1,37 @@
 package com.facebook.react.uimanager.events
 
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import io.flutter.plugin.common.MethodChannel
+import java.util.ArrayList
+import java.util.HashMap
 
 class RCTEventEmitter(private val channel: MethodChannel) {
 
     fun receiveEvent(viewTag: Any, eventName: String, serializeEventData: ReadableMap?) {
-        channel.invokeMethod(eventName, serializeEventData)
+        channel.invokeMethod(eventName, deepConvert(serializeEventData))
+    }
+
+    private fun deepConvert(value: Any?): Any? {
+        if (value is WritableMap) {
+            val map = HashMap<String, Any?>()
+            for ((k, v) in value.entries) {
+                map[k] = deepConvert(v)
+            }
+            return map
+        } else if (value is WritableArray) {
+            val list = ArrayList<Any?>()
+            for (item in value) {
+                list.add(deepConvert(item))
+            }
+            return list
+        } else if (value is ReadableMap) {
+            return value.toHashMap()
+        } else if (value is ReadableArray) {
+            return value.toArrayList()
+        }
+        return value
     }
 }

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkCardFormPlatformView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkCardFormPlatformView.kt
@@ -95,6 +95,9 @@ class StripeSdkCardFormPlatformView(
                 cardFormViewManager.delegate.receiveCommand(cardView, call.method, null)
                 result.success(null)
             }
+            "topFocusChange", "topCardChange" -> {
+                result.success(null)
+            }
             else -> {
                 cardFormViewManager.delegate.setProperty(
                     cardView,

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkCardPlatformView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeSdkCardPlatformView.kt
@@ -125,6 +125,9 @@ class StripeSdkCardPlatformView(
                 )
                 result.success(null)
             }
+            "topFocusChange", "topCardChange" -> {
+                result.success(null)
+            }
             else -> {
                 stripeSdkCardViewManager.delegate.setProperty(
                     cardView,

--- a/packages/stripe_web/lib/src/widgets/card_field.dart
+++ b/packages/stripe_web/lib/src/widgets/card_field.dart
@@ -11,6 +11,8 @@ import 'package:web/web.dart' as web;
 
 import '../../flutter_stripe_web.dart';
 
+web.HTMLDivElement? _cardElementDiv;
+
 const kCardFieldDefaultHeight = 10.0;
 const kCardFieldDefaultFontSize = 17.0;
 
@@ -56,9 +58,11 @@ class WebStripeCardState extends State<WebCardField> with CardFieldContext {
   void initState() {
     ui.platformViewRegistry.registerViewFactory(
       'stripe_card',
-      (int viewId) => web.HTMLDivElement()
-        ..id = 'card-element'
-        ..style.border = 'none',
+      (int viewId) {
+        final element = web.HTMLDivElement()..style.border = 'none';
+        _cardElementDiv = element;
+        return element;
+      },
     );
     initStripe();
     super.initState();
@@ -83,10 +87,14 @@ class WebStripeCardState extends State<WebCardField> with CardFieldContext {
             const CardFieldInputDetails(complete: false),
             controller,
           );
+          final container = _cardElementDiv;
+          if (container == null) {
+            return;
+          }
           element = WebStripe.js
               .elements(createElementOptions())
               .createCard(createOptions())
-            ..mount('#card-element'.toJS)
+            ..mount(container)
             ..onBlur(requestBlur)
             ..onFocus(requestFocus)
             ..onChange(onCardChanged);
@@ -186,6 +194,7 @@ class WebStripeCardState extends State<WebCardField> with CardFieldContext {
   void dispose() {
     detachController(controller);
     element?.unmount();
+    _cardElementDiv = null;
     super.dispose();
   }
 


### PR DESCRIPTION
The card element div was being recreated on each mount, causing issues with Stripe's element mounting. Store it globally and clear on dispose to ensure consistent mounting and unmounting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Card field now emits focus and card-change events reliably, improving real-time feedback during input.

* **Bug Fixes**
  * Improved initialization and mounting so the payment card element renders consistently.
  * Better cleanup on dispose to avoid stale references and potential leaks.

* **Platform**
  * Web and Android platform integrations hardened to ensure event handling and view wiring behave consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->