### PR TITLE
fix: correct CardField web color rendering and apply all style colors

### DIFF
--- a/packages/stripe_web/lib/src/widgets/card_field.dart
+++ b/packages/stripe_web/lib/src/widgets/card_field.dart
@@ -191,7 +191,7 @@ class WebStripeCardState extends State<WebCardField> with CardFieldContext {
         'base': {
           'color': ?textColor,
           'backgroundColor': ?backgroundColor,
-          '::placeholder': {'color': ?placeholderColor},
+          if (placeholderColor != null) '::placeholder': {'color': placeholderColor},
         },
       },
       hidePostalCode: !widget.enablePostalCode,


### PR DESCRIPTION
Fixes #1567

Bugs:
- `colorToCssString()` used `color.r`, `color.g`, `color.b` which return normalized floats (`0.0–1.0`) instead of integers. This caused `Colors.white` to produce `rgb(1, 1, 1)` (near-black) instead of `rgb(255, 255, 255)`, making text appear black regardless of the configured `CardStyle`.
- `placeholderColor` and `backgroundColor` were accepted by `CardStyle` but silently ignored on web.

Fixes:
- Use `color.toARGB32()` with bit-shifting to extract proper 0–255 integer values.
- `backgroundColor` on the base style, and `placeholderColor` to `::placeholder`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color handling in the card input field to preserve null-safety for text, background, and placeholder colors.
  * Standardized color-to-CSS conversion so element styles (text, background, placeholder) render consistently and only include color rules when values are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->