### PR TITLE
fix(web): unique view type per PaymentElement instance to fix infinite spinner on remount (#2368)

### DIFF
--- a/packages/stripe_web/lib/src/widgets/payment_element.dart
+++ b/packages/stripe_web/lib/src/widgets/payment_element.dart
@@ -72,6 +72,9 @@ class PaymentElement extends StatefulWidget {
 }
 
 class PaymentElementState extends State<PaymentElement> {
+  static int _nextId = 0;
+  final String _viewType = 'stripe_payment_element_${_nextId++}';
+
   web.HTMLDivElement _divElement = web.HTMLDivElement();
   double height = 300.0;
   bool _isReady = false;
@@ -108,7 +111,7 @@ class PaymentElementState extends State<PaymentElement> {
     _cachedElementOptions = _elementOptionsOnce();
 
     ui.platformViewRegistry.registerViewFactory(
-      'stripe_payment_element',
+      _viewType,
       (int viewId) => _divElement,
     );
 
@@ -176,7 +179,7 @@ class PaymentElementState extends State<PaymentElement> {
         ),
         child: Stack(
           children: [
-            const HtmlElementView(viewType: 'stripe_payment_element'),
+            HtmlElementView(viewType: _viewType),
             if (!_isReady)
               Container(
                 color: Theme.of(context).scaffoldBackgroundColor,


### PR DESCRIPTION
## Summary

- Fixes #2368 

When navigating away from a screen containing a `PaymentElement` and back to it, the widget
displayed an infinite `CircularProgressIndicator` and the payment form never became interactive.


### Route cause

`platformViewRegistry.registerViewFactory` silently ignores re-registrations for an already-known view type ID.
- The hardcoded ID `'stripe_payment_element'` was registered on the first `initState`. 
- On the second mount, a new `_divElement` is created but its factory registration is ignored. Flutter's renderer keeps using the stale factory from the first mount. 
- The new div is never injected into the DOM, so `_divElement.isConnected` stays `false` forever.
- `_mountWhenConnected` then loops infinitely via `addPostFrameCallback`, `_isReady` is never set to `true`, and the `CircularProgressIndicator` overlay is never removed.


### Fix

Generate a unique view type ID per state instance using a static counter (`stripe_payment_element_0`, `stripe_payment_element_1`, …). Each mount registers a fresh factory, so `HtmlElementView` always resolves to the correct div for that instance.


### Test plan

- [ ] Navigate to a screen containing `PaymentElement` => form loads correctly
- [ ] Navigate away (widget disposed) then navigate back => form loads correctly on remount


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal handling for multiple payment element instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->