### PR TITLE
fix: Bump Stripe iOS SDK to ~> 25.9.0 (Xcode 26.4 crash fix)

### DIFF
--- a/packages/stripe_ios/ios/stripe_ios.podspec
+++ b/packages/stripe_ios/ios/stripe_ios.podspec
@@ -2,7 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint stripe_ios.podspec' to validate before publishing.
 #
-stripe_version = '~> 25.6.0'
+stripe_version = '~> 25.9.0'
 Pod::Spec.new do |s|
   s.name             = 'stripe_ios'
   s.version          = '0.0.1'


### PR DESCRIPTION
## Summary

Apps built with **Xcode 26.4** (Swift 6.3 compiler) crash at payment time when using Stripe iOS SDK < 25.9.0. The crash occurs in `PaymentSheetLoader.load` due to a Swift compiler bug with `async let` (`swiftlang/swift#87481`).

Stripe fixed this in **iOS SDK 25.9.0**. This PR bumps the podspec constraint from `~> 25.6.0` to `~> 25.9.0`.

## Changes

- `packages/stripe_ios/ios/stripe_ios.podspec`: `stripe_version` from `~> 25.6.0` to `~> 25.9.0`

## Breaking change analysis (25.6 → 25.9)

The only breaking change is in **25.7.0**: `PaymentMethodMessagingElement.Appearance.infoIconColor` was removed (replaced by `linkTextColor`). This type is **not used** by the `stripe_ios` plugin — zero references in the Swift source.

All other changes (25.7.1, 25.8.0, 25.9.0) are additive or behavioral with no API signature changes.

## Refs

- Stripe iOS SDK 25.9.0 release: https://github.com/stripe/stripe-ios/releases/tag/25.9.0
- Swift compiler bug: https://github.com/swiftlang/swift/issues/87481
- Related issue: #2373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS Stripe payment library dependencies from version 25.6.0 to 25.9.0, including all related Stripe components (PaymentSheet, Payments, PaymentsUI, ApplePay, FinancialConnections).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->