### PR TITLE
feat: expose Stripe Connect deep link infrastructure to Dart

### DIFF
--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -744,7 +744,8 @@ class Stripe {
 
   /// Store a Stripe Connect deep link URL for later retrieval.
   ///
-  /// Used on Android to intercept stripe-connect:// deep links.
+  /// **Android-only.** Used to intercept `stripe-connect://` deep links.
+  /// On iOS this is a no-op and on Web it throws [WebUnsupportedError].
   Future<void> storeStripeConnectDeepLink(String url) async {
     await _awaitForSettings();
     return _platform.storeStripeConnectDeepLink(url);
@@ -752,7 +753,9 @@ class Stripe {
 
   /// Retrieve and clear any pending Stripe Connect deep link URLs.
   ///
-  /// Returns a list of URLs that were stored via [storeStripeConnectDeepLink].
+  /// **Android-only.** Returns a list of URLs that were stored via
+  /// [storeStripeConnectDeepLink]. On iOS this always returns an empty list
+  /// and on Web it throws [WebUnsupportedError].
   Future<List<String>> pollAndClearPendingStripeConnectUrls() async {
     await _awaitForSettings();
     return _platform.pollAndClearPendingStripeConnectUrls();

--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -734,6 +734,22 @@ class Stripe {
     }
   }
 
+  /// Store a Stripe Connect deep link URL for later retrieval.
+  ///
+  /// Used on Android to intercept stripe-connect:// deep links.
+  Future<void> storeStripeConnectDeepLink(String url) async {
+    await _awaitForSettings();
+    return _platform.storeStripeConnectDeepLink(url);
+  }
+
+  /// Retrieve and clear any pending Stripe Connect deep link URLs.
+  ///
+  /// Returns a list of URLs that were stored via [storeStripeConnectDeepLink].
+  Future<List<String>> pollAndClearPendingStripeConnectUrls() async {
+    await _awaitForSettings();
+    return _platform.pollAndClearPendingStripeConnectUrls();
+  }
+
   /// Initializes the customer sheet with the provided [parameters].
   ///
   /// Throws a [StripeException] if initialization fails.

--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -742,20 +742,11 @@ class Stripe {
     }
   }
 
-  /// Store a Stripe Connect deep link URL for later retrieval.
-  ///
-  /// **Android-only.** Used to intercept `stripe-connect://` deep links.
-  /// On iOS this is a no-op and on Web it throws [WebUnsupportedError].
-  Future<void> storeStripeConnectDeepLink(String url) async {
-    await _awaitForSettings();
-    return _platform.storeStripeConnectDeepLink(url);
-  }
-
   /// Retrieve and clear any pending Stripe Connect deep link URLs.
   ///
-  /// **Android-only.** Returns a list of URLs that were stored via
-  /// [storeStripeConnectDeepLink]. On iOS this always returns an empty list
-  /// and on Web it throws [WebUnsupportedError].
+  /// **Android-only.** Returns any `stripe-connect://` URLs captured by the
+  /// native deep link interceptor since the last poll. On iOS this always
+  /// returns an empty list and on Web it throws [WebUnsupportedError].
   Future<List<String>> pollAndClearPendingStripeConnectUrls() async {
     await _awaitForSettings();
     return _platform.pollAndClearPendingStripeConnectUrls();

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
@@ -302,6 +302,13 @@ If you continue to have trouble, follow this discussion to get some support http
                     promise = Promise(result)
                 )
             }
+            "storeStripeConnectDeepLink" -> stripeSdk.storeStripeConnectDeepLink(
+                url = call.requiredArgument("url"),
+                promise = Promise(result)
+            )
+            "pollAndClearPendingStripeConnectUrls" -> stripeSdk.pollAndClearPendingStripeConnectUrls(
+                promise = Promise(result)
+            )
             else -> result.notImplemented()
         }
     }

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
@@ -305,10 +305,6 @@ If you continue to have trouble, follow this discussion to get some support http
             "createRadarSession" -> stripeSdk.createRadarSession(
                 promise = Promise(result)
             )
-            "storeStripeConnectDeepLink" -> stripeSdk.storeStripeConnectDeepLink(
-                url = call.requiredArgument("url"),
-                promise = Promise(result)
-            )
             "pollAndClearPendingStripeConnectUrls" -> stripeSdk.pollAndClearPendingStripeConnectUrls(
                 promise = Promise(result)
             )

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
@@ -271,6 +271,12 @@ class StripePlugin: StripeSdkImpl, FlutterPlugin, ViewManagerDelegate {
             )
         case "handleNextActionForSetup":
             return handleNextActionForSetupIntent(call, result: result)
+        case "storeStripeConnectDeepLink":
+            // No-op on iOS — deep link interception is Android-specific
+            result(nil)
+        case "pollAndClearPendingStripeConnectUrls":
+            // No-op on iOS — returns empty list
+            result([String]())
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
@@ -273,9 +273,6 @@ class StripePlugin: StripeSdkImpl, FlutterPlugin, ViewManagerDelegate {
             return handleNextActionForSetupIntent(call, result: result)
         case "createRadarSession":
             createRadarSession(resolver: resolver(for: result), rejecter: rejecter(for: result))
-        case "storeStripeConnectDeepLink":
-            // No-op on iOS — deep link interception is Android-specific
-            result(nil)
         case "pollAndClearPendingStripeConnectUrls":
             // No-op on iOS — returns empty list
             result([String]())

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -773,13 +773,6 @@ class MethodChannelStripe extends StripePlatform {
   }
 
   @override
-  Future<void> storeStripeConnectDeepLink(String url) async {
-    await _methodChannel.invokeMethod('storeStripeConnectDeepLink', {
-      'url': url,
-    });
-  }
-
-  @override
   Future<List<String>> pollAndClearPendingStripeConnectUrls() async {
     final result = await _methodChannel.invokeMethod<List<dynamic>>(
       'pollAndClearPendingStripeConnectUrls',

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -761,6 +761,21 @@ class MethodChannelStripe extends StripePlatform {
   }
 
   @override
+  Future<void> storeStripeConnectDeepLink(String url) async {
+    await _methodChannel.invokeMethod('storeStripeConnectDeepLink', {
+      'url': url,
+    });
+  }
+
+  @override
+  Future<List<String>> pollAndClearPendingStripeConnectUrls() async {
+    final result = await _methodChannel.invokeMethod<List<dynamic>>(
+      'pollAndClearPendingStripeConnectUrls',
+    );
+    return result?.cast<String>() ?? [];
+  }
+
+  @override
   Future<IsCardInWalletResult> isCardInWallet(String cardLastFour) async {
     final result = await _methodChannel.invokeMapMethod<String, dynamic>(
       'isCardInWallet',

--- a/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
@@ -198,14 +198,10 @@ abstract class StripePlatform extends PlatformInterface {
     IntentCreationCallbackParams params,
   );
 
-  /// Store a Stripe Connect deep link URL for later retrieval.
-  ///
-  /// Used on Android to intercept stripe-connect:// deep links.
-  Future<void> storeStripeConnectDeepLink(String url);
-
   /// Retrieve and clear any pending Stripe Connect deep link URLs.
   ///
-  /// Returns a list of URLs that were stored via [storeStripeConnectDeepLink].
+  /// Returns stripe-connect:// URLs captured natively on Android since the
+  /// last poll.
   Future<List<String>> pollAndClearPendingStripeConnectUrls();
 
   Widget buildCard({

--- a/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
@@ -196,6 +196,16 @@ abstract class StripePlatform extends PlatformInterface {
     IntentCreationCallbackParams params,
   );
 
+  /// Store a Stripe Connect deep link URL for later retrieval.
+  ///
+  /// Used on Android to intercept stripe-connect:// deep links.
+  Future<void> storeStripeConnectDeepLink(String url);
+
+  /// Retrieve and clear any pending Stripe Connect deep link URLs.
+  ///
+  /// Returns a list of URLs that were stored via [storeStripeConnectDeepLink].
+  Future<List<String>> pollAndClearPendingStripeConnectUrls();
+
   Widget buildCard({
     Key? key,
     required CardEditController controller,

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -686,11 +686,6 @@ class WebStripe extends StripePlatform {
   }
 
   @override
-  Future<void> storeStripeConnectDeepLink(String url) {
-    throw WebUnsupportedError.method('storeStripeConnectDeepLink');
-  }
-
-  @override
   Future<List<String>> pollAndClearPendingStripeConnectUrls() {
     throw WebUnsupportedError.method('pollAndClearPendingStripeConnectUrls');
   }

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -679,6 +679,16 @@ class WebStripe extends StripePlatform {
       IntentCreationCallbackParams params) {
     throw WebUnsupportedError.method('confirmationTokenCreationCallback');
   }
+
+  @override
+  Future<void> storeStripeConnectDeepLink(String url) {
+    throw WebUnsupportedError.method('storeStripeConnectDeepLink');
+  }
+
+  @override
+  Future<List<String>> pollAndClearPendingStripeConnectUrls() {
+    throw WebUnsupportedError.method('pollAndClearPendingStripeConnectUrls');
+  }
 }
 
 class WebUnsupportedError extends Error implements UnsupportedError {


### PR DESCRIPTION
## Summary
- Wire existing Android `storeStripeConnectDeepLink` and `pollAndClearPendingStripeConnectUrls` to Dart API
- iOS returns no-op (deep links are Android-specific)
- Web throws `WebUnsupportedError`

Closes part of #2378

## Test plan
- [ ] Store and poll deep link URLs on Android
- [ ] Verify iOS returns empty list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to retrieve and clear pending Stripe Connect deep-link URLs so apps can collect and process deferred connect callbacks.
  * Android: forwards captured deep-link URLs to the API.
  * iOS: API returns an empty list.
  * Web: API is marked unsupported on web.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->