### PR TITLE
fix(#2389): update compileSdk to 36

### DIFF
--- a/packages/stripe_android/android/build.gradle
+++ b/packages/stripe_android/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.3'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
     }
@@ -30,7 +30,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'com.flutter.stripe'
-    compileSdk 35
+    compileSdk 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android build configuration to use a newer toolchain and target a more recent Android SDK, improving compatibility with recent devices and OS versions. No public APIs or user-facing functionality were changed; this is an internal platform update intended to reduce build issues and improve runtime compatibility with current Android releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->