### PR TITLE
fix!: return sealed CollectBankAccountResult from collectBankAccount / verifyMicrodeposits

### DIFF
--- a/example/lib/screens/regional_payment_methods/us_bank_account_direct_debit_screen.dart
+++ b/example/lib/screens/regional_payment_methods/us_bank_account_direct_debit_screen.dart
@@ -134,10 +134,15 @@ class _UsBankAccountDirectDebitScreenState
           ),
         );
 
-        if (result.status == PaymentIntentsStatus.RequiresConfirmation) {
+        final paymentIntent = switch (result) {
+          CollectBankAccountPaymentIntentResult(:final paymentIntent) =>
+            paymentIntent,
+          CollectBankAccountSetupIntentResult() => null,
+        };
+        if (paymentIntent?.status == PaymentIntentsStatus.RequiresConfirmation) {
           setState(() {
             canConfirm = true;
-            clientSecretForConfirm = result.clientSecret;
+            clientSecretForConfirm = paymentIntent!.clientSecret;
           });
           if (context.mounted) {
             scaffoldMessenger.showSnackBar(

--- a/packages/stripe/lib/src/stripe.dart
+++ b/packages/stripe/lib/src/stripe.dart
@@ -632,8 +632,10 @@ class Stripe {
 
   /// Collect the bankaccount details for the payment intent.
   ///
-  /// Only US bank accounts are supported.
-  Future<PaymentIntent> collectBankAccount({
+  /// Only US bank accounts are supported. The returned
+  /// [CollectBankAccountResult] is a sealed union containing either a
+  /// [PaymentIntent] or a [SetupIntent] depending on [isPaymentIntent].
+  Future<CollectBankAccountResult> collectBankAccount({
     /// Whether the clientsecret is associated with setup or paymentintent
     required bool isPaymentIntent,
 
@@ -655,8 +657,10 @@ class Stripe {
   /// Verify the bank account with microtransactions
   ///
   /// Only US bank accounts are supported.This method is only implemented for
-  /// iOS at the moment.
-  Future<PaymentIntent> verifyPaymentIntentWithMicrodeposits({
+  /// iOS at the moment. The returned [CollectBankAccountResult] is a sealed
+  /// union containing either a [PaymentIntent] or a [SetupIntent] depending on
+  /// [isPaymentIntent].
+  Future<CollectBankAccountResult> verifyPaymentIntentWithMicrodeposits({
     /// Whether the clientsecret is associated with setup or paymentintent
     required bool isPaymentIntent,
 

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -15,6 +15,7 @@ import 'package:stripe_platform_interface/src/result_parser.dart';
 
 import 'models/app_info.dart';
 import 'models/card_details.dart';
+import 'models/collect_bank_account_result.dart';
 import 'models/errors.dart';
 import 'models/payment_intents.dart';
 import 'models/payment_methods.dart';
@@ -569,7 +570,7 @@ class MethodChannelStripe extends StripePlatform {
   }
 
   @override
-  Future<PaymentIntent> collectBankAccount({
+  Future<CollectBankAccountResult> collectBankAccount({
     required bool isPaymentIntent,
     required String clientSecret,
     required CollectBankAccountParams params,
@@ -583,13 +584,11 @@ class MethodChannelStripe extends StripePlatform {
 
     _financialConnectionsEventHandler = params.onEvent;
 
-    return ResultParser<PaymentIntent>(
-      parseJson: (json) => PaymentIntent.fromJson(json),
-    ).parse(result: result!, successResultKey: 'paymentIntent');
+    return CollectBankAccountResult.fromJson(result!);
   }
 
   @override
-  Future<PaymentIntent> verifyPaymentIntentWithMicrodeposits({
+  Future<CollectBankAccountResult> verifyPaymentIntentWithMicrodeposits({
     required bool isPaymentIntent,
     required String clientSecret,
     required VerifyMicroDepositsParams params,
@@ -601,9 +600,7 @@ class MethodChannelStripe extends StripePlatform {
           'clientSecret': clientSecret,
         });
 
-    return ResultParser<PaymentIntent>(
-      parseJson: (json) => PaymentIntent.fromJson(json),
-    ).parse(result: result!, successResultKey: 'paymentIntent');
+    return CollectBankAccountResult.fromJson(result!);
   }
 
   @override

--- a/packages/stripe_platform_interface/lib/src/models/collect_bank_account_result.dart
+++ b/packages/stripe_platform_interface/lib/src/models/collect_bank_account_result.dart
@@ -1,0 +1,38 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'errors.dart';
+import 'payment_intents.dart';
+import 'setup_intent.dart';
+
+part 'collect_bank_account_result.freezed.dart';
+
+/// Result of `collectBankAccount` / `verifyPaymentIntentWithMicrodeposits`.
+///
+/// Native SDKs return either a payment intent or a setup intent depending on
+/// the client secret that was supplied, so the result is modelled as a sealed
+/// union to keep both flows strongly typed.
+@freezed
+sealed class CollectBankAccountResult with _$CollectBankAccountResult {
+  const factory CollectBankAccountResult.paymentIntent(
+    PaymentIntent paymentIntent,
+  ) = CollectBankAccountPaymentIntentResult;
+
+  const factory CollectBankAccountResult.setupIntent(SetupIntent setupIntent) =
+      CollectBankAccountSetupIntentResult;
+
+  /// Parses a native method-channel response into the matching variant, or
+  /// throws [StripeException] when neither key is present.
+  factory CollectBankAccountResult.fromJson(Map<String, dynamic> json) {
+    final payment = json['paymentIntent'];
+    if (payment is Map<String, dynamic>) {
+      return CollectBankAccountResult.paymentIntent(
+        PaymentIntent.fromJson(payment),
+      );
+    }
+    final setup = json['setupIntent'];
+    if (setup is Map<String, dynamic>) {
+      return CollectBankAccountResult.setupIntent(SetupIntent.fromJson(setup));
+    }
+    throw StripeException.fromJson(json);
+  }
+}

--- a/packages/stripe_platform_interface/lib/src/models/collect_bank_account_result.freezed.dart
+++ b/packages/stripe_platform_interface/lib/src/models/collect_bank_account_result.freezed.dart
@@ -1,0 +1,324 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'collect_bank_account_result.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$CollectBankAccountResult {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CollectBankAccountResult);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CollectBankAccountResult()';
+}
+
+
+}
+
+/// @nodoc
+class $CollectBankAccountResultCopyWith<$Res>  {
+$CollectBankAccountResultCopyWith(CollectBankAccountResult _, $Res Function(CollectBankAccountResult) __);
+}
+
+
+/// Adds pattern-matching-related methods to [CollectBankAccountResult].
+extension CollectBankAccountResultPatterns on CollectBankAccountResult {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( CollectBankAccountPaymentIntentResult value)?  paymentIntent,TResult Function( CollectBankAccountSetupIntentResult value)?  setupIntent,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case CollectBankAccountPaymentIntentResult() when paymentIntent != null:
+return paymentIntent(_that);case CollectBankAccountSetupIntentResult() when setupIntent != null:
+return setupIntent(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( CollectBankAccountPaymentIntentResult value)  paymentIntent,required TResult Function( CollectBankAccountSetupIntentResult value)  setupIntent,}){
+final _that = this;
+switch (_that) {
+case CollectBankAccountPaymentIntentResult():
+return paymentIntent(_that);case CollectBankAccountSetupIntentResult():
+return setupIntent(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( CollectBankAccountPaymentIntentResult value)?  paymentIntent,TResult? Function( CollectBankAccountSetupIntentResult value)?  setupIntent,}){
+final _that = this;
+switch (_that) {
+case CollectBankAccountPaymentIntentResult() when paymentIntent != null:
+return paymentIntent(_that);case CollectBankAccountSetupIntentResult() when setupIntent != null:
+return setupIntent(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( PaymentIntent paymentIntent)?  paymentIntent,TResult Function( SetupIntent setupIntent)?  setupIntent,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case CollectBankAccountPaymentIntentResult() when paymentIntent != null:
+return paymentIntent(_that.paymentIntent);case CollectBankAccountSetupIntentResult() when setupIntent != null:
+return setupIntent(_that.setupIntent);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( PaymentIntent paymentIntent)  paymentIntent,required TResult Function( SetupIntent setupIntent)  setupIntent,}) {final _that = this;
+switch (_that) {
+case CollectBankAccountPaymentIntentResult():
+return paymentIntent(_that.paymentIntent);case CollectBankAccountSetupIntentResult():
+return setupIntent(_that.setupIntent);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( PaymentIntent paymentIntent)?  paymentIntent,TResult? Function( SetupIntent setupIntent)?  setupIntent,}) {final _that = this;
+switch (_that) {
+case CollectBankAccountPaymentIntentResult() when paymentIntent != null:
+return paymentIntent(_that.paymentIntent);case CollectBankAccountSetupIntentResult() when setupIntent != null:
+return setupIntent(_that.setupIntent);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class CollectBankAccountPaymentIntentResult implements CollectBankAccountResult {
+  const CollectBankAccountPaymentIntentResult(this.paymentIntent);
+  
+
+ final  PaymentIntent paymentIntent;
+
+/// Create a copy of CollectBankAccountResult
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CollectBankAccountPaymentIntentResultCopyWith<CollectBankAccountPaymentIntentResult> get copyWith => _$CollectBankAccountPaymentIntentResultCopyWithImpl<CollectBankAccountPaymentIntentResult>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CollectBankAccountPaymentIntentResult&&(identical(other.paymentIntent, paymentIntent) || other.paymentIntent == paymentIntent));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,paymentIntent);
+
+@override
+String toString() {
+  return 'CollectBankAccountResult.paymentIntent(paymentIntent: $paymentIntent)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CollectBankAccountPaymentIntentResultCopyWith<$Res> implements $CollectBankAccountResultCopyWith<$Res> {
+  factory $CollectBankAccountPaymentIntentResultCopyWith(CollectBankAccountPaymentIntentResult value, $Res Function(CollectBankAccountPaymentIntentResult) _then) = _$CollectBankAccountPaymentIntentResultCopyWithImpl;
+@useResult
+$Res call({
+ PaymentIntent paymentIntent
+});
+
+
+$PaymentIntentCopyWith<$Res> get paymentIntent;
+
+}
+/// @nodoc
+class _$CollectBankAccountPaymentIntentResultCopyWithImpl<$Res>
+    implements $CollectBankAccountPaymentIntentResultCopyWith<$Res> {
+  _$CollectBankAccountPaymentIntentResultCopyWithImpl(this._self, this._then);
+
+  final CollectBankAccountPaymentIntentResult _self;
+  final $Res Function(CollectBankAccountPaymentIntentResult) _then;
+
+/// Create a copy of CollectBankAccountResult
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? paymentIntent = null,}) {
+  return _then(CollectBankAccountPaymentIntentResult(
+null == paymentIntent ? _self.paymentIntent : paymentIntent // ignore: cast_nullable_to_non_nullable
+as PaymentIntent,
+  ));
+}
+
+/// Create a copy of CollectBankAccountResult
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PaymentIntentCopyWith<$Res> get paymentIntent {
+  
+  return $PaymentIntentCopyWith<$Res>(_self.paymentIntent, (value) {
+    return _then(_self.copyWith(paymentIntent: value));
+  });
+}
+}
+
+/// @nodoc
+
+
+class CollectBankAccountSetupIntentResult implements CollectBankAccountResult {
+  const CollectBankAccountSetupIntentResult(this.setupIntent);
+  
+
+ final  SetupIntent setupIntent;
+
+/// Create a copy of CollectBankAccountResult
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CollectBankAccountSetupIntentResultCopyWith<CollectBankAccountSetupIntentResult> get copyWith => _$CollectBankAccountSetupIntentResultCopyWithImpl<CollectBankAccountSetupIntentResult>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CollectBankAccountSetupIntentResult&&(identical(other.setupIntent, setupIntent) || other.setupIntent == setupIntent));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,setupIntent);
+
+@override
+String toString() {
+  return 'CollectBankAccountResult.setupIntent(setupIntent: $setupIntent)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CollectBankAccountSetupIntentResultCopyWith<$Res> implements $CollectBankAccountResultCopyWith<$Res> {
+  factory $CollectBankAccountSetupIntentResultCopyWith(CollectBankAccountSetupIntentResult value, $Res Function(CollectBankAccountSetupIntentResult) _then) = _$CollectBankAccountSetupIntentResultCopyWithImpl;
+@useResult
+$Res call({
+ SetupIntent setupIntent
+});
+
+
+$SetupIntentCopyWith<$Res> get setupIntent;
+
+}
+/// @nodoc
+class _$CollectBankAccountSetupIntentResultCopyWithImpl<$Res>
+    implements $CollectBankAccountSetupIntentResultCopyWith<$Res> {
+  _$CollectBankAccountSetupIntentResultCopyWithImpl(this._self, this._then);
+
+  final CollectBankAccountSetupIntentResult _self;
+  final $Res Function(CollectBankAccountSetupIntentResult) _then;
+
+/// Create a copy of CollectBankAccountResult
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? setupIntent = null,}) {
+  return _then(CollectBankAccountSetupIntentResult(
+null == setupIntent ? _self.setupIntent : setupIntent // ignore: cast_nullable_to_non_nullable
+as SetupIntent,
+  ));
+}
+
+/// Create a copy of CollectBankAccountResult
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SetupIntentCopyWith<$Res> get setupIntent {
+  
+  return $SetupIntentCopyWith<$Res>(_self.setupIntent, (value) {
+    return _then(_self.copyWith(setupIntent: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/src/stripe_platform_interface.dart
@@ -157,13 +157,13 @@ abstract class StripePlatform extends PlatformInterface {
   Future<RadarSession> createRadarSession();
 
   /// Methods related to ACH payments
-  Future<PaymentIntent> collectBankAccount({
+  Future<CollectBankAccountResult> collectBankAccount({
     required bool isPaymentIntent,
     required String clientSecret,
     required CollectBankAccountParams params,
   });
 
-  Future<PaymentIntent> verifyPaymentIntentWithMicrodeposits({
+  Future<CollectBankAccountResult> verifyPaymentIntentWithMicrodeposits({
     required bool isPaymentIntent,
     required String clientSecret,
     required VerifyMicroDepositsParams params,

--- a/packages/stripe_platform_interface/lib/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/stripe_platform_interface.dart
@@ -8,6 +8,7 @@ export 'src/models/app_info.dart';
 export 'src/models/apple_pay.dart';
 export 'src/models/aubecs_form.dart';
 export 'src/models/capture_method.dart';
+export 'src/models/collect_bank_account_result.dart';
 export 'src/models/card_brand.dart';
 export 'src/models/card_details.dart';
 export 'src/models/card_field_input.dart';

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -509,7 +509,7 @@ class WebStripe extends StripePlatform {
   }
 
   @override
-  Future<PaymentIntent> collectBankAccount(
+  Future<CollectBankAccountResult> collectBankAccount(
       {required bool isPaymentIntent,
       required String clientSecret,
       required CollectBankAccountParams params}) {
@@ -517,7 +517,7 @@ class WebStripe extends StripePlatform {
   }
 
   @override
-  Future<PaymentIntent> verifyPaymentIntentWithMicrodeposits(
+  Future<CollectBankAccountResult> verifyPaymentIntentWithMicrodeposits(
       {required bool isPaymentIntent,
       required String clientSecret,
       required VerifyMicroDepositsParams params}) {


### PR DESCRIPTION
## Summary

- **Fixes** `collectBankAccount` and `verifyPaymentIntentWithMicrodeposits` when called with `isPaymentIntent: false`. The native SDKs return a setup-intent-shaped payload that cannot be parsed by `PaymentIntent.fromJson` (missing `amount`, `currency`, `captureMethod`, `confirmationMethod`).
- **Introduces** a sealed `CollectBankAccountResult` union with `.paymentIntent(PaymentIntent)` / `.setupIntent(SetupIntent)` variants.
- Both `MethodChannelStripe` methods now delegate to `ResultParser<T>` + the generated `fromJson` for both branches, removing all hand-written field extraction and status mapping.

---

## Breaking change

`Stripe.instance.collectBankAccount` and `Stripe.instance.verifyPaymentIntentWithMicrodeposits` now return `Future<CollectBankAccountResult>` instead of `Future<PaymentIntent>`. 

Callers must now destructure the union:

```dart
final result = await Stripe.instance.collectBankAccount(...);

switch (result) {
  case CollectBankAccountPaymentIntentResult(:final paymentIntent):
    // handle payment intent flow
    break;
  case CollectBankAccountSetupIntentResult(:final setupIntent):
    // handle setup intent flow
    break;
}
```

**Note:** The setup-intent branch was broken before this change, so no working code depends on the previous shape.

---

## Affected packages

- `stripe_platform_interface`
- `stripe`
- `stripe_web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The return type of `collectBankAccount()` and `verifyPaymentIntentWithMicrodeposits()` has changed from a generic intent to a sealed union result type that explicitly indicates whether a payment or setup intent was obtained. Code calling these methods requires updates to properly handle the distinct result types and their associated data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->