### PR TITLE
feat(web): add web support for collectBankAccount and verifyMicrodeposits

### DIFF
--- a/packages/stripe_js/lib/src/api/payment_intents/collect_bank_account_for_payment_params.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/collect_bank_account_for_payment_params.dart
@@ -1,0 +1,36 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:stripe_js/stripe_api.dart';
+
+part 'collect_bank_account_for_payment_params.freezed.dart';
+part 'collect_bank_account_for_payment_params.g.dart';
+
+@freezed
+abstract class CollectBankAccountForPaymentParams
+    with _$CollectBankAccountForPaymentParams {
+  const factory CollectBankAccountForPaymentParams({
+    /// The type of payment method to collect. Currently only
+    /// `us_bank_account` is supported.
+    @JsonKey(name: 'payment_method_type') required String paymentMethodType,
+
+    /// Payment method data to prefill, including billing details.
+    @JsonKey(name: 'payment_method_data')
+    CollectBankAccountForPaymentMethodData? paymentMethodData,
+  }) = _CollectBankAccountForPaymentParams;
+
+  factory CollectBankAccountForPaymentParams.fromJson(
+    Map<String, dynamic> json,
+  ) => _$CollectBankAccountForPaymentParamsFromJson(json);
+}
+
+@freezed
+abstract class CollectBankAccountForPaymentMethodData
+    with _$CollectBankAccountForPaymentMethodData {
+  const factory CollectBankAccountForPaymentMethodData({
+    /// Billing details for the payment method.
+    @JsonKey(name: 'billing_details') BillingDetails? billingDetails,
+  }) = _CollectBankAccountForPaymentMethodData;
+
+  factory CollectBankAccountForPaymentMethodData.fromJson(
+    Map<String, dynamic> json,
+  ) => _$CollectBankAccountForPaymentMethodDataFromJson(json);
+}

--- a/packages/stripe_js/lib/src/api/payment_intents/collect_bank_account_for_payment_params.freezed.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/collect_bank_account_for_payment_params.freezed.dart
@@ -1,0 +1,599 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'collect_bank_account_for_payment_params.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$CollectBankAccountForPaymentParams {
+
+/// The type of payment method to collect. Currently only
+/// `us_bank_account` is supported.
+@JsonKey(name: 'payment_method_type') String get paymentMethodType;/// Payment method data to prefill, including billing details.
+@JsonKey(name: 'payment_method_data') CollectBankAccountForPaymentMethodData? get paymentMethodData;
+/// Create a copy of CollectBankAccountForPaymentParams
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CollectBankAccountForPaymentParamsCopyWith<CollectBankAccountForPaymentParams> get copyWith => _$CollectBankAccountForPaymentParamsCopyWithImpl<CollectBankAccountForPaymentParams>(this as CollectBankAccountForPaymentParams, _$identity);
+
+  /// Serializes this CollectBankAccountForPaymentParams to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CollectBankAccountForPaymentParams&&(identical(other.paymentMethodType, paymentMethodType) || other.paymentMethodType == paymentMethodType)&&(identical(other.paymentMethodData, paymentMethodData) || other.paymentMethodData == paymentMethodData));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,paymentMethodType,paymentMethodData);
+
+@override
+String toString() {
+  return 'CollectBankAccountForPaymentParams(paymentMethodType: $paymentMethodType, paymentMethodData: $paymentMethodData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CollectBankAccountForPaymentParamsCopyWith<$Res>  {
+  factory $CollectBankAccountForPaymentParamsCopyWith(CollectBankAccountForPaymentParams value, $Res Function(CollectBankAccountForPaymentParams) _then) = _$CollectBankAccountForPaymentParamsCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'payment_method_type') String paymentMethodType,@JsonKey(name: 'payment_method_data') CollectBankAccountForPaymentMethodData? paymentMethodData
+});
+
+
+$CollectBankAccountForPaymentMethodDataCopyWith<$Res>? get paymentMethodData;
+
+}
+/// @nodoc
+class _$CollectBankAccountForPaymentParamsCopyWithImpl<$Res>
+    implements $CollectBankAccountForPaymentParamsCopyWith<$Res> {
+  _$CollectBankAccountForPaymentParamsCopyWithImpl(this._self, this._then);
+
+  final CollectBankAccountForPaymentParams _self;
+  final $Res Function(CollectBankAccountForPaymentParams) _then;
+
+/// Create a copy of CollectBankAccountForPaymentParams
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? paymentMethodType = null,Object? paymentMethodData = freezed,}) {
+  return _then(_self.copyWith(
+paymentMethodType: null == paymentMethodType ? _self.paymentMethodType : paymentMethodType // ignore: cast_nullable_to_non_nullable
+as String,paymentMethodData: freezed == paymentMethodData ? _self.paymentMethodData : paymentMethodData // ignore: cast_nullable_to_non_nullable
+as CollectBankAccountForPaymentMethodData?,
+  ));
+}
+/// Create a copy of CollectBankAccountForPaymentParams
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CollectBankAccountForPaymentMethodDataCopyWith<$Res>? get paymentMethodData {
+    if (_self.paymentMethodData == null) {
+    return null;
+  }
+
+  return $CollectBankAccountForPaymentMethodDataCopyWith<$Res>(_self.paymentMethodData!, (value) {
+    return _then(_self.copyWith(paymentMethodData: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [CollectBankAccountForPaymentParams].
+extension CollectBankAccountForPaymentParamsPatterns on CollectBankAccountForPaymentParams {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _CollectBankAccountForPaymentParams value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentParams() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _CollectBankAccountForPaymentParams value)  $default,){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentParams():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _CollectBankAccountForPaymentParams value)?  $default,){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentParams() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'payment_method_type')  String paymentMethodType, @JsonKey(name: 'payment_method_data')  CollectBankAccountForPaymentMethodData? paymentMethodData)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentParams() when $default != null:
+return $default(_that.paymentMethodType,_that.paymentMethodData);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'payment_method_type')  String paymentMethodType, @JsonKey(name: 'payment_method_data')  CollectBankAccountForPaymentMethodData? paymentMethodData)  $default,) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentParams():
+return $default(_that.paymentMethodType,_that.paymentMethodData);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'payment_method_type')  String paymentMethodType, @JsonKey(name: 'payment_method_data')  CollectBankAccountForPaymentMethodData? paymentMethodData)?  $default,) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentParams() when $default != null:
+return $default(_that.paymentMethodType,_that.paymentMethodData);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _CollectBankAccountForPaymentParams implements CollectBankAccountForPaymentParams {
+  const _CollectBankAccountForPaymentParams({@JsonKey(name: 'payment_method_type') required this.paymentMethodType, @JsonKey(name: 'payment_method_data') this.paymentMethodData});
+  factory _CollectBankAccountForPaymentParams.fromJson(Map<String, dynamic> json) => _$CollectBankAccountForPaymentParamsFromJson(json);
+
+/// The type of payment method to collect. Currently only
+/// `us_bank_account` is supported.
+@override@JsonKey(name: 'payment_method_type') final  String paymentMethodType;
+/// Payment method data to prefill, including billing details.
+@override@JsonKey(name: 'payment_method_data') final  CollectBankAccountForPaymentMethodData? paymentMethodData;
+
+/// Create a copy of CollectBankAccountForPaymentParams
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CollectBankAccountForPaymentParamsCopyWith<_CollectBankAccountForPaymentParams> get copyWith => __$CollectBankAccountForPaymentParamsCopyWithImpl<_CollectBankAccountForPaymentParams>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CollectBankAccountForPaymentParamsToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CollectBankAccountForPaymentParams&&(identical(other.paymentMethodType, paymentMethodType) || other.paymentMethodType == paymentMethodType)&&(identical(other.paymentMethodData, paymentMethodData) || other.paymentMethodData == paymentMethodData));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,paymentMethodType,paymentMethodData);
+
+@override
+String toString() {
+  return 'CollectBankAccountForPaymentParams(paymentMethodType: $paymentMethodType, paymentMethodData: $paymentMethodData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CollectBankAccountForPaymentParamsCopyWith<$Res> implements $CollectBankAccountForPaymentParamsCopyWith<$Res> {
+  factory _$CollectBankAccountForPaymentParamsCopyWith(_CollectBankAccountForPaymentParams value, $Res Function(_CollectBankAccountForPaymentParams) _then) = __$CollectBankAccountForPaymentParamsCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'payment_method_type') String paymentMethodType,@JsonKey(name: 'payment_method_data') CollectBankAccountForPaymentMethodData? paymentMethodData
+});
+
+
+@override $CollectBankAccountForPaymentMethodDataCopyWith<$Res>? get paymentMethodData;
+
+}
+/// @nodoc
+class __$CollectBankAccountForPaymentParamsCopyWithImpl<$Res>
+    implements _$CollectBankAccountForPaymentParamsCopyWith<$Res> {
+  __$CollectBankAccountForPaymentParamsCopyWithImpl(this._self, this._then);
+
+  final _CollectBankAccountForPaymentParams _self;
+  final $Res Function(_CollectBankAccountForPaymentParams) _then;
+
+/// Create a copy of CollectBankAccountForPaymentParams
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? paymentMethodType = null,Object? paymentMethodData = freezed,}) {
+  return _then(_CollectBankAccountForPaymentParams(
+paymentMethodType: null == paymentMethodType ? _self.paymentMethodType : paymentMethodType // ignore: cast_nullable_to_non_nullable
+as String,paymentMethodData: freezed == paymentMethodData ? _self.paymentMethodData : paymentMethodData // ignore: cast_nullable_to_non_nullable
+as CollectBankAccountForPaymentMethodData?,
+  ));
+}
+
+/// Create a copy of CollectBankAccountForPaymentParams
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CollectBankAccountForPaymentMethodDataCopyWith<$Res>? get paymentMethodData {
+    if (_self.paymentMethodData == null) {
+    return null;
+  }
+
+  return $CollectBankAccountForPaymentMethodDataCopyWith<$Res>(_self.paymentMethodData!, (value) {
+    return _then(_self.copyWith(paymentMethodData: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$CollectBankAccountForPaymentMethodData {
+
+/// Billing details for the payment method.
+@JsonKey(name: 'billing_details') BillingDetails? get billingDetails;
+/// Create a copy of CollectBankAccountForPaymentMethodData
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CollectBankAccountForPaymentMethodDataCopyWith<CollectBankAccountForPaymentMethodData> get copyWith => _$CollectBankAccountForPaymentMethodDataCopyWithImpl<CollectBankAccountForPaymentMethodData>(this as CollectBankAccountForPaymentMethodData, _$identity);
+
+  /// Serializes this CollectBankAccountForPaymentMethodData to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CollectBankAccountForPaymentMethodData&&(identical(other.billingDetails, billingDetails) || other.billingDetails == billingDetails));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,billingDetails);
+
+@override
+String toString() {
+  return 'CollectBankAccountForPaymentMethodData(billingDetails: $billingDetails)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CollectBankAccountForPaymentMethodDataCopyWith<$Res>  {
+  factory $CollectBankAccountForPaymentMethodDataCopyWith(CollectBankAccountForPaymentMethodData value, $Res Function(CollectBankAccountForPaymentMethodData) _then) = _$CollectBankAccountForPaymentMethodDataCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'billing_details') BillingDetails? billingDetails
+});
+
+
+$BillingDetailsCopyWith<$Res>? get billingDetails;
+
+}
+/// @nodoc
+class _$CollectBankAccountForPaymentMethodDataCopyWithImpl<$Res>
+    implements $CollectBankAccountForPaymentMethodDataCopyWith<$Res> {
+  _$CollectBankAccountForPaymentMethodDataCopyWithImpl(this._self, this._then);
+
+  final CollectBankAccountForPaymentMethodData _self;
+  final $Res Function(CollectBankAccountForPaymentMethodData) _then;
+
+/// Create a copy of CollectBankAccountForPaymentMethodData
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? billingDetails = freezed,}) {
+  return _then(_self.copyWith(
+billingDetails: freezed == billingDetails ? _self.billingDetails : billingDetails // ignore: cast_nullable_to_non_nullable
+as BillingDetails?,
+  ));
+}
+/// Create a copy of CollectBankAccountForPaymentMethodData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BillingDetailsCopyWith<$Res>? get billingDetails {
+    if (_self.billingDetails == null) {
+    return null;
+  }
+
+  return $BillingDetailsCopyWith<$Res>(_self.billingDetails!, (value) {
+    return _then(_self.copyWith(billingDetails: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [CollectBankAccountForPaymentMethodData].
+extension CollectBankAccountForPaymentMethodDataPatterns on CollectBankAccountForPaymentMethodData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _CollectBankAccountForPaymentMethodData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentMethodData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _CollectBankAccountForPaymentMethodData value)  $default,){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentMethodData():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _CollectBankAccountForPaymentMethodData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentMethodData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'billing_details')  BillingDetails? billingDetails)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentMethodData() when $default != null:
+return $default(_that.billingDetails);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'billing_details')  BillingDetails? billingDetails)  $default,) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentMethodData():
+return $default(_that.billingDetails);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'billing_details')  BillingDetails? billingDetails)?  $default,) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForPaymentMethodData() when $default != null:
+return $default(_that.billingDetails);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _CollectBankAccountForPaymentMethodData implements CollectBankAccountForPaymentMethodData {
+  const _CollectBankAccountForPaymentMethodData({@JsonKey(name: 'billing_details') this.billingDetails});
+  factory _CollectBankAccountForPaymentMethodData.fromJson(Map<String, dynamic> json) => _$CollectBankAccountForPaymentMethodDataFromJson(json);
+
+/// Billing details for the payment method.
+@override@JsonKey(name: 'billing_details') final  BillingDetails? billingDetails;
+
+/// Create a copy of CollectBankAccountForPaymentMethodData
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CollectBankAccountForPaymentMethodDataCopyWith<_CollectBankAccountForPaymentMethodData> get copyWith => __$CollectBankAccountForPaymentMethodDataCopyWithImpl<_CollectBankAccountForPaymentMethodData>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CollectBankAccountForPaymentMethodDataToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CollectBankAccountForPaymentMethodData&&(identical(other.billingDetails, billingDetails) || other.billingDetails == billingDetails));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,billingDetails);
+
+@override
+String toString() {
+  return 'CollectBankAccountForPaymentMethodData(billingDetails: $billingDetails)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CollectBankAccountForPaymentMethodDataCopyWith<$Res> implements $CollectBankAccountForPaymentMethodDataCopyWith<$Res> {
+  factory _$CollectBankAccountForPaymentMethodDataCopyWith(_CollectBankAccountForPaymentMethodData value, $Res Function(_CollectBankAccountForPaymentMethodData) _then) = __$CollectBankAccountForPaymentMethodDataCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'billing_details') BillingDetails? billingDetails
+});
+
+
+@override $BillingDetailsCopyWith<$Res>? get billingDetails;
+
+}
+/// @nodoc
+class __$CollectBankAccountForPaymentMethodDataCopyWithImpl<$Res>
+    implements _$CollectBankAccountForPaymentMethodDataCopyWith<$Res> {
+  __$CollectBankAccountForPaymentMethodDataCopyWithImpl(this._self, this._then);
+
+  final _CollectBankAccountForPaymentMethodData _self;
+  final $Res Function(_CollectBankAccountForPaymentMethodData) _then;
+
+/// Create a copy of CollectBankAccountForPaymentMethodData
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? billingDetails = freezed,}) {
+  return _then(_CollectBankAccountForPaymentMethodData(
+billingDetails: freezed == billingDetails ? _self.billingDetails : billingDetails // ignore: cast_nullable_to_non_nullable
+as BillingDetails?,
+  ));
+}
+
+/// Create a copy of CollectBankAccountForPaymentMethodData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BillingDetailsCopyWith<$Res>? get billingDetails {
+    if (_self.billingDetails == null) {
+    return null;
+  }
+
+  return $BillingDetailsCopyWith<$Res>(_self.billingDetails!, (value) {
+    return _then(_self.copyWith(billingDetails: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/stripe_js/lib/src/api/payment_intents/collect_bank_account_for_payment_params.g.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/collect_bank_account_for_payment_params.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'collect_bank_account_for_payment_params.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_CollectBankAccountForPaymentParams
+_$CollectBankAccountForPaymentParamsFromJson(Map json) =>
+    _CollectBankAccountForPaymentParams(
+      paymentMethodType: json['payment_method_type'] as String,
+      paymentMethodData: json['payment_method_data'] == null
+          ? null
+          : CollectBankAccountForPaymentMethodData.fromJson(
+              Map<String, dynamic>.from(json['payment_method_data'] as Map),
+            ),
+    );
+
+Map<String, dynamic> _$CollectBankAccountForPaymentParamsToJson(
+  _CollectBankAccountForPaymentParams instance,
+) => <String, dynamic>{
+  'payment_method_type': instance.paymentMethodType,
+  'payment_method_data': ?instance.paymentMethodData?.toJson(),
+};
+
+_CollectBankAccountForPaymentMethodData
+_$CollectBankAccountForPaymentMethodDataFromJson(Map json) =>
+    _CollectBankAccountForPaymentMethodData(
+      billingDetails: json['billing_details'] == null
+          ? null
+          : BillingDetails.fromJson(
+              Map<String, dynamic>.from(json['billing_details'] as Map),
+            ),
+    );
+
+Map<String, dynamic> _$CollectBankAccountForPaymentMethodDataToJson(
+  _CollectBankAccountForPaymentMethodData instance,
+) => <String, dynamic>{'billing_details': ?instance.billingDetails?.toJson()};

--- a/packages/stripe_js/lib/src/api/payment_intents/payment_intents.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/payment_intents.dart
@@ -1,3 +1,4 @@
+export 'collect_bank_account_for_payment_params.dart';
 export 'confirm_acss_debit_payment_data.dart';
 export 'confirm_acss_debit_payment_options.dart';
 export 'confirm_alipay_payment_data.dart';
@@ -13,3 +14,4 @@ export 'confirm_sepa_debit_payment_data.dart';
 export 'payment_intent.dart';
 export 'payment_intent_response.dart';
 export 'payment_intent_status.dart';
+export 'verify_microdeposits_for_payment_data.dart';

--- a/packages/stripe_js/lib/src/api/payment_intents/verify_microdeposits_for_payment_data.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/verify_microdeposits_for_payment_data.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'verify_microdeposits_for_payment_data.freezed.dart';
+part 'verify_microdeposits_for_payment_data.g.dart';
+
+@freezed
+abstract class VerifyMicrodepositsForPaymentData
+    with _$VerifyMicrodepositsForPaymentData {
+  const factory VerifyMicrodepositsForPaymentData({
+    /// The amounts of the microdeposits that were deposited on the
+    /// customer's bank account. Must contain exactly 2 values.
+    /// Mutually exclusive with [descriptorCode].
+    List<int>? amounts,
+
+    /// The descriptor code from the microdeposit to the customer's
+    /// bank account. Mutually exclusive with [amounts].
+    @JsonKey(name: 'descriptor_code') String? descriptorCode,
+  }) = _VerifyMicrodepositsForPaymentData;
+
+  factory VerifyMicrodepositsForPaymentData.fromJson(
+    Map<String, dynamic> json,
+  ) => _$VerifyMicrodepositsForPaymentDataFromJson(json);
+}

--- a/packages/stripe_js/lib/src/api/payment_intents/verify_microdeposits_for_payment_data.freezed.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/verify_microdeposits_for_payment_data.freezed.dart
@@ -1,0 +1,301 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'verify_microdeposits_for_payment_data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$VerifyMicrodepositsForPaymentData {
+
+/// The amounts of the microdeposits that were deposited on the
+/// customer's bank account. Must contain exactly 2 values.
+/// Mutually exclusive with [descriptorCode].
+ List<int>? get amounts;/// The descriptor code from the microdeposit to the customer's
+/// bank account. Mutually exclusive with [amounts].
+@JsonKey(name: 'descriptor_code') String? get descriptorCode;
+/// Create a copy of VerifyMicrodepositsForPaymentData
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VerifyMicrodepositsForPaymentDataCopyWith<VerifyMicrodepositsForPaymentData> get copyWith => _$VerifyMicrodepositsForPaymentDataCopyWithImpl<VerifyMicrodepositsForPaymentData>(this as VerifyMicrodepositsForPaymentData, _$identity);
+
+  /// Serializes this VerifyMicrodepositsForPaymentData to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VerifyMicrodepositsForPaymentData&&const DeepCollectionEquality().equals(other.amounts, amounts)&&(identical(other.descriptorCode, descriptorCode) || other.descriptorCode == descriptorCode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(amounts),descriptorCode);
+
+@override
+String toString() {
+  return 'VerifyMicrodepositsForPaymentData(amounts: $amounts, descriptorCode: $descriptorCode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $VerifyMicrodepositsForPaymentDataCopyWith<$Res>  {
+  factory $VerifyMicrodepositsForPaymentDataCopyWith(VerifyMicrodepositsForPaymentData value, $Res Function(VerifyMicrodepositsForPaymentData) _then) = _$VerifyMicrodepositsForPaymentDataCopyWithImpl;
+@useResult
+$Res call({
+ List<int>? amounts,@JsonKey(name: 'descriptor_code') String? descriptorCode
+});
+
+
+
+
+}
+/// @nodoc
+class _$VerifyMicrodepositsForPaymentDataCopyWithImpl<$Res>
+    implements $VerifyMicrodepositsForPaymentDataCopyWith<$Res> {
+  _$VerifyMicrodepositsForPaymentDataCopyWithImpl(this._self, this._then);
+
+  final VerifyMicrodepositsForPaymentData _self;
+  final $Res Function(VerifyMicrodepositsForPaymentData) _then;
+
+/// Create a copy of VerifyMicrodepositsForPaymentData
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? amounts = freezed,Object? descriptorCode = freezed,}) {
+  return _then(_self.copyWith(
+amounts: freezed == amounts ? _self.amounts : amounts // ignore: cast_nullable_to_non_nullable
+as List<int>?,descriptorCode: freezed == descriptorCode ? _self.descriptorCode : descriptorCode // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [VerifyMicrodepositsForPaymentData].
+extension VerifyMicrodepositsForPaymentDataPatterns on VerifyMicrodepositsForPaymentData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _VerifyMicrodepositsForPaymentData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForPaymentData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _VerifyMicrodepositsForPaymentData value)  $default,){
+final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForPaymentData():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _VerifyMicrodepositsForPaymentData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForPaymentData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<int>? amounts, @JsonKey(name: 'descriptor_code')  String? descriptorCode)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForPaymentData() when $default != null:
+return $default(_that.amounts,_that.descriptorCode);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<int>? amounts, @JsonKey(name: 'descriptor_code')  String? descriptorCode)  $default,) {final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForPaymentData():
+return $default(_that.amounts,_that.descriptorCode);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<int>? amounts, @JsonKey(name: 'descriptor_code')  String? descriptorCode)?  $default,) {final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForPaymentData() when $default != null:
+return $default(_that.amounts,_that.descriptorCode);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _VerifyMicrodepositsForPaymentData implements VerifyMicrodepositsForPaymentData {
+  const _VerifyMicrodepositsForPaymentData({final  List<int>? amounts, @JsonKey(name: 'descriptor_code') this.descriptorCode}): _amounts = amounts;
+  factory _VerifyMicrodepositsForPaymentData.fromJson(Map<String, dynamic> json) => _$VerifyMicrodepositsForPaymentDataFromJson(json);
+
+/// The amounts of the microdeposits that were deposited on the
+/// customer's bank account. Must contain exactly 2 values.
+/// Mutually exclusive with [descriptorCode].
+ final  List<int>? _amounts;
+/// The amounts of the microdeposits that were deposited on the
+/// customer's bank account. Must contain exactly 2 values.
+/// Mutually exclusive with [descriptorCode].
+@override List<int>? get amounts {
+  final value = _amounts;
+  if (value == null) return null;
+  if (_amounts is EqualUnmodifiableListView) return _amounts;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+/// The descriptor code from the microdeposit to the customer's
+/// bank account. Mutually exclusive with [amounts].
+@override@JsonKey(name: 'descriptor_code') final  String? descriptorCode;
+
+/// Create a copy of VerifyMicrodepositsForPaymentData
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VerifyMicrodepositsForPaymentDataCopyWith<_VerifyMicrodepositsForPaymentData> get copyWith => __$VerifyMicrodepositsForPaymentDataCopyWithImpl<_VerifyMicrodepositsForPaymentData>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$VerifyMicrodepositsForPaymentDataToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VerifyMicrodepositsForPaymentData&&const DeepCollectionEquality().equals(other._amounts, _amounts)&&(identical(other.descriptorCode, descriptorCode) || other.descriptorCode == descriptorCode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_amounts),descriptorCode);
+
+@override
+String toString() {
+  return 'VerifyMicrodepositsForPaymentData(amounts: $amounts, descriptorCode: $descriptorCode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$VerifyMicrodepositsForPaymentDataCopyWith<$Res> implements $VerifyMicrodepositsForPaymentDataCopyWith<$Res> {
+  factory _$VerifyMicrodepositsForPaymentDataCopyWith(_VerifyMicrodepositsForPaymentData value, $Res Function(_VerifyMicrodepositsForPaymentData) _then) = __$VerifyMicrodepositsForPaymentDataCopyWithImpl;
+@override @useResult
+$Res call({
+ List<int>? amounts,@JsonKey(name: 'descriptor_code') String? descriptorCode
+});
+
+
+
+
+}
+/// @nodoc
+class __$VerifyMicrodepositsForPaymentDataCopyWithImpl<$Res>
+    implements _$VerifyMicrodepositsForPaymentDataCopyWith<$Res> {
+  __$VerifyMicrodepositsForPaymentDataCopyWithImpl(this._self, this._then);
+
+  final _VerifyMicrodepositsForPaymentData _self;
+  final $Res Function(_VerifyMicrodepositsForPaymentData) _then;
+
+/// Create a copy of VerifyMicrodepositsForPaymentData
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? amounts = freezed,Object? descriptorCode = freezed,}) {
+  return _then(_VerifyMicrodepositsForPaymentData(
+amounts: freezed == amounts ? _self._amounts : amounts // ignore: cast_nullable_to_non_nullable
+as List<int>?,descriptorCode: freezed == descriptorCode ? _self.descriptorCode : descriptorCode // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/stripe_js/lib/src/api/payment_intents/verify_microdeposits_for_payment_data.g.dart
+++ b/packages/stripe_js/lib/src/api/payment_intents/verify_microdeposits_for_payment_data.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'verify_microdeposits_for_payment_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_VerifyMicrodepositsForPaymentData _$VerifyMicrodepositsForPaymentDataFromJson(
+  Map json,
+) => _VerifyMicrodepositsForPaymentData(
+  amounts: (json['amounts'] as List<dynamic>?)
+      ?.map((e) => (e as num).toInt())
+      .toList(),
+  descriptorCode: json['descriptor_code'] as String?,
+);
+
+Map<String, dynamic> _$VerifyMicrodepositsForPaymentDataToJson(
+  _VerifyMicrodepositsForPaymentData instance,
+) => <String, dynamic>{
+  'amounts': ?instance.amounts,
+  'descriptor_code': ?instance.descriptorCode,
+};

--- a/packages/stripe_js/lib/src/api/setup_intents/collect_bank_account_for_setup_params.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/collect_bank_account_for_setup_params.dart
@@ -1,0 +1,36 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:stripe_js/stripe_api.dart';
+
+part 'collect_bank_account_for_setup_params.freezed.dart';
+part 'collect_bank_account_for_setup_params.g.dart';
+
+@freezed
+abstract class CollectBankAccountForSetupParams
+    with _$CollectBankAccountForSetupParams {
+  const factory CollectBankAccountForSetupParams({
+    /// The type of payment method to collect. Currently only
+    /// `us_bank_account` is supported.
+    @JsonKey(name: 'payment_method_type') required String paymentMethodType,
+
+    /// Payment method data to prefill, including billing details.
+    @JsonKey(name: 'payment_method_data')
+    CollectBankAccountForSetupMethodData? paymentMethodData,
+  }) = _CollectBankAccountForSetupParams;
+
+  factory CollectBankAccountForSetupParams.fromJson(
+    Map<String, dynamic> json,
+  ) => _$CollectBankAccountForSetupParamsFromJson(json);
+}
+
+@freezed
+abstract class CollectBankAccountForSetupMethodData
+    with _$CollectBankAccountForSetupMethodData {
+  const factory CollectBankAccountForSetupMethodData({
+    /// Billing details for the payment method.
+    @JsonKey(name: 'billing_details') BillingDetails? billingDetails,
+  }) = _CollectBankAccountForSetupMethodData;
+
+  factory CollectBankAccountForSetupMethodData.fromJson(
+    Map<String, dynamic> json,
+  ) => _$CollectBankAccountForSetupMethodDataFromJson(json);
+}

--- a/packages/stripe_js/lib/src/api/setup_intents/collect_bank_account_for_setup_params.freezed.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/collect_bank_account_for_setup_params.freezed.dart
@@ -1,0 +1,599 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'collect_bank_account_for_setup_params.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$CollectBankAccountForSetupParams {
+
+/// The type of payment method to collect. Currently only
+/// `us_bank_account` is supported.
+@JsonKey(name: 'payment_method_type') String get paymentMethodType;/// Payment method data to prefill, including billing details.
+@JsonKey(name: 'payment_method_data') CollectBankAccountForSetupMethodData? get paymentMethodData;
+/// Create a copy of CollectBankAccountForSetupParams
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CollectBankAccountForSetupParamsCopyWith<CollectBankAccountForSetupParams> get copyWith => _$CollectBankAccountForSetupParamsCopyWithImpl<CollectBankAccountForSetupParams>(this as CollectBankAccountForSetupParams, _$identity);
+
+  /// Serializes this CollectBankAccountForSetupParams to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CollectBankAccountForSetupParams&&(identical(other.paymentMethodType, paymentMethodType) || other.paymentMethodType == paymentMethodType)&&(identical(other.paymentMethodData, paymentMethodData) || other.paymentMethodData == paymentMethodData));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,paymentMethodType,paymentMethodData);
+
+@override
+String toString() {
+  return 'CollectBankAccountForSetupParams(paymentMethodType: $paymentMethodType, paymentMethodData: $paymentMethodData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CollectBankAccountForSetupParamsCopyWith<$Res>  {
+  factory $CollectBankAccountForSetupParamsCopyWith(CollectBankAccountForSetupParams value, $Res Function(CollectBankAccountForSetupParams) _then) = _$CollectBankAccountForSetupParamsCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'payment_method_type') String paymentMethodType,@JsonKey(name: 'payment_method_data') CollectBankAccountForSetupMethodData? paymentMethodData
+});
+
+
+$CollectBankAccountForSetupMethodDataCopyWith<$Res>? get paymentMethodData;
+
+}
+/// @nodoc
+class _$CollectBankAccountForSetupParamsCopyWithImpl<$Res>
+    implements $CollectBankAccountForSetupParamsCopyWith<$Res> {
+  _$CollectBankAccountForSetupParamsCopyWithImpl(this._self, this._then);
+
+  final CollectBankAccountForSetupParams _self;
+  final $Res Function(CollectBankAccountForSetupParams) _then;
+
+/// Create a copy of CollectBankAccountForSetupParams
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? paymentMethodType = null,Object? paymentMethodData = freezed,}) {
+  return _then(_self.copyWith(
+paymentMethodType: null == paymentMethodType ? _self.paymentMethodType : paymentMethodType // ignore: cast_nullable_to_non_nullable
+as String,paymentMethodData: freezed == paymentMethodData ? _self.paymentMethodData : paymentMethodData // ignore: cast_nullable_to_non_nullable
+as CollectBankAccountForSetupMethodData?,
+  ));
+}
+/// Create a copy of CollectBankAccountForSetupParams
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CollectBankAccountForSetupMethodDataCopyWith<$Res>? get paymentMethodData {
+    if (_self.paymentMethodData == null) {
+    return null;
+  }
+
+  return $CollectBankAccountForSetupMethodDataCopyWith<$Res>(_self.paymentMethodData!, (value) {
+    return _then(_self.copyWith(paymentMethodData: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [CollectBankAccountForSetupParams].
+extension CollectBankAccountForSetupParamsPatterns on CollectBankAccountForSetupParams {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _CollectBankAccountForSetupParams value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupParams() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _CollectBankAccountForSetupParams value)  $default,){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupParams():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _CollectBankAccountForSetupParams value)?  $default,){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupParams() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'payment_method_type')  String paymentMethodType, @JsonKey(name: 'payment_method_data')  CollectBankAccountForSetupMethodData? paymentMethodData)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupParams() when $default != null:
+return $default(_that.paymentMethodType,_that.paymentMethodData);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'payment_method_type')  String paymentMethodType, @JsonKey(name: 'payment_method_data')  CollectBankAccountForSetupMethodData? paymentMethodData)  $default,) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupParams():
+return $default(_that.paymentMethodType,_that.paymentMethodData);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'payment_method_type')  String paymentMethodType, @JsonKey(name: 'payment_method_data')  CollectBankAccountForSetupMethodData? paymentMethodData)?  $default,) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupParams() when $default != null:
+return $default(_that.paymentMethodType,_that.paymentMethodData);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _CollectBankAccountForSetupParams implements CollectBankAccountForSetupParams {
+  const _CollectBankAccountForSetupParams({@JsonKey(name: 'payment_method_type') required this.paymentMethodType, @JsonKey(name: 'payment_method_data') this.paymentMethodData});
+  factory _CollectBankAccountForSetupParams.fromJson(Map<String, dynamic> json) => _$CollectBankAccountForSetupParamsFromJson(json);
+
+/// The type of payment method to collect. Currently only
+/// `us_bank_account` is supported.
+@override@JsonKey(name: 'payment_method_type') final  String paymentMethodType;
+/// Payment method data to prefill, including billing details.
+@override@JsonKey(name: 'payment_method_data') final  CollectBankAccountForSetupMethodData? paymentMethodData;
+
+/// Create a copy of CollectBankAccountForSetupParams
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CollectBankAccountForSetupParamsCopyWith<_CollectBankAccountForSetupParams> get copyWith => __$CollectBankAccountForSetupParamsCopyWithImpl<_CollectBankAccountForSetupParams>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CollectBankAccountForSetupParamsToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CollectBankAccountForSetupParams&&(identical(other.paymentMethodType, paymentMethodType) || other.paymentMethodType == paymentMethodType)&&(identical(other.paymentMethodData, paymentMethodData) || other.paymentMethodData == paymentMethodData));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,paymentMethodType,paymentMethodData);
+
+@override
+String toString() {
+  return 'CollectBankAccountForSetupParams(paymentMethodType: $paymentMethodType, paymentMethodData: $paymentMethodData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CollectBankAccountForSetupParamsCopyWith<$Res> implements $CollectBankAccountForSetupParamsCopyWith<$Res> {
+  factory _$CollectBankAccountForSetupParamsCopyWith(_CollectBankAccountForSetupParams value, $Res Function(_CollectBankAccountForSetupParams) _then) = __$CollectBankAccountForSetupParamsCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'payment_method_type') String paymentMethodType,@JsonKey(name: 'payment_method_data') CollectBankAccountForSetupMethodData? paymentMethodData
+});
+
+
+@override $CollectBankAccountForSetupMethodDataCopyWith<$Res>? get paymentMethodData;
+
+}
+/// @nodoc
+class __$CollectBankAccountForSetupParamsCopyWithImpl<$Res>
+    implements _$CollectBankAccountForSetupParamsCopyWith<$Res> {
+  __$CollectBankAccountForSetupParamsCopyWithImpl(this._self, this._then);
+
+  final _CollectBankAccountForSetupParams _self;
+  final $Res Function(_CollectBankAccountForSetupParams) _then;
+
+/// Create a copy of CollectBankAccountForSetupParams
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? paymentMethodType = null,Object? paymentMethodData = freezed,}) {
+  return _then(_CollectBankAccountForSetupParams(
+paymentMethodType: null == paymentMethodType ? _self.paymentMethodType : paymentMethodType // ignore: cast_nullable_to_non_nullable
+as String,paymentMethodData: freezed == paymentMethodData ? _self.paymentMethodData : paymentMethodData // ignore: cast_nullable_to_non_nullable
+as CollectBankAccountForSetupMethodData?,
+  ));
+}
+
+/// Create a copy of CollectBankAccountForSetupParams
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CollectBankAccountForSetupMethodDataCopyWith<$Res>? get paymentMethodData {
+    if (_self.paymentMethodData == null) {
+    return null;
+  }
+
+  return $CollectBankAccountForSetupMethodDataCopyWith<$Res>(_self.paymentMethodData!, (value) {
+    return _then(_self.copyWith(paymentMethodData: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$CollectBankAccountForSetupMethodData {
+
+/// Billing details for the payment method.
+@JsonKey(name: 'billing_details') BillingDetails? get billingDetails;
+/// Create a copy of CollectBankAccountForSetupMethodData
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CollectBankAccountForSetupMethodDataCopyWith<CollectBankAccountForSetupMethodData> get copyWith => _$CollectBankAccountForSetupMethodDataCopyWithImpl<CollectBankAccountForSetupMethodData>(this as CollectBankAccountForSetupMethodData, _$identity);
+
+  /// Serializes this CollectBankAccountForSetupMethodData to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CollectBankAccountForSetupMethodData&&(identical(other.billingDetails, billingDetails) || other.billingDetails == billingDetails));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,billingDetails);
+
+@override
+String toString() {
+  return 'CollectBankAccountForSetupMethodData(billingDetails: $billingDetails)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CollectBankAccountForSetupMethodDataCopyWith<$Res>  {
+  factory $CollectBankAccountForSetupMethodDataCopyWith(CollectBankAccountForSetupMethodData value, $Res Function(CollectBankAccountForSetupMethodData) _then) = _$CollectBankAccountForSetupMethodDataCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'billing_details') BillingDetails? billingDetails
+});
+
+
+$BillingDetailsCopyWith<$Res>? get billingDetails;
+
+}
+/// @nodoc
+class _$CollectBankAccountForSetupMethodDataCopyWithImpl<$Res>
+    implements $CollectBankAccountForSetupMethodDataCopyWith<$Res> {
+  _$CollectBankAccountForSetupMethodDataCopyWithImpl(this._self, this._then);
+
+  final CollectBankAccountForSetupMethodData _self;
+  final $Res Function(CollectBankAccountForSetupMethodData) _then;
+
+/// Create a copy of CollectBankAccountForSetupMethodData
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? billingDetails = freezed,}) {
+  return _then(_self.copyWith(
+billingDetails: freezed == billingDetails ? _self.billingDetails : billingDetails // ignore: cast_nullable_to_non_nullable
+as BillingDetails?,
+  ));
+}
+/// Create a copy of CollectBankAccountForSetupMethodData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BillingDetailsCopyWith<$Res>? get billingDetails {
+    if (_self.billingDetails == null) {
+    return null;
+  }
+
+  return $BillingDetailsCopyWith<$Res>(_self.billingDetails!, (value) {
+    return _then(_self.copyWith(billingDetails: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [CollectBankAccountForSetupMethodData].
+extension CollectBankAccountForSetupMethodDataPatterns on CollectBankAccountForSetupMethodData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _CollectBankAccountForSetupMethodData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupMethodData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _CollectBankAccountForSetupMethodData value)  $default,){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupMethodData():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _CollectBankAccountForSetupMethodData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupMethodData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'billing_details')  BillingDetails? billingDetails)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupMethodData() when $default != null:
+return $default(_that.billingDetails);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'billing_details')  BillingDetails? billingDetails)  $default,) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupMethodData():
+return $default(_that.billingDetails);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'billing_details')  BillingDetails? billingDetails)?  $default,) {final _that = this;
+switch (_that) {
+case _CollectBankAccountForSetupMethodData() when $default != null:
+return $default(_that.billingDetails);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _CollectBankAccountForSetupMethodData implements CollectBankAccountForSetupMethodData {
+  const _CollectBankAccountForSetupMethodData({@JsonKey(name: 'billing_details') this.billingDetails});
+  factory _CollectBankAccountForSetupMethodData.fromJson(Map<String, dynamic> json) => _$CollectBankAccountForSetupMethodDataFromJson(json);
+
+/// Billing details for the payment method.
+@override@JsonKey(name: 'billing_details') final  BillingDetails? billingDetails;
+
+/// Create a copy of CollectBankAccountForSetupMethodData
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CollectBankAccountForSetupMethodDataCopyWith<_CollectBankAccountForSetupMethodData> get copyWith => __$CollectBankAccountForSetupMethodDataCopyWithImpl<_CollectBankAccountForSetupMethodData>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CollectBankAccountForSetupMethodDataToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CollectBankAccountForSetupMethodData&&(identical(other.billingDetails, billingDetails) || other.billingDetails == billingDetails));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,billingDetails);
+
+@override
+String toString() {
+  return 'CollectBankAccountForSetupMethodData(billingDetails: $billingDetails)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CollectBankAccountForSetupMethodDataCopyWith<$Res> implements $CollectBankAccountForSetupMethodDataCopyWith<$Res> {
+  factory _$CollectBankAccountForSetupMethodDataCopyWith(_CollectBankAccountForSetupMethodData value, $Res Function(_CollectBankAccountForSetupMethodData) _then) = __$CollectBankAccountForSetupMethodDataCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'billing_details') BillingDetails? billingDetails
+});
+
+
+@override $BillingDetailsCopyWith<$Res>? get billingDetails;
+
+}
+/// @nodoc
+class __$CollectBankAccountForSetupMethodDataCopyWithImpl<$Res>
+    implements _$CollectBankAccountForSetupMethodDataCopyWith<$Res> {
+  __$CollectBankAccountForSetupMethodDataCopyWithImpl(this._self, this._then);
+
+  final _CollectBankAccountForSetupMethodData _self;
+  final $Res Function(_CollectBankAccountForSetupMethodData) _then;
+
+/// Create a copy of CollectBankAccountForSetupMethodData
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? billingDetails = freezed,}) {
+  return _then(_CollectBankAccountForSetupMethodData(
+billingDetails: freezed == billingDetails ? _self.billingDetails : billingDetails // ignore: cast_nullable_to_non_nullable
+as BillingDetails?,
+  ));
+}
+
+/// Create a copy of CollectBankAccountForSetupMethodData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BillingDetailsCopyWith<$Res>? get billingDetails {
+    if (_self.billingDetails == null) {
+    return null;
+  }
+
+  return $BillingDetailsCopyWith<$Res>(_self.billingDetails!, (value) {
+    return _then(_self.copyWith(billingDetails: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/stripe_js/lib/src/api/setup_intents/collect_bank_account_for_setup_params.g.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/collect_bank_account_for_setup_params.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'collect_bank_account_for_setup_params.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_CollectBankAccountForSetupParams _$CollectBankAccountForSetupParamsFromJson(
+  Map json,
+) => _CollectBankAccountForSetupParams(
+  paymentMethodType: json['payment_method_type'] as String,
+  paymentMethodData: json['payment_method_data'] == null
+      ? null
+      : CollectBankAccountForSetupMethodData.fromJson(
+          Map<String, dynamic>.from(json['payment_method_data'] as Map),
+        ),
+);
+
+Map<String, dynamic> _$CollectBankAccountForSetupParamsToJson(
+  _CollectBankAccountForSetupParams instance,
+) => <String, dynamic>{
+  'payment_method_type': instance.paymentMethodType,
+  'payment_method_data': ?instance.paymentMethodData?.toJson(),
+};
+
+_CollectBankAccountForSetupMethodData
+_$CollectBankAccountForSetupMethodDataFromJson(Map json) =>
+    _CollectBankAccountForSetupMethodData(
+      billingDetails: json['billing_details'] == null
+          ? null
+          : BillingDetails.fromJson(
+              Map<String, dynamic>.from(json['billing_details'] as Map),
+            ),
+    );
+
+Map<String, dynamic> _$CollectBankAccountForSetupMethodDataToJson(
+  _CollectBankAccountForSetupMethodData instance,
+) => <String, dynamic>{'billing_details': ?instance.billingDetails?.toJson()};

--- a/packages/stripe_js/lib/src/api/setup_intents/setup_intents.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/setup_intents.dart
@@ -1,3 +1,4 @@
+export 'collect_bank_account_for_setup_params.dart';
 export 'confirm_card_setup_data.dart';
 export 'confirm_card_setup_options.dart';
 export 'confirm_sepa_debit_setup_data.dart';
@@ -5,3 +6,4 @@ export 'setup_intent.dart';
 export 'setup_intent_response.dart';
 export 'setup_intent_status.dart';
 export 'confirm_setup_options.dart';
+export 'verify_microdeposits_for_setup_data.dart';

--- a/packages/stripe_js/lib/src/api/setup_intents/verify_microdeposits_for_setup_data.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/verify_microdeposits_for_setup_data.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'verify_microdeposits_for_setup_data.freezed.dart';
+part 'verify_microdeposits_for_setup_data.g.dart';
+
+@freezed
+abstract class VerifyMicrodepositsForSetupData
+    with _$VerifyMicrodepositsForSetupData {
+  const factory VerifyMicrodepositsForSetupData({
+    /// The amounts of the microdeposits that were deposited on the
+    /// customer's bank account. Must contain exactly 2 values.
+    /// Mutually exclusive with [descriptorCode].
+    List<int>? amounts,
+
+    /// The descriptor code from the microdeposit to the customer's
+    /// bank account. Mutually exclusive with [amounts].
+    @JsonKey(name: 'descriptor_code') String? descriptorCode,
+  }) = _VerifyMicrodepositsForSetupData;
+
+  factory VerifyMicrodepositsForSetupData.fromJson(
+    Map<String, dynamic> json,
+  ) => _$VerifyMicrodepositsForSetupDataFromJson(json);
+}

--- a/packages/stripe_js/lib/src/api/setup_intents/verify_microdeposits_for_setup_data.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/verify_microdeposits_for_setup_data.dart
@@ -17,7 +17,6 @@ abstract class VerifyMicrodepositsForSetupData
     @JsonKey(name: 'descriptor_code') String? descriptorCode,
   }) = _VerifyMicrodepositsForSetupData;
 
-  factory VerifyMicrodepositsForSetupData.fromJson(
-    Map<String, dynamic> json,
-  ) => _$VerifyMicrodepositsForSetupDataFromJson(json);
+  factory VerifyMicrodepositsForSetupData.fromJson(Map<String, dynamic> json) =>
+      _$VerifyMicrodepositsForSetupDataFromJson(json);
 }

--- a/packages/stripe_js/lib/src/api/setup_intents/verify_microdeposits_for_setup_data.freezed.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/verify_microdeposits_for_setup_data.freezed.dart
@@ -1,0 +1,301 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'verify_microdeposits_for_setup_data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$VerifyMicrodepositsForSetupData {
+
+/// The amounts of the microdeposits that were deposited on the
+/// customer's bank account. Must contain exactly 2 values.
+/// Mutually exclusive with [descriptorCode].
+ List<int>? get amounts;/// The descriptor code from the microdeposit to the customer's
+/// bank account. Mutually exclusive with [amounts].
+@JsonKey(name: 'descriptor_code') String? get descriptorCode;
+/// Create a copy of VerifyMicrodepositsForSetupData
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VerifyMicrodepositsForSetupDataCopyWith<VerifyMicrodepositsForSetupData> get copyWith => _$VerifyMicrodepositsForSetupDataCopyWithImpl<VerifyMicrodepositsForSetupData>(this as VerifyMicrodepositsForSetupData, _$identity);
+
+  /// Serializes this VerifyMicrodepositsForSetupData to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VerifyMicrodepositsForSetupData&&const DeepCollectionEquality().equals(other.amounts, amounts)&&(identical(other.descriptorCode, descriptorCode) || other.descriptorCode == descriptorCode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(amounts),descriptorCode);
+
+@override
+String toString() {
+  return 'VerifyMicrodepositsForSetupData(amounts: $amounts, descriptorCode: $descriptorCode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $VerifyMicrodepositsForSetupDataCopyWith<$Res>  {
+  factory $VerifyMicrodepositsForSetupDataCopyWith(VerifyMicrodepositsForSetupData value, $Res Function(VerifyMicrodepositsForSetupData) _then) = _$VerifyMicrodepositsForSetupDataCopyWithImpl;
+@useResult
+$Res call({
+ List<int>? amounts,@JsonKey(name: 'descriptor_code') String? descriptorCode
+});
+
+
+
+
+}
+/// @nodoc
+class _$VerifyMicrodepositsForSetupDataCopyWithImpl<$Res>
+    implements $VerifyMicrodepositsForSetupDataCopyWith<$Res> {
+  _$VerifyMicrodepositsForSetupDataCopyWithImpl(this._self, this._then);
+
+  final VerifyMicrodepositsForSetupData _self;
+  final $Res Function(VerifyMicrodepositsForSetupData) _then;
+
+/// Create a copy of VerifyMicrodepositsForSetupData
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? amounts = freezed,Object? descriptorCode = freezed,}) {
+  return _then(_self.copyWith(
+amounts: freezed == amounts ? _self.amounts : amounts // ignore: cast_nullable_to_non_nullable
+as List<int>?,descriptorCode: freezed == descriptorCode ? _self.descriptorCode : descriptorCode // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [VerifyMicrodepositsForSetupData].
+extension VerifyMicrodepositsForSetupDataPatterns on VerifyMicrodepositsForSetupData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _VerifyMicrodepositsForSetupData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForSetupData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _VerifyMicrodepositsForSetupData value)  $default,){
+final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForSetupData():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _VerifyMicrodepositsForSetupData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForSetupData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<int>? amounts, @JsonKey(name: 'descriptor_code')  String? descriptorCode)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForSetupData() when $default != null:
+return $default(_that.amounts,_that.descriptorCode);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<int>? amounts, @JsonKey(name: 'descriptor_code')  String? descriptorCode)  $default,) {final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForSetupData():
+return $default(_that.amounts,_that.descriptorCode);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<int>? amounts, @JsonKey(name: 'descriptor_code')  String? descriptorCode)?  $default,) {final _that = this;
+switch (_that) {
+case _VerifyMicrodepositsForSetupData() when $default != null:
+return $default(_that.amounts,_that.descriptorCode);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _VerifyMicrodepositsForSetupData implements VerifyMicrodepositsForSetupData {
+  const _VerifyMicrodepositsForSetupData({final  List<int>? amounts, @JsonKey(name: 'descriptor_code') this.descriptorCode}): _amounts = amounts;
+  factory _VerifyMicrodepositsForSetupData.fromJson(Map<String, dynamic> json) => _$VerifyMicrodepositsForSetupDataFromJson(json);
+
+/// The amounts of the microdeposits that were deposited on the
+/// customer's bank account. Must contain exactly 2 values.
+/// Mutually exclusive with [descriptorCode].
+ final  List<int>? _amounts;
+/// The amounts of the microdeposits that were deposited on the
+/// customer's bank account. Must contain exactly 2 values.
+/// Mutually exclusive with [descriptorCode].
+@override List<int>? get amounts {
+  final value = _amounts;
+  if (value == null) return null;
+  if (_amounts is EqualUnmodifiableListView) return _amounts;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+/// The descriptor code from the microdeposit to the customer's
+/// bank account. Mutually exclusive with [amounts].
+@override@JsonKey(name: 'descriptor_code') final  String? descriptorCode;
+
+/// Create a copy of VerifyMicrodepositsForSetupData
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VerifyMicrodepositsForSetupDataCopyWith<_VerifyMicrodepositsForSetupData> get copyWith => __$VerifyMicrodepositsForSetupDataCopyWithImpl<_VerifyMicrodepositsForSetupData>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$VerifyMicrodepositsForSetupDataToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VerifyMicrodepositsForSetupData&&const DeepCollectionEquality().equals(other._amounts, _amounts)&&(identical(other.descriptorCode, descriptorCode) || other.descriptorCode == descriptorCode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_amounts),descriptorCode);
+
+@override
+String toString() {
+  return 'VerifyMicrodepositsForSetupData(amounts: $amounts, descriptorCode: $descriptorCode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$VerifyMicrodepositsForSetupDataCopyWith<$Res> implements $VerifyMicrodepositsForSetupDataCopyWith<$Res> {
+  factory _$VerifyMicrodepositsForSetupDataCopyWith(_VerifyMicrodepositsForSetupData value, $Res Function(_VerifyMicrodepositsForSetupData) _then) = __$VerifyMicrodepositsForSetupDataCopyWithImpl;
+@override @useResult
+$Res call({
+ List<int>? amounts,@JsonKey(name: 'descriptor_code') String? descriptorCode
+});
+
+
+
+
+}
+/// @nodoc
+class __$VerifyMicrodepositsForSetupDataCopyWithImpl<$Res>
+    implements _$VerifyMicrodepositsForSetupDataCopyWith<$Res> {
+  __$VerifyMicrodepositsForSetupDataCopyWithImpl(this._self, this._then);
+
+  final _VerifyMicrodepositsForSetupData _self;
+  final $Res Function(_VerifyMicrodepositsForSetupData) _then;
+
+/// Create a copy of VerifyMicrodepositsForSetupData
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? amounts = freezed,Object? descriptorCode = freezed,}) {
+  return _then(_VerifyMicrodepositsForSetupData(
+amounts: freezed == amounts ? _self._amounts : amounts // ignore: cast_nullable_to_non_nullable
+as List<int>?,descriptorCode: freezed == descriptorCode ? _self.descriptorCode : descriptorCode // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/stripe_js/lib/src/api/setup_intents/verify_microdeposits_for_setup_data.g.dart
+++ b/packages/stripe_js/lib/src/api/setup_intents/verify_microdeposits_for_setup_data.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'verify_microdeposits_for_setup_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_VerifyMicrodepositsForSetupData _$VerifyMicrodepositsForSetupDataFromJson(
+  Map json,
+) => _VerifyMicrodepositsForSetupData(
+  amounts: (json['amounts'] as List<dynamic>?)
+      ?.map((e) => (e as num).toInt())
+      .toList(),
+  descriptorCode: json['descriptor_code'] as String?,
+);
+
+Map<String, dynamic> _$VerifyMicrodepositsForSetupDataToJson(
+  _VerifyMicrodepositsForSetupData instance,
+) => <String, dynamic>{
+  'amounts': ?instance.amounts,
+  'descriptor_code': ?instance.descriptorCode,
+};

--- a/packages/stripe_js/lib/src/js/payment_intents/collect_bank_account_for_payment.dart
+++ b/packages/stripe_js/lib/src/js/payment_intents/collect_bank_account_for_payment.dart
@@ -1,0 +1,32 @@
+import 'package:stripe_js/src/js/utils/utils.dart';
+import 'package:stripe_js/stripe_api.dart';
+import 'package:stripe_js/stripe_js.dart';
+import 'dart:js_interop';
+
+extension ExtensionCollectBankAccountForPayment on Stripe {
+  /// Use stripe.collectBankAccountForPayment to collect bank account details
+  /// for a PaymentIntent using the Financial Connections authentication flow.
+  ///
+  /// When called, it will launch a modal UI where the customer can connect
+  /// their bank account. On success, the PaymentIntent will have an attached
+  /// PaymentMethod of type `us_bank_account`.
+  ///
+  /// https://docs.stripe.com/js/payment_intents/collect_bank_account_for_payment
+  Future<PaymentIntentResponse> collectBankAccountForPayment(
+    String clientSecret, {
+    CollectBankAccountForPaymentParams? params,
+  }) async {
+    final jsOptions = <String, dynamic>{
+      'clientSecret': clientSecret,
+      if (params != null) 'params': params.toJson(),
+    }.jsify();
+    return _collectBankAccountForPayment(jsOptions)
+        .toDart
+        .then((response) => response.toDart);
+  }
+
+  @JS('collectBankAccountForPayment')
+  external JSPromise<JSIntentResponse> _collectBankAccountForPayment(
+    JSAny? options,
+  );
+}

--- a/packages/stripe_js/lib/src/js/payment_intents/collect_bank_account_for_payment.dart
+++ b/packages/stripe_js/lib/src/js/payment_intents/collect_bank_account_for_payment.dart
@@ -20,9 +20,9 @@ extension ExtensionCollectBankAccountForPayment on Stripe {
       'clientSecret': clientSecret,
       if (params != null) 'params': params.toJson(),
     }.jsify();
-    return _collectBankAccountForPayment(jsOptions)
-        .toDart
-        .then((response) => response.toDart);
+    return _collectBankAccountForPayment(
+      jsOptions,
+    ).toDart.then((response) => response.toDart);
   }
 
   @JS('collectBankAccountForPayment')

--- a/packages/stripe_js/lib/src/js/payment_intents/payment_intents.dart
+++ b/packages/stripe_js/lib/src/js/payment_intents/payment_intents.dart
@@ -1,3 +1,4 @@
+export 'collect_bank_account_for_payment.dart';
 export 'confirm_acss_debit_payment.dart';
 export 'confirm_alipay_payment.dart';
 export 'confirm_card_payment.dart';
@@ -7,3 +8,4 @@ export 'confirm_payment.dart';
 export 'confirm_sepa_debit_payment.dart';
 export 'handle_card_action.dart';
 export 'retrieve_payment_intent.dart';
+export 'verify_microdeposits_for_payment.dart';

--- a/packages/stripe_js/lib/src/js/payment_intents/verify_microdeposits_for_payment.dart
+++ b/packages/stripe_js/lib/src/js/payment_intents/verify_microdeposits_for_payment.dart
@@ -1,0 +1,31 @@
+import 'package:stripe_js/src/js/utils/utils.dart';
+import 'package:stripe_js/stripe_api.dart';
+import 'package:stripe_js/stripe_js.dart';
+import 'dart:js_interop';
+
+extension ExtensionVerifyMicrodepositsForPayment on Stripe {
+  /// Use stripe.verifyMicrodepositsForPayment to verify microdeposits on a
+  /// PaymentIntent with an attached `us_bank_account` PaymentMethod.
+  ///
+  /// Provide either the two microdeposit [amounts] or the
+  /// [descriptorCode] from the customer's bank statement.
+  ///
+  /// https://docs.stripe.com/js/payment_intents/verify_microdeposits_for_payment
+  Future<PaymentIntentResponse> verifyMicrodepositsForPayment(
+    String clientSecret, {
+    VerifyMicrodepositsForPaymentData? data,
+  }) async {
+    final jsOptions = <String, dynamic>{
+      'clientSecret': clientSecret,
+      ...?data?.toJson(),
+    }.jsify();
+    return _verifyMicrodepositsForPayment(jsOptions)
+        .toDart
+        .then((response) => response.toDart);
+  }
+
+  @JS('verifyMicrodepositsForPayment')
+  external JSPromise<JSIntentResponse> _verifyMicrodepositsForPayment(
+    JSAny? options,
+  );
+}

--- a/packages/stripe_js/lib/src/js/payment_intents/verify_microdeposits_for_payment.dart
+++ b/packages/stripe_js/lib/src/js/payment_intents/verify_microdeposits_for_payment.dart
@@ -16,9 +16,10 @@ extension ExtensionVerifyMicrodepositsForPayment on Stripe {
     VerifyMicrodepositsForPaymentData? data,
   }) {
     final jsData = data?.toJson().jsify();
-    return _verifyMicrodepositsForPayment(clientSecret, jsData)
-        .toDart
-        .then((response) => response.toDart);
+    return _verifyMicrodepositsForPayment(
+      clientSecret,
+      jsData,
+    ).toDart.then((response) => response.toDart);
   }
 
   @JS('verifyMicrodepositsForPayment')

--- a/packages/stripe_js/lib/src/js/payment_intents/verify_microdeposits_for_payment.dart
+++ b/packages/stripe_js/lib/src/js/payment_intents/verify_microdeposits_for_payment.dart
@@ -14,18 +14,16 @@ extension ExtensionVerifyMicrodepositsForPayment on Stripe {
   Future<PaymentIntentResponse> verifyMicrodepositsForPayment(
     String clientSecret, {
     VerifyMicrodepositsForPaymentData? data,
-  }) async {
-    final jsOptions = <String, dynamic>{
-      'clientSecret': clientSecret,
-      ...?data?.toJson(),
-    }.jsify();
-    return _verifyMicrodepositsForPayment(jsOptions)
+  }) {
+    final jsData = data?.toJson().jsify();
+    return _verifyMicrodepositsForPayment(clientSecret, jsData)
         .toDart
         .then((response) => response.toDart);
   }
 
   @JS('verifyMicrodepositsForPayment')
   external JSPromise<JSIntentResponse> _verifyMicrodepositsForPayment(
-    JSAny? options,
-  );
+    String clientSecret, [
+    JSAny? data,
+  ]);
 }

--- a/packages/stripe_js/lib/src/js/setup_intents/collect_bank_account_for_setup.dart
+++ b/packages/stripe_js/lib/src/js/setup_intents/collect_bank_account_for_setup.dart
@@ -1,0 +1,32 @@
+import 'package:stripe_js/src/js/utils/utils.dart';
+import 'package:stripe_js/stripe_api.dart';
+import 'package:stripe_js/stripe_js.dart';
+import 'dart:js_interop';
+
+extension ExtensionCollectBankAccountForSetup on Stripe {
+  /// Use stripe.collectBankAccountForSetup to collect bank account details
+  /// for a SetupIntent using the Financial Connections authentication flow.
+  ///
+  /// When called, it will launch a modal UI where the customer can connect
+  /// their bank account. On success, the SetupIntent will have an attached
+  /// PaymentMethod of type `us_bank_account`.
+  ///
+  /// https://docs.stripe.com/js/setup_intents/collect_bank_account_for_setup
+  Future<SetupIntentResponse> collectBankAccountForSetup(
+    String clientSecret, {
+    CollectBankAccountForSetupParams? params,
+  }) async {
+    final jsOptions = <String, dynamic>{
+      'clientSecret': clientSecret,
+      if (params != null) 'params': params.toJson(),
+    }.jsify();
+    return _collectBankAccountForSetup(jsOptions)
+        .toDart
+        .then((response) => response.toDart);
+  }
+
+  @JS('collectBankAccountForSetup')
+  external JSPromise<JSSetupIntentResponse> _collectBankAccountForSetup(
+    JSAny? options,
+  );
+}

--- a/packages/stripe_js/lib/src/js/setup_intents/collect_bank_account_for_setup.dart
+++ b/packages/stripe_js/lib/src/js/setup_intents/collect_bank_account_for_setup.dart
@@ -20,9 +20,9 @@ extension ExtensionCollectBankAccountForSetup on Stripe {
       'clientSecret': clientSecret,
       if (params != null) 'params': params.toJson(),
     }.jsify();
-    return _collectBankAccountForSetup(jsOptions)
-        .toDart
-        .then((response) => response.toDart);
+    return _collectBankAccountForSetup(
+      jsOptions,
+    ).toDart.then((response) => response.toDart);
   }
 
   @JS('collectBankAccountForSetup')

--- a/packages/stripe_js/lib/src/js/setup_intents/setup_intents.dart
+++ b/packages/stripe_js/lib/src/js/setup_intents/setup_intents.dart
@@ -1,4 +1,6 @@
+export 'collect_bank_account_for_setup.dart';
 export 'confirm_card_setup.dart';
 export 'confirm_sepa_debit_setup.dart';
 export 'retrieve_setup_intent.dart';
 export 'confirm_setup.dart';
+export 'verify_microdeposits_for_setup.dart';

--- a/packages/stripe_js/lib/src/js/setup_intents/verify_microdeposits_for_setup.dart
+++ b/packages/stripe_js/lib/src/js/setup_intents/verify_microdeposits_for_setup.dart
@@ -1,0 +1,31 @@
+import 'package:stripe_js/src/js/utils/utils.dart';
+import 'package:stripe_js/stripe_api.dart';
+import 'package:stripe_js/stripe_js.dart';
+import 'dart:js_interop';
+
+extension ExtensionVerifyMicrodepositsForSetup on Stripe {
+  /// Use stripe.verifyMicrodepositsForSetup to verify microdeposits on a
+  /// SetupIntent with an attached `us_bank_account` PaymentMethod.
+  ///
+  /// Provide either the two microdeposit [amounts] or the
+  /// [descriptorCode] from the customer's bank statement.
+  ///
+  /// https://docs.stripe.com/js/setup_intents/verify_microdeposits_for_setup
+  Future<SetupIntentResponse> verifyMicrodepositsForSetup(
+    String clientSecret, {
+    VerifyMicrodepositsForSetupData? data,
+  }) async {
+    final jsOptions = <String, dynamic>{
+      'clientSecret': clientSecret,
+      ...?data?.toJson(),
+    }.jsify();
+    return _verifyMicrodepositsForSetup(jsOptions)
+        .toDart
+        .then((response) => response.toDart);
+  }
+
+  @JS('verifyMicrodepositsForSetup')
+  external JSPromise<JSSetupIntentResponse> _verifyMicrodepositsForSetup(
+    JSAny? options,
+  );
+}

--- a/packages/stripe_js/lib/src/js/setup_intents/verify_microdeposits_for_setup.dart
+++ b/packages/stripe_js/lib/src/js/setup_intents/verify_microdeposits_for_setup.dart
@@ -14,18 +14,16 @@ extension ExtensionVerifyMicrodepositsForSetup on Stripe {
   Future<SetupIntentResponse> verifyMicrodepositsForSetup(
     String clientSecret, {
     VerifyMicrodepositsForSetupData? data,
-  }) async {
-    final jsOptions = <String, dynamic>{
-      'clientSecret': clientSecret,
-      ...?data?.toJson(),
-    }.jsify();
-    return _verifyMicrodepositsForSetup(jsOptions)
+  }) {
+    final jsData = data?.toJson().jsify();
+    return _verifyMicrodepositsForSetup(clientSecret, jsData)
         .toDart
         .then((response) => response.toDart);
   }
 
   @JS('verifyMicrodepositsForSetup')
   external JSPromise<JSSetupIntentResponse> _verifyMicrodepositsForSetup(
-    JSAny? options,
-  );
+    String clientSecret, [
+    JSAny? data,
+  ]);
 }

--- a/packages/stripe_js/lib/src/js/setup_intents/verify_microdeposits_for_setup.dart
+++ b/packages/stripe_js/lib/src/js/setup_intents/verify_microdeposits_for_setup.dart
@@ -16,9 +16,10 @@ extension ExtensionVerifyMicrodepositsForSetup on Stripe {
     VerifyMicrodepositsForSetupData? data,
   }) {
     final jsData = data?.toJson().jsify();
-    return _verifyMicrodepositsForSetup(clientSecret, jsData)
-        .toDart
-        .then((response) => response.toDart);
+    return _verifyMicrodepositsForSetup(
+      clientSecret,
+      jsData,
+    ).toDart.then((response) => response.toDart);
   }
 
   @JS('verifyMicrodepositsForSetup')

--- a/packages/stripe_web/lib/src/web_stripe.dart
+++ b/packages/stripe_web/lib/src/web_stripe.dart
@@ -509,19 +509,95 @@ class WebStripe extends StripePlatform {
   }
 
   @override
-  Future<CollectBankAccountResult> collectBankAccount(
-      {required bool isPaymentIntent,
-      required String clientSecret,
-      required CollectBankAccountParams params}) {
-    throw UnimplementedError();
+  Future<CollectBankAccountResult> collectBankAccount({
+    required bool isPaymentIntent,
+    required String clientSecret,
+    required CollectBankAccountParams params,
+  }) async {
+    final billingDetails = params.paymentMethodData.billingDetails.toJs();
+
+    if (isPaymentIntent) {
+      final response = await js.collectBankAccountForPayment(
+        clientSecret,
+        params: stripe_js.CollectBankAccountForPaymentParams(
+          paymentMethodType: 'us_bank_account',
+          paymentMethodData: stripe_js.CollectBankAccountForPaymentMethodData(
+            billingDetails: billingDetails,
+          ),
+        ),
+      );
+      if (response.error != null) {
+        throw StripeError(
+          message: response.error?.message ?? '',
+          code: response.error!.code,
+        );
+      }
+      return CollectBankAccountResult.paymentIntent(
+        response.paymentIntent!.parse(),
+      );
+    }
+
+    final response = await js.collectBankAccountForSetup(
+      clientSecret,
+      params: stripe_js.CollectBankAccountForSetupParams(
+        paymentMethodType: 'us_bank_account',
+        paymentMethodData: stripe_js.CollectBankAccountForSetupMethodData(
+          billingDetails: billingDetails,
+        ),
+      ),
+    );
+    if (response.error != null) {
+      throw StripeError(
+        message: response.error?.message ?? '',
+        code: response.error!.code,
+      );
+    }
+    return CollectBankAccountResult.setupIntent(
+      response.setupIntent!.parse(),
+    );
   }
 
   @override
-  Future<CollectBankAccountResult> verifyPaymentIntentWithMicrodeposits(
-      {required bool isPaymentIntent,
-      required String clientSecret,
-      required VerifyMicroDepositsParams params}) {
-    throw UnimplementedError();
+  Future<CollectBankAccountResult> verifyPaymentIntentWithMicrodeposits({
+    required bool isPaymentIntent,
+    required String clientSecret,
+    required VerifyMicroDepositsParams params,
+  }) async {
+    if (isPaymentIntent) {
+      final response = await js.verifyMicrodepositsForPayment(
+        clientSecret,
+        data: stripe_js.VerifyMicrodepositsForPaymentData(
+          amounts: params.amounts,
+          descriptorCode: params.descriptorCode,
+        ),
+      );
+      if (response.error != null) {
+        throw StripeError(
+          message: response.error?.message ?? '',
+          code: response.error!.code,
+        );
+      }
+      return CollectBankAccountResult.paymentIntent(
+        response.paymentIntent!.parse(),
+      );
+    }
+
+    final response = await js.verifyMicrodepositsForSetup(
+      clientSecret,
+      data: stripe_js.VerifyMicrodepositsForSetupData(
+        amounts: params.amounts,
+        descriptorCode: params.descriptorCode,
+      ),
+    );
+    if (response.error != null) {
+      throw StripeError(
+        message: response.error?.message ?? '',
+        code: response.error!.code,
+      );
+    }
+    return CollectBankAccountResult.setupIntent(
+      response.setupIntent!.parse(),
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary

- **Adds** Stripe.js v3 interop bindings for `collectBankAccountForPayment`, `collectBankAccountForSetup`, `verifyMicrodepositsForPayment`, and `verifyMicrodepositsForSetup` in the `stripe_js` package.
- **Implements** `collectBankAccount` and `verifyPaymentIntentWithMicrodeposits` in `WebStripe`, replacing the previous `UnimplementedError` stubs.
- **Returns** the sealed `CollectBankAccountResult` introduced in #2395 — `response.paymentIntent!.parse()` or `response.setupIntent!.parse()` wrapped in the matching variant. No hand-written field mapping.
- `collectBankAccountToken` and `collectFinancialConnectionsAccounts` remain **unsupported** on web (they require the standalone Financial Connections JS SDK).

---

## Depends on

- #2395

---

## Affected packages

- `stripe_js`
- `stripe_web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collect bank account flows for payments and setups via web/JS integrations.
  * Verify microdeposits for payments and setups.
* **API Changes**
  * Methods now return a unified CollectBankAccountResult representing either a PaymentIntent or SetupIntent.
* **Exports**
  * New models and helpers for bank-account collection and microdeposit verification are publicly available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->