### PR TITLE
Fix: #2382 confirm token handler on payment sheet

### DIFF
--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
@@ -447,16 +447,9 @@ extension  StripePlugin {
 
     func initPaymentSheet(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let arguments = call.arguments as? FlutterMap,
-              var params = arguments["params"] as? NSDictionary else {
+              let params = arguments["params"] as? NSDictionary else {
             result(FlutterError.invalidParams)
             return
-        }
-        if (params.object(forKey: "intentConfiguration") != nil && params.object(forKey: "intentConfiguration") is NSDictionary) {
-            let mutable = (params["intentConfiguration"] as! NSDictionary).mutableCopy() as! NSMutableDictionary
-            mutable["confirmHandler"] = true;
-            let adjusted = params.mutableCopy() as! NSMutableDictionary
-            adjusted["intentConfiguration"] = mutable
-            params = adjusted
         }
         initPaymentSheet(params: params, resolver: resolver(for: result), rejecter: rejecter(for: result))
     }

--- a/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
+++ b/packages/stripe_platform_interface/lib/src/method_channel_stripe.dart
@@ -80,7 +80,7 @@ class MethodChannelStripe extends StripePlatform {
           _confirmTokenHandler != null) {
         final method = ResultParser<ConfirmationTokenResult>(
           parseJson: (json) => ConfirmationTokenResult.fromJson(json),
-        ).parse(result: call.arguments!, successResultKey: 'paymentMethod');
+        ).parse(result: call.arguments!, successResultKey: 'confirmationToken');
         _confirmTokenHandler!(method);
       } else if (call.method == 'onCustomPaymentMethodConfirmHandlerCallback' &&
           _confirmCustomPaymentMethodCallback != null) {
@@ -243,8 +243,18 @@ class MethodChannelStripe extends StripePlatform {
   Future<PaymentSheetPaymentOption?> initPaymentSheet(
     SetupPaymentSheetParameters params,
   ) async {
+    final paramsJson = params.toJson();
+    final intentConfig = paramsJson['intentConfiguration'];
+    if (intentConfig is Map<String, dynamic>) {
+      if (params.intentConfiguration?.confirmHandler != null) {
+        intentConfig['confirmHandler'] = true;
+      }
+      if (params.intentConfiguration?.confirmTokenHandler != null) {
+        intentConfig['confirmationTokenConfirmHandler'] = true;
+      }
+    }
     final result = await _methodChannel.invokeMethod('initPaymentSheet', {
-      'params': params.toJson(),
+      'params': paramsJson,
     });
     if (params.intentConfiguration?.confirmHandler != null) {
       _confirmHandler = params.intentConfiguration?.confirmHandler;


### PR DESCRIPTION
Fixes #2382 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed confirmation token parsing in payment callbacks so the correct token field is used.
  * Improved payment sheet initialization to properly detect and enable available confirmation handlers, ensuring handlers are invoked as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->