### PR TITLE
fix(android): crash when app backgrounded during Google Pay readiness check

### DIFF
--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/GooglePayLauncherManager.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/GooglePayLauncherManager.kt
@@ -1,6 +1,7 @@
 package com.reactnativestripesdk
 
 import android.annotation.SuppressLint
+import androidx.lifecycle.Lifecycle
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
@@ -63,6 +64,17 @@ class GooglePayLauncherManager(
 
   private fun onGooglePayReady(isReady: Boolean) {
     if (isReady) {
+      val activity = getCurrentActivityOrResolveWithError(promise) ?: return
+      if (!activity.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+        callback(
+          null,
+          createError(
+            GooglePayErrorType.Failed.toString(),
+            "Google Pay presentation was interrupted. Please try again.",
+          ),
+        )
+        return
+      }
       when (mode) {
         Mode.ForSetup -> {
           launcher?.presentForSetupIntent(clientSecret, currencyCode, amount?.toLong(), label)


### PR DESCRIPTION
## Summary
- Fix crash in `GooglePayLauncherManager` when the app is backgrounded while Google Pay availability is being checked
- `GooglePayLauncher` checks availability asynchronously; if the activity moves to `STOPPED` before the callback fires, calling `ActivityResultLauncher.launch()` throws `IllegalStateException` (enforced by AndroidX since activity 1.2.0)
- Guard `onGooglePayReady` with a lifecycle state check before calling `presentForPaymentIntent` / `presentForSetupIntent`; return `GooglePayErrorType.Failed` if the activity is not `STARTED`
