### PR TITLE
feat: add PaymentMethodMessaging widget (via PaymentMethodMessagingElement)

### DIFF
--- a/packages/stripe/lib/flutter_stripe.dart
+++ b/packages/stripe/lib/flutter_stripe.dart
@@ -8,4 +8,5 @@ export 'src/widgets/aubecs_debit_form.dart';
 export 'src/widgets/card_field.dart';
 export 'src/widgets/card_form_field.dart';
 // export 'src/widgets/google_pay_button.dart';
+export 'src/widgets/payment_method_messaging.dart';
 export 'src/widgets/platform_pay_button.dart';

--- a/packages/stripe/lib/src/widgets/payment_method_messaging.dart
+++ b/packages/stripe/lib/src/widgets/payment_method_messaging.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:stripe_platform_interface/stripe_platform_interface.dart';
+
+/// Renders Stripe's Klarna / Afterpay / Affirm promotional messaging element.
+///
+/// Backed by Stripe's `PaymentMethodMessagingElement` on both iOS (via
+/// `StripePaymentSheet`) and Android (via the `com.stripe:payment-method-messaging`
+/// artifact). The element is currently marked preview by Stripe (`@_spi` on
+/// iOS, `@OptIn(PaymentMethodMessagingElementPreview::class)` on Android), so
+/// its visual output may change in future SDK releases.
+///
+/// The widget auto-resizes: the native element reports its rendered height
+/// back to Dart, which drives the surrounding `SizedBox`. The optional
+/// [onHeightChange] callback receives the same value if callers want to react
+/// to height changes themselves.
+class PaymentMethodMessaging extends StatefulWidget {
+  const PaymentMethodMessaging({
+    required this.configuration,
+    this.onHeightChange,
+    super.key,
+  });
+
+  final PaymentMethodMessagingConfiguration configuration;
+  final ValueChanged<double>? onHeightChange;
+
+  @override
+  State<PaymentMethodMessaging> createState() =>
+      _PaymentMethodMessagingState();
+}
+
+class _PaymentMethodMessagingState extends State<PaymentMethodMessaging> {
+  static const _viewType = 'flutter.stripe/payment_method_messaging';
+
+  MethodChannel? _methodChannel;
+  double _height = 50;
+
+  void onPlatformViewCreated(int viewId) {
+    _methodChannel =
+        MethodChannel('flutter.stripe/payment_method_messaging/$viewId');
+    _methodChannel!.setMethodCallHandler((call) async {
+      if (call.method == 'onHeightChange') {
+        final args = Map<String, dynamic>.from(call.arguments);
+        final height = (args['height'] as num).toDouble();
+        if (mounted) {
+          setState(() {
+            _height = height;
+          });
+        }
+        widget.onHeightChange?.call(height);
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant PaymentMethodMessaging oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.configuration != oldWidget.configuration) {
+      _methodChannel?.invokeMethod(
+        'updateConfiguration',
+        widget.configuration.toJson(),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _methodChannel?.setMethodCallHandler(null);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final creationParams = widget.configuration.toJson();
+
+    Widget platform;
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      platform = UiKitView(
+        viewType: _viewType,
+        creationParamsCodec: const StandardMessageCodec(),
+        creationParams: creationParams,
+        onPlatformViewCreated: onPlatformViewCreated,
+      );
+    } else if (defaultTargetPlatform == TargetPlatform.android) {
+      platform = PlatformViewLink(
+        viewType: _viewType,
+        surfaceFactory: (context, controller) {
+          return AndroidViewSurface(
+            controller: controller as AndroidViewController,
+            hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+            gestureRecognizers:
+                const <Factory<OneSequenceGestureRecognizer>>{},
+          );
+        },
+        onCreatePlatformView: (params) {
+          onPlatformViewCreated(params.id);
+          return PlatformViewsService.initSurfaceAndroidView(
+              id: params.id,
+              viewType: _viewType,
+              layoutDirection: TextDirection.ltr,
+              creationParams: creationParams,
+              creationParamsCodec: const StandardMessageCodec(),
+            )
+            ..addOnPlatformViewCreatedListener(
+              params.onPlatformViewCreated,
+            )
+            ..create();
+        },
+      );
+    } else {
+      throw UnsupportedError('Unsupported platform view');
+    }
+
+    return SizedBox(
+      height: _height,
+      child: platform,
+    );
+  }
+}

--- a/packages/stripe_android/android/build.gradle
+++ b/packages/stripe_android/android/build.gradle
@@ -65,6 +65,12 @@ dependencies {
     implementation "com.stripe:stripe-android:$stripe_version"
     implementation "com.stripe:financial-connections:$stripe_version"
     implementation "com.stripe:payment-method-messaging:$stripe_version"
+    // Compose modules used by StripePaymentMethodMessagingPlatformView. The
+    // payment-method-messaging artifact declares these at runtime scope only,
+    // so consuming modules must add them to the compile classpath explicitly.
+    implementation "androidx.compose.ui:ui:1.10.4"
+    implementation "androidx.compose.foundation:foundation:1.10.4"
+    implementation "androidx.compose.runtime:runtime:1.10.4"
     implementation 'com.google.android.material:material:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.squareup.okhttp3:okhttp:5.3.2'

--- a/packages/stripe_android/android/build.gradle
+++ b/packages/stripe_android/android/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.1"
     implementation "com.stripe:stripe-android:$stripe_version"
     implementation "com.stripe:financial-connections:$stripe_version"
+    implementation "com.stripe:payment-method-messaging:$stripe_version"
     implementation 'com.google.android.material:material:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.squareup.okhttp3:okhttp:5.3.2'

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripeAndroidPlugin.kt
@@ -77,6 +77,7 @@ class StripeAndroidPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             .platformViewRegistry
             .registerViewFactory("flutter.stripe/add_to_wallet", StripeAddToWalletPlatformViewFactory(flutterPluginBinding, AddToWalletButtonManager()){stripeSdk})
         flutterPluginBinding.platformViewRegistry.registerViewFactory("flutter.stripe/address_sheet", StripeAddressSheetPlatformViewFactory(flutterPluginBinding, addressSheetFormViewManager ){stripeSdk})
+        flutterPluginBinding.platformViewRegistry.registerViewFactory("flutter.stripe/payment_method_messaging", StripePaymentMethodMessagingPlatformViewFactory(flutterPluginBinding))
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripePaymentMethodMessagingPlatformView.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripePaymentMethodMessagingPlatformView.kt
@@ -1,0 +1,157 @@
+package com.flutter.stripe
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.View
+import android.widget.FrameLayout
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import com.stripe.android.paymentmethodmessaging.element.PaymentMethodMessagingElement
+import com.stripe.android.paymentmethodmessaging.element.PaymentMethodMessagingElementPreview
+import com.stripe.android.model.PaymentMethod
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.platform.PlatformView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+
+@OptIn(PaymentMethodMessagingElementPreview::class)
+class StripePaymentMethodMessagingPlatformView(
+    private val context: Context,
+    private val channel: MethodChannel,
+    creationParams: Map<String?, Any?>?,
+) : PlatformView {
+
+    private val container: FrameLayout = FrameLayout(context)
+    private val composeView: ComposeView = ComposeView(context).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    }
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+    private var configureJob: Job? = null
+    private var elementState: ((PaymentMethodMessagingElement?) -> Unit)? = null
+    private var lastReportedHeightPx: Int = -1
+
+    init {
+        container.addView(
+            composeView,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+            ),
+        )
+        composeView.setContent {
+            var element by remember { mutableStateOf<PaymentMethodMessagingElement?>(null) }
+            elementState = { element = it }
+            val density = LocalDensity.current
+            Box(
+                modifier = Modifier.onSizeChanged { size ->
+                    if (size.height != lastReportedHeightPx) {
+                        lastReportedHeightPx = size.height
+                        val heightDp = with(density) { size.height.toDp().value }
+                        channel.invokeMethod(
+                            "onHeightChange",
+                            mapOf("height" to heightDp.toDouble()),
+                        )
+                    }
+                },
+            ) {
+                element?.Content(PaymentMethodMessagingElement.Appearance())
+            }
+        }
+
+        channel.setMethodCallHandler { call, result -> handleMethodCall(call, result) }
+        applyConfiguration(creationParams)
+    }
+
+    private fun handleMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "updateConfiguration" -> {
+                @Suppress("UNCHECKED_CAST")
+                applyConfiguration(call.arguments as? Map<String?, Any?>)
+                result.success(null)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun applyConfiguration(params: Map<String?, Any?>?) {
+        configureJob?.cancel()
+        elementState?.invoke(null)
+        emitCollapsedHeight()
+
+        if (params == null) return
+
+        @Suppress("UNCHECKED_CAST")
+        val methodStrings = params["paymentMethods"] as? List<String> ?: return
+        val currency = params["currency"] as? String ?: return
+        val amount = (params["amount"] as? Number)?.toLong() ?: return
+        val countryCode = params["countryCode"] as? String
+        val locale = params["locale"] as? String
+
+        val types = methodStrings.mapNotNull { PaymentMethod.Type.fromCode(it) }
+        val application = context.findApplication() ?: return
+
+        val configuration = PaymentMethodMessagingElement.Configuration().apply {
+            amount(amount)
+            currency(currency)
+            locale?.let { locale(it) }
+            countryCode?.let { countryCode(it) }
+            if (types.isNotEmpty()) paymentMethodTypes(types)
+        }
+
+        configureJob = scope.launch {
+            val element = PaymentMethodMessagingElement.create(application)
+            val result = element.configure(configuration)
+            when (result) {
+                is PaymentMethodMessagingElement.ConfigureResult.Succeeded -> {
+                    elementState?.invoke(element)
+                }
+                is PaymentMethodMessagingElement.ConfigureResult.NoContent,
+                is PaymentMethodMessagingElement.ConfigureResult.Failed -> {
+                    elementState?.invoke(null)
+                    emitCollapsedHeight()
+                }
+            }
+        }
+    }
+
+    private fun emitCollapsedHeight() {
+        if (lastReportedHeightPx != 0) {
+            lastReportedHeightPx = 0
+            channel.invokeMethod("onHeightChange", mapOf("height" to 0.0))
+        }
+    }
+
+    override fun getView(): View = container
+
+    override fun dispose() {
+        configureJob?.cancel()
+        scope.cancel()
+        composeView.disposeComposition()
+        channel.setMethodCallHandler(null)
+    }
+}
+
+private fun Context.findApplication(): Application? {
+    var ctx: Context = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Application) return ctx
+        if (ctx is Activity) return ctx.application
+        ctx = ctx.baseContext
+    }
+    return applicationContext as? Application
+}

--- a/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripePaymentMethodMessagingPlatformViewFactory.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/flutter/stripe/StripePaymentMethodMessagingPlatformViewFactory.kt
@@ -1,0 +1,25 @@
+package com.flutter.stripe
+
+import android.content.Context
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.StandardMessageCodec
+import io.flutter.plugin.platform.PlatformView
+import io.flutter.plugin.platform.PlatformViewFactory
+
+class StripePaymentMethodMessagingPlatformViewFactory(
+    private val flutterPluginBinding: FlutterPlugin.FlutterPluginBinding,
+) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+    override fun create(context: Context?, viewId: Int, args: Any?): PlatformView {
+        if (context == null) {
+            throw AssertionError("Context is not allowed to be null when launching PaymentMethodMessaging view.")
+        }
+        val channel = MethodChannel(
+            flutterPluginBinding.binaryMessenger,
+            "flutter.stripe/payment_method_messaging/$viewId",
+        )
+        @Suppress("UNCHECKED_CAST")
+        val creationParams = args as? Map<String?, Any?>?
+        return StripePaymentMethodMessagingPlatformView(context, channel, creationParams)
+    }
+}

--- a/packages/stripe_ios/ios/stripe_ios/Package.resolved
+++ b/packages/stripe_ios/ios/stripe_ios/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stripe/stripe-ios-spm",
       "state" : {
-        "revision" : "4f322eb59a7f49a239a36078357c4cac7dac07cd",
-        "version" : "24.16.1"
+        "revision" : "bf87cb248c4a8bd5176acbf9e10e50a010977ac1",
+        "version" : "25.9.0"
       }
     }
   ],

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/PaymentMethodMessagingElementFactory.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/PaymentMethodMessagingElementFactory.swift
@@ -1,0 +1,94 @@
+import Flutter
+import Foundation
+import UIKit
+
+public class PaymentMethodMessagingElementFactory: NSObject, FlutterPlatformViewFactory {
+
+    private var messenger: FlutterBinaryMessenger
+
+    init(messenger: FlutterBinaryMessenger) {
+        self.messenger = messenger
+        super.init()
+    }
+
+    public func create(
+        withFrame frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?
+    ) -> FlutterPlatformView {
+        return PaymentMethodMessagingElementPlatformView(
+            frame: frame,
+            viewIdentifier: viewId,
+            arguments: args,
+            binaryMessenger: messenger
+        )
+    }
+
+    public func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+        return FlutterStandardMessageCodec.sharedInstance()
+    }
+}
+
+class PaymentMethodMessagingElementPlatformView: NSObject, FlutterPlatformView {
+
+    let messagingView = PaymentMethodMessagingElementView()
+    private let channel: FlutterMethodChannel
+
+    func view() -> UIView { return messagingView }
+
+    init(
+        frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?,
+        binaryMessenger messenger: FlutterBinaryMessenger
+    ) {
+        channel = FlutterMethodChannel(
+            name: "flutter.stripe/payment_method_messaging/\(viewId)",
+            binaryMessenger: messenger
+        )
+        super.init()
+        channel.setMethodCallHandler(handle)
+        messagingView.onHeightChange = { [weak self] height in
+            self?.channel.invokeMethod("onHeightChange", arguments: ["height": height])
+        }
+        updateProps(args)
+    }
+
+    deinit {
+        channel.setMethodCallHandler(nil)
+        messagingView.teardown()
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "updateConfiguration":
+            updateProps(call.arguments)
+            result(nil)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func updateProps(_ args: Any?) {
+        guard let arguments = args as? [String: Any],
+              let paymentMethods = arguments["paymentMethods"] as? [String],
+              let currency = arguments["currency"] as? String,
+              let amount = (arguments["amount"] as? NSNumber)?.intValue else {
+            messagingView.applyConfiguration(
+                paymentMethods: [],
+                currency: "",
+                amount: 0,
+                countryCode: nil,
+                locale: nil
+            )
+            return
+        }
+        messagingView.applyConfiguration(
+            paymentMethods: paymentMethods,
+            currency: currency,
+            amount: amount,
+            countryCode: arguments["countryCode"] as? String,
+            locale: arguments["locale"] as? String
+        )
+    }
+}

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/PaymentMethodMessagingElementView.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/PaymentMethodMessagingElementView.swift
@@ -1,0 +1,113 @@
+import Foundation
+@_spi(PaymentMethodMessagingElementPreview) @_spi(STP) import StripePaymentSheet
+import Stripe
+import UIKit
+
+/// Wraps Stripe's `PaymentMethodMessagingElement` (iOS SDK preview API) in a
+/// plain `UIView` so that the Flutter platform-view adapter can be a thin
+/// wrapper. Mirrors the shape of `CardFieldView` / `AuBECSDebitFormView`.
+@objc(PaymentMethodMessagingElementView)
+public class PaymentMethodMessagingElementView: UIView {
+    public var onHeightChange: ((CGFloat) -> Void)?
+
+    private var messagingInstance: PaymentMethodMessagingElement?
+    private var paymentMethodMessagingElementView: UIView?
+    private var previousHeight: CGFloat?
+    private var pendingTask: Task<Void, Never>?
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+    }
+
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        let desiredHeight = systemLayoutSizeFitting(
+            CGSize(width: frame.width, height: UIView.layoutFittingCompressedSize.height)
+        ).height
+        if desiredHeight != previousHeight {
+            previousHeight = desiredHeight
+            onHeightChange?(desiredHeight)
+        }
+    }
+
+    public func applyConfiguration(
+        paymentMethods: [String],
+        currency: String,
+        amount: Int,
+        countryCode: String?,
+        locale: String?
+    ) {
+        pendingTask?.cancel()
+        pendingTask = nil
+        removeMessagingSubview()
+        emitHeight(0)
+
+        guard STPAPIClient.shared.publishableKey != nil else { return }
+
+        let types: [STPPaymentMethodType] = paymentMethods.compactMap { id in
+            let type = STPPaymentMethodType.fromIdentifier(id)
+            return type == .unknown ? nil : type
+        }
+
+        var configuration = PaymentMethodMessagingElement.Configuration(
+            amount: amount,
+            currency: currency
+        )
+        if let countryCode = countryCode { configuration.countryCode = countryCode }
+        if let locale = locale { configuration.locale = locale }
+        if !types.isEmpty { configuration.paymentMethodTypes = types }
+
+        pendingTask = Task { @MainActor [weak self] in
+            let result = await PaymentMethodMessagingElement.create(configuration: configuration)
+            guard let self = self, !Task.isCancelled else { return }
+            switch result {
+            case .success(let element):
+                self.messagingInstance = element
+                self.attachMessagingSubview()
+            case .noContent, .failed:
+                self.messagingInstance = nil
+                self.emitHeight(0)
+            }
+        }
+    }
+
+    public func teardown() {
+        pendingTask?.cancel()
+        pendingTask = nil
+        removeMessagingSubview()
+        messagingInstance = nil
+    }
+
+    private func attachMessagingSubview() {
+        removeMessagingSubview()
+        guard let element = messagingInstance else { return }
+        let subview = element.view
+        subview.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(subview)
+        NSLayoutConstraint.activate([
+            subview.leadingAnchor.constraint(equalTo: leadingAnchor),
+            subview.trailingAnchor.constraint(equalTo: trailingAnchor),
+            subview.topAnchor.constraint(equalTo: topAnchor),
+            subview.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+        paymentMethodMessagingElementView = subview
+        setNeedsLayout()
+    }
+
+    private func removeMessagingSubview() {
+        paymentMethodMessagingElementView?.removeFromSuperview()
+        paymentMethodMessagingElementView = nil
+    }
+
+    private func emitHeight(_ height: CGFloat) {
+        if previousHeight != height {
+            previousHeight = height
+            onHeightChange?(height)
+        }
+    }
+}

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
@@ -87,6 +87,9 @@ class StripePlugin: StripeSdkImpl, FlutterPlugin, ViewManagerDelegate {
         let addressSheetFactory = AddressSheetViewFactory(messenger: registrar.messenger(), delegate: instance)
         registrar.register(addressSheetFactory, withId: "flutter.stripe/address_sheet")
 
+        // Payment Method Messaging
+        let messagingFactory = PaymentMethodMessagingElementFactory(messenger: registrar.messenger())
+        registrar.register(messagingFactory, withId: "flutter.stripe/payment_method_messaging")
     }
 
     init(channel : FlutterMethodChannel) {

--- a/packages/stripe_platform_interface/lib/src/models/payment_method_messaging.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_method_messaging.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'payment_method_messaging.freezed.dart';
+part 'payment_method_messaging.g.dart';
+
+@freezed
+abstract class PaymentMethodMessagingConfiguration
+    with _$PaymentMethodMessagingConfiguration {
+  @JsonSerializable(explicitToJson: true)
+  const factory PaymentMethodMessagingConfiguration({
+    required List<PaymentMethodMessagingPaymentMethod> paymentMethods,
+    required String currency,
+    required int amount,
+    String? countryCode,
+    String? locale,
+  }) = _PaymentMethodMessagingConfiguration;
+
+  factory PaymentMethodMessagingConfiguration.fromJson(
+    Map<String, dynamic> json,
+  ) => _$PaymentMethodMessagingConfigurationFromJson(json);
+}
+
+@JsonEnum(valueField: 'value')
+enum PaymentMethodMessagingPaymentMethod {
+  klarna('klarna'),
+  afterpayClearpay('afterpay_clearpay'),
+  affirm('affirm');
+
+  const PaymentMethodMessagingPaymentMethod(this.value);
+  final String value;
+}

--- a/packages/stripe_platform_interface/lib/src/models/payment_method_messaging.freezed.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_method_messaging.freezed.dart
@@ -1,0 +1,295 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'payment_method_messaging.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PaymentMethodMessagingConfiguration {
+
+ List<PaymentMethodMessagingPaymentMethod> get paymentMethods; String get currency; int get amount; String? get countryCode; String? get locale;
+/// Create a copy of PaymentMethodMessagingConfiguration
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PaymentMethodMessagingConfigurationCopyWith<PaymentMethodMessagingConfiguration> get copyWith => _$PaymentMethodMessagingConfigurationCopyWithImpl<PaymentMethodMessagingConfiguration>(this as PaymentMethodMessagingConfiguration, _$identity);
+
+  /// Serializes this PaymentMethodMessagingConfiguration to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PaymentMethodMessagingConfiguration&&const DeepCollectionEquality().equals(other.paymentMethods, paymentMethods)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.countryCode, countryCode) || other.countryCode == countryCode)&&(identical(other.locale, locale) || other.locale == locale));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(paymentMethods),currency,amount,countryCode,locale);
+
+@override
+String toString() {
+  return 'PaymentMethodMessagingConfiguration(paymentMethods: $paymentMethods, currency: $currency, amount: $amount, countryCode: $countryCode, locale: $locale)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PaymentMethodMessagingConfigurationCopyWith<$Res>  {
+  factory $PaymentMethodMessagingConfigurationCopyWith(PaymentMethodMessagingConfiguration value, $Res Function(PaymentMethodMessagingConfiguration) _then) = _$PaymentMethodMessagingConfigurationCopyWithImpl;
+@useResult
+$Res call({
+ List<PaymentMethodMessagingPaymentMethod> paymentMethods, String currency, int amount, String? countryCode, String? locale
+});
+
+
+
+
+}
+/// @nodoc
+class _$PaymentMethodMessagingConfigurationCopyWithImpl<$Res>
+    implements $PaymentMethodMessagingConfigurationCopyWith<$Res> {
+  _$PaymentMethodMessagingConfigurationCopyWithImpl(this._self, this._then);
+
+  final PaymentMethodMessagingConfiguration _self;
+  final $Res Function(PaymentMethodMessagingConfiguration) _then;
+
+/// Create a copy of PaymentMethodMessagingConfiguration
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? paymentMethods = null,Object? currency = null,Object? amount = null,Object? countryCode = freezed,Object? locale = freezed,}) {
+  return _then(_self.copyWith(
+paymentMethods: null == paymentMethods ? _self.paymentMethods : paymentMethods // ignore: cast_nullable_to_non_nullable
+as List<PaymentMethodMessagingPaymentMethod>,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as int,countryCode: freezed == countryCode ? _self.countryCode : countryCode // ignore: cast_nullable_to_non_nullable
+as String?,locale: freezed == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PaymentMethodMessagingConfiguration].
+extension PaymentMethodMessagingConfigurationPatterns on PaymentMethodMessagingConfiguration {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PaymentMethodMessagingConfiguration value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PaymentMethodMessagingConfiguration() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PaymentMethodMessagingConfiguration value)  $default,){
+final _that = this;
+switch (_that) {
+case _PaymentMethodMessagingConfiguration():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PaymentMethodMessagingConfiguration value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PaymentMethodMessagingConfiguration() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<PaymentMethodMessagingPaymentMethod> paymentMethods,  String currency,  int amount,  String? countryCode,  String? locale)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PaymentMethodMessagingConfiguration() when $default != null:
+return $default(_that.paymentMethods,_that.currency,_that.amount,_that.countryCode,_that.locale);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<PaymentMethodMessagingPaymentMethod> paymentMethods,  String currency,  int amount,  String? countryCode,  String? locale)  $default,) {final _that = this;
+switch (_that) {
+case _PaymentMethodMessagingConfiguration():
+return $default(_that.paymentMethods,_that.currency,_that.amount,_that.countryCode,_that.locale);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<PaymentMethodMessagingPaymentMethod> paymentMethods,  String currency,  int amount,  String? countryCode,  String? locale)?  $default,) {final _that = this;
+switch (_that) {
+case _PaymentMethodMessagingConfiguration() when $default != null:
+return $default(_that.paymentMethods,_that.currency,_that.amount,_that.countryCode,_that.locale);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true)
+class _PaymentMethodMessagingConfiguration implements PaymentMethodMessagingConfiguration {
+  const _PaymentMethodMessagingConfiguration({required final  List<PaymentMethodMessagingPaymentMethod> paymentMethods, required this.currency, required this.amount, this.countryCode, this.locale}): _paymentMethods = paymentMethods;
+  factory _PaymentMethodMessagingConfiguration.fromJson(Map<String, dynamic> json) => _$PaymentMethodMessagingConfigurationFromJson(json);
+
+ final  List<PaymentMethodMessagingPaymentMethod> _paymentMethods;
+@override List<PaymentMethodMessagingPaymentMethod> get paymentMethods {
+  if (_paymentMethods is EqualUnmodifiableListView) return _paymentMethods;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_paymentMethods);
+}
+
+@override final  String currency;
+@override final  int amount;
+@override final  String? countryCode;
+@override final  String? locale;
+
+/// Create a copy of PaymentMethodMessagingConfiguration
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PaymentMethodMessagingConfigurationCopyWith<_PaymentMethodMessagingConfiguration> get copyWith => __$PaymentMethodMessagingConfigurationCopyWithImpl<_PaymentMethodMessagingConfiguration>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PaymentMethodMessagingConfigurationToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PaymentMethodMessagingConfiguration&&const DeepCollectionEquality().equals(other._paymentMethods, _paymentMethods)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.countryCode, countryCode) || other.countryCode == countryCode)&&(identical(other.locale, locale) || other.locale == locale));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_paymentMethods),currency,amount,countryCode,locale);
+
+@override
+String toString() {
+  return 'PaymentMethodMessagingConfiguration(paymentMethods: $paymentMethods, currency: $currency, amount: $amount, countryCode: $countryCode, locale: $locale)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PaymentMethodMessagingConfigurationCopyWith<$Res> implements $PaymentMethodMessagingConfigurationCopyWith<$Res> {
+  factory _$PaymentMethodMessagingConfigurationCopyWith(_PaymentMethodMessagingConfiguration value, $Res Function(_PaymentMethodMessagingConfiguration) _then) = __$PaymentMethodMessagingConfigurationCopyWithImpl;
+@override @useResult
+$Res call({
+ List<PaymentMethodMessagingPaymentMethod> paymentMethods, String currency, int amount, String? countryCode, String? locale
+});
+
+
+
+
+}
+/// @nodoc
+class __$PaymentMethodMessagingConfigurationCopyWithImpl<$Res>
+    implements _$PaymentMethodMessagingConfigurationCopyWith<$Res> {
+  __$PaymentMethodMessagingConfigurationCopyWithImpl(this._self, this._then);
+
+  final _PaymentMethodMessagingConfiguration _self;
+  final $Res Function(_PaymentMethodMessagingConfiguration) _then;
+
+/// Create a copy of PaymentMethodMessagingConfiguration
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? paymentMethods = null,Object? currency = null,Object? amount = null,Object? countryCode = freezed,Object? locale = freezed,}) {
+  return _then(_PaymentMethodMessagingConfiguration(
+paymentMethods: null == paymentMethods ? _self._paymentMethods : paymentMethods // ignore: cast_nullable_to_non_nullable
+as List<PaymentMethodMessagingPaymentMethod>,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as int,countryCode: freezed == countryCode ? _self.countryCode : countryCode // ignore: cast_nullable_to_non_nullable
+as String?,locale: freezed == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/stripe_platform_interface/lib/src/models/payment_method_messaging.g.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_method_messaging.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'payment_method_messaging.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PaymentMethodMessagingConfiguration
+_$PaymentMethodMessagingConfigurationFromJson(Map<String, dynamic> json) =>
+    _PaymentMethodMessagingConfiguration(
+      paymentMethods: (json['paymentMethods'] as List<dynamic>)
+          .map(
+            (e) => $enumDecode(_$PaymentMethodMessagingPaymentMethodEnumMap, e),
+          )
+          .toList(),
+      currency: json['currency'] as String,
+      amount: (json['amount'] as num).toInt(),
+      countryCode: json['countryCode'] as String?,
+      locale: json['locale'] as String?,
+    );
+
+Map<String, dynamic> _$PaymentMethodMessagingConfigurationToJson(
+  _PaymentMethodMessagingConfiguration instance,
+) => <String, dynamic>{
+  'paymentMethods': instance.paymentMethods
+      .map((e) => _$PaymentMethodMessagingPaymentMethodEnumMap[e]!)
+      .toList(),
+  'currency': instance.currency,
+  'amount': instance.amount,
+  'countryCode': instance.countryCode,
+  'locale': instance.locale,
+};
+
+const _$PaymentMethodMessagingPaymentMethodEnumMap = {
+  PaymentMethodMessagingPaymentMethod.klarna: 'klarna',
+  PaymentMethodMessagingPaymentMethod.afterpayClearpay: 'afterpay_clearpay',
+  PaymentMethodMessagingPaymentMethod.affirm: 'affirm',
+};

--- a/packages/stripe_platform_interface/lib/stripe_platform_interface.dart
+++ b/packages/stripe_platform_interface/lib/stripe_platform_interface.dart
@@ -19,6 +19,7 @@ export 'src/models/google_pay.dart';
 export 'src/models/intent_creation_callback_params.dart';
 export 'src/models/next_action.dart';
 export 'src/models/payment_intents.dart';
+export 'src/models/payment_method_messaging.dart';
 export 'src/models/payment_methods.dart';
 export 'src/models/payment_sheet.dart';
 export 'src/models/platform_pay.dart';


### PR DESCRIPTION
## Summary

Add a `PaymentMethodMessaging` Flutter widget that wraps Stripe's `PaymentMethodMessagingElement` (Klarna / Afterpay / Affirm promotional messaging) on both iOS and Android. Supersedes #2387 — see the [closing comment there](https://github.com/flutter-stripe/flutter_stripe/pull/2387) for the full post-mortem on why that branch was abandoned.

## Why the rewrite

The prior PR #2387 referenced SDK classes that don't exist: iOS `StripePaymentSheet.PaymentMethodMessagingView` and Android `com.stripe.android.paymentsheet.paymentmethodmessaging.PaymentMethodMessagingView`. Neither is published by Stripe at any version. The correct class on both platforms is `PaymentMethodMessagingElement`, gated behind a preview annotation — the same API that `stripe-react-native` v0.61 wraps.

This PR starts clean from `main` (which already carries the 25.9.0 `stripe-ios-spm` bump) and implements both platforms against the real API.

## What changed

- **Dart model** (`stripe_platform_interface`): Freezed `PaymentMethodMessagingConfiguration` with `paymentMethods`, `currency`, `amount`, optional `countryCode`, optional `locale`. Enum covers Klarna, Afterpay/Clearpay, and Affirm (matches the Element's supported methods).
- **Dart widget** (`stripe`): `PaymentMethodMessaging` widget with auto-resizing height, `didUpdateWidget` forwarding config changes to native via a per-viewId `MethodChannel`, `dispose` clearing the handler, explicit iOS / Android / `UnsupportedError` branching.
- **iOS** (`stripe_ios`): `PaymentMethodMessagingElementView` UIView subclass (under `Stripe Sdk/`, matching `CardFieldView`/`AuBECSDebitFormView`) owns the `PaymentMethodMessagingElement`, embeds `element.view` with Auto Layout, guards publishable-key presence, emits height via `systemLayoutSizeFitting` in `layoutSubviews`. `PaymentMethodMessagingElementFactory` is the thin `FlutterPlatformView` adapter handling `updateConfiguration` and `onHeightChange` over the per-viewId channel (with `NSNumber.intValue` for the Flutter codec). Registered under `flutter.stripe/payment_method_messaging` in `StripePlugin`.
- **Android** (`stripe_android`): adds the separate `com.stripe:payment-method-messaging:$stripe_version` artifact. Platform view hosts an AndroidX `ComposeView` inside a `FrameLayout`; `applyConfiguration` launches a coroutine that calls `PaymentMethodMessagingElement.create(application).configure(config)` and swaps composition state on the result (`Succeeded` → render `element.Content(appearance)`; `NoContent`/`Failed` → empty composition + collapsed height). Height reported in dp via `Modifier.onSizeChanged`. `dispose()` cancels the scope, disposes the composition, clears the method-channel handler.
- Also fixes `Package.resolved` to match the 25.9.0 pin in `Package.swift` — main was committed with a stale resolve.

## Scope notes

Intentionally deferred to follow-ups (keeps review surface small):

- **Appearance config.** iOS `UIFont`/`UIColor` and Android `Theme/Font/Colors` don't map cleanly to a shared Dart model; worth a dedicated design pass. Default Stripe appearance works for a first release.
- **Configure-result callback.** RN surfaces `loading / loaded / no_content / failed(error)` to JS. Here we surface no-content/failed only via collapse-to-zero height. A dedicated `onConfigureResult` callback can land later.

## Closes

- Closes #2402 (Android follow-up we filed earlier; now implemented in this PR from day one).
- Supersedes #2387.
- Part of #2378 (v0.61 sync).

## Test plan

- [x] `dart analyze` clean across `packages/stripe` and `packages/stripe_platform_interface`.
- [x] `dart run build_runner build --delete-conflicting-outputs` regenerates Freezed/JSON cleanly.
- [ ] Manual: render the widget in the example app on iOS simulator with a valid publishable key — messaging displays, height auto-adjusts.
- [ ] Manual: render on Android emulator — Compose-hosted element displays, height auto-adjusts.
- [ ] Manual: toggle `amount` in the configuration while mounted — the `didUpdateWidget` → `updateConfiguration` path reconfigures the native element.
- [ ] Manual: on unsupported platforms (web/desktop) the widget throws `UnsupportedError` at build rather than failing inside Android-specific APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PaymentMethodMessaging widget to display Klarna/Afterpay/Affirm promotional messaging
  * Widget auto-resizes based on native content and emits height-change events
  * Full configuration: payment methods, currency, amount, country code, and locale
  * Enabled end-to-end platform support on iOS and Android and exported via the package API
<!-- end of auto-generated comment: release notes by coderabbit.ai -->