### PR TITLE
Fix native LinkDisplayParams handling

### DIFF
--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/PaymentElementConfig.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/PaymentElementConfig.kt
@@ -65,7 +65,7 @@ internal fun buildLinkConfig(params: ReadableMap?): PaymentSheet.LinkConfigurati
     return PaymentSheet.LinkConfiguration()
   }
 
-  val display = mapStringToLinkDisplay(params.getString("display"))
+  val display = mapStringToLinkDisplay(params.getString("linkDisplay"))
 
   return PaymentSheet.LinkConfiguration(
     display = display,

--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -306,7 +306,7 @@ class PaymentSheetManager(
     }
     val primaryButtonLabel = args.getString("primaryButtonLabel")
     val googlePayConfig = buildGooglePayConfig(args.getMap("googlePay"))
-    val linkConfig = buildLinkConfig(args.getMap("link"))
+    val linkConfig = buildLinkConfig(args.getMap("linkDisplayParams"))
     val allowsDelayedPaymentMethods = args.getBooleanOr("allowsDelayedPaymentMethods", false)
     val billingDetailsMap = args.getMap("defaultBillingDetails")
     val billingConfigParams = args.getMap("billingDetailsCollectionConfiguration")

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+Embedded.swift
@@ -223,8 +223,8 @@ extension StripeSdkImpl {
       }
     }
 
-    if let linkParams = params["link"] as? NSDictionary {
-      let display = StripeSdkImpl.mapToLinkDisplay(value: linkParams["display"] as? String)
+    if let linkParams = params["linkDisplayParams"] as? NSDictionary {
+      let display = StripeSdkImpl.mapToLinkDisplay(value: linkParams["linkDisplay"] as? String)
       configuration.link = PaymentSheet.LinkConfiguration(display: display)
     }
 

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+PaymentSheet.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl+PaymentSheet.swift
@@ -38,9 +38,9 @@ extension StripeSdkImpl {
             }
         }
 
-        if let linkParams = params["link"] as? NSDictionary {
+        if let linkParams = params["linkDisplayParams"] as? NSDictionary {
             do {
-              let display = StripeSdkImpl.mapToLinkDisplay(value: linkParams["display"] as? String)
+              let display = StripeSdkImpl.mapToLinkDisplay(value: linkParams["linkDisplay"] as? String)
               configuration.link = PaymentSheet.LinkConfiguration(display: display)
             } catch {
                 return(error: Errors.createError(ErrorType.Failed, error.localizedDescription), configuration: nil)


### PR DESCRIPTION
Dart's `LinkDisplayParams` is converted to JSON as follows:

```json
{
  "linkDisplayParams": {
    "linkDisplay": "never"
  }
}
```

However, the Swift and Kotlin implementations expected the following JSON:

```json
{
  "link": {
    "display": "never"
  }
}
```

The referenced fields did not match.

This Pull Request fixes the fields referenced by Swift and Kotlin to `linkDisplayParams` and `linkDisplay`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed link display configuration parameter reading in payment sheet and embedded payment element initialization on Android and iOS platforms, ensuring accurate link display behavior during payment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->