### PR TITLE
Fix: Link display params serialization

### DIFF
--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.dart
@@ -68,7 +68,7 @@ abstract class SetupPaymentSheetParameters with _$SetupPaymentSheetParameters {
     PaymentSheetGooglePay? googlePay,
 
     /// Configuration related to Link
-    LinkDisplayParams? linkDisplayParams,
+    @JsonKey(name: 'link') LinkDisplayParams? linkDisplayParams,
 
     /// Flag that allows payment methods that do not move money at the send of the checkout.
     ///
@@ -751,7 +751,7 @@ abstract class CardBrandAcceptance with _$CardBrandAcceptance {
 abstract class LinkDisplayParams with _$LinkDisplayParams {
   const factory LinkDisplayParams({
     /// Display configuration for Link
-    required LinkDisplay linkDisplay,
+    @JsonKey(name: 'display') required LinkDisplay linkDisplay,
   }) = _LinkDisplayParams;
 
   factory LinkDisplayParams.fromJson(Map<String, Object?> json) =>

--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.freezed.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.freezed.dart
@@ -50,7 +50,7 @@ mixin _$SetupPaymentSheetParameters {
 @JsonKey(toJson: UserInterfaceStyleKey.toJson) ThemeMode? get style;/// Configuration related to Google Pay
 /// If set, PaymentSheet displays Google Pay as a payment option
  PaymentSheetGooglePay? get googlePay;/// Configuration related to Link
- LinkDisplayParams? get linkDisplayParams;/// Flag that allows payment methods that do not move money at the send of the checkout.
+@JsonKey(name: 'link') LinkDisplayParams? get linkDisplayParams;/// Flag that allows payment methods that do not move money at the send of the checkout.
 ///
 /// Defaul value is false.
  bool get allowsDelayedPaymentMethods;/// Appearance of the paymentsheet.
@@ -128,7 +128,7 @@ abstract mixin class $SetupPaymentSheetParametersCopyWith<$Res>  {
   factory $SetupPaymentSheetParametersCopyWith(SetupPaymentSheetParameters value, $Res Function(SetupPaymentSheetParameters) _then) = _$SetupPaymentSheetParametersCopyWithImpl;
 @useResult
 $Res call({
- bool customFlow, String? customerId, String? primaryButtonLabel, String? customerEphemeralKeySecret, String? customerSessionClientSecret, String? paymentIntentClientSecret, String? setupIntentClientSecret, IntentConfiguration? intentConfiguration, String? merchantDisplayName, PaymentSheetApplePay? applePay,@JsonKey(toJson: UserInterfaceStyleKey.toJson) ThemeMode? style, PaymentSheetGooglePay? googlePay, LinkDisplayParams? linkDisplayParams, bool allowsDelayedPaymentMethods, PaymentSheetAppearance? appearance,@JsonKey(name: 'defaultBillingDetails') BillingDetails? billingDetails, bool? allowsRemovalOfLastSavedPaymentMethod, List<String>? paymentMethodOrder, String? returnURL, BillingDetailsCollectionConfiguration? billingDetailsCollectionConfiguration, String? removeSavedPaymentMethodMessage,@JsonKey(toJson: _cardBrandListToJson) List<CardBrand>? preferredNetworks, CardBrandAcceptance? cardBrandAcceptance, CardFundingFiltering? cardFundingFiltering, CustomPaymentMethodConfiguration? customPaymentMethodConfiguration, bool? opensCardScannerAutomatically,@JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson) Map<String, TermsDisplay>? termsDisplay
+ bool customFlow, String? customerId, String? primaryButtonLabel, String? customerEphemeralKeySecret, String? customerSessionClientSecret, String? paymentIntentClientSecret, String? setupIntentClientSecret, IntentConfiguration? intentConfiguration, String? merchantDisplayName, PaymentSheetApplePay? applePay,@JsonKey(toJson: UserInterfaceStyleKey.toJson) ThemeMode? style, PaymentSheetGooglePay? googlePay,@JsonKey(name: 'link') LinkDisplayParams? linkDisplayParams, bool allowsDelayedPaymentMethods, PaymentSheetAppearance? appearance,@JsonKey(name: 'defaultBillingDetails') BillingDetails? billingDetails, bool? allowsRemovalOfLastSavedPaymentMethod, List<String>? paymentMethodOrder, String? returnURL, BillingDetailsCollectionConfiguration? billingDetailsCollectionConfiguration, String? removeSavedPaymentMethodMessage,@JsonKey(toJson: _cardBrandListToJson) List<CardBrand>? preferredNetworks, CardBrandAcceptance? cardBrandAcceptance, CardFundingFiltering? cardFundingFiltering, CustomPaymentMethodConfiguration? customPaymentMethodConfiguration, bool? opensCardScannerAutomatically,@JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson) Map<String, TermsDisplay>? termsDisplay
 });
 
 
@@ -379,7 +379,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool customFlow,  String? customerId,  String? primaryButtonLabel,  String? customerEphemeralKeySecret,  String? customerSessionClientSecret,  String? paymentIntentClientSecret,  String? setupIntentClientSecret,  IntentConfiguration? intentConfiguration,  String? merchantDisplayName,  PaymentSheetApplePay? applePay, @JsonKey(toJson: UserInterfaceStyleKey.toJson)  ThemeMode? style,  PaymentSheetGooglePay? googlePay,  LinkDisplayParams? linkDisplayParams,  bool allowsDelayedPaymentMethods,  PaymentSheetAppearance? appearance, @JsonKey(name: 'defaultBillingDetails')  BillingDetails? billingDetails,  bool? allowsRemovalOfLastSavedPaymentMethod,  List<String>? paymentMethodOrder,  String? returnURL,  BillingDetailsCollectionConfiguration? billingDetailsCollectionConfiguration,  String? removeSavedPaymentMethodMessage, @JsonKey(toJson: _cardBrandListToJson)  List<CardBrand>? preferredNetworks,  CardBrandAcceptance? cardBrandAcceptance,  CardFundingFiltering? cardFundingFiltering,  CustomPaymentMethodConfiguration? customPaymentMethodConfiguration,  bool? opensCardScannerAutomatically, @JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson)  Map<String, TermsDisplay>? termsDisplay)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool customFlow,  String? customerId,  String? primaryButtonLabel,  String? customerEphemeralKeySecret,  String? customerSessionClientSecret,  String? paymentIntentClientSecret,  String? setupIntentClientSecret,  IntentConfiguration? intentConfiguration,  String? merchantDisplayName,  PaymentSheetApplePay? applePay, @JsonKey(toJson: UserInterfaceStyleKey.toJson)  ThemeMode? style,  PaymentSheetGooglePay? googlePay, @JsonKey(name: 'link')  LinkDisplayParams? linkDisplayParams,  bool allowsDelayedPaymentMethods,  PaymentSheetAppearance? appearance, @JsonKey(name: 'defaultBillingDetails')  BillingDetails? billingDetails,  bool? allowsRemovalOfLastSavedPaymentMethod,  List<String>? paymentMethodOrder,  String? returnURL,  BillingDetailsCollectionConfiguration? billingDetailsCollectionConfiguration,  String? removeSavedPaymentMethodMessage, @JsonKey(toJson: _cardBrandListToJson)  List<CardBrand>? preferredNetworks,  CardBrandAcceptance? cardBrandAcceptance,  CardFundingFiltering? cardFundingFiltering,  CustomPaymentMethodConfiguration? customPaymentMethodConfiguration,  bool? opensCardScannerAutomatically, @JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson)  Map<String, TermsDisplay>? termsDisplay)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _SetupParameters() when $default != null:
 return $default(_that.customFlow,_that.customerId,_that.primaryButtonLabel,_that.customerEphemeralKeySecret,_that.customerSessionClientSecret,_that.paymentIntentClientSecret,_that.setupIntentClientSecret,_that.intentConfiguration,_that.merchantDisplayName,_that.applePay,_that.style,_that.googlePay,_that.linkDisplayParams,_that.allowsDelayedPaymentMethods,_that.appearance,_that.billingDetails,_that.allowsRemovalOfLastSavedPaymentMethod,_that.paymentMethodOrder,_that.returnURL,_that.billingDetailsCollectionConfiguration,_that.removeSavedPaymentMethodMessage,_that.preferredNetworks,_that.cardBrandAcceptance,_that.cardFundingFiltering,_that.customPaymentMethodConfiguration,_that.opensCardScannerAutomatically,_that.termsDisplay);case _:
@@ -400,7 +400,7 @@ return $default(_that.customFlow,_that.customerId,_that.primaryButtonLabel,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool customFlow,  String? customerId,  String? primaryButtonLabel,  String? customerEphemeralKeySecret,  String? customerSessionClientSecret,  String? paymentIntentClientSecret,  String? setupIntentClientSecret,  IntentConfiguration? intentConfiguration,  String? merchantDisplayName,  PaymentSheetApplePay? applePay, @JsonKey(toJson: UserInterfaceStyleKey.toJson)  ThemeMode? style,  PaymentSheetGooglePay? googlePay,  LinkDisplayParams? linkDisplayParams,  bool allowsDelayedPaymentMethods,  PaymentSheetAppearance? appearance, @JsonKey(name: 'defaultBillingDetails')  BillingDetails? billingDetails,  bool? allowsRemovalOfLastSavedPaymentMethod,  List<String>? paymentMethodOrder,  String? returnURL,  BillingDetailsCollectionConfiguration? billingDetailsCollectionConfiguration,  String? removeSavedPaymentMethodMessage, @JsonKey(toJson: _cardBrandListToJson)  List<CardBrand>? preferredNetworks,  CardBrandAcceptance? cardBrandAcceptance,  CardFundingFiltering? cardFundingFiltering,  CustomPaymentMethodConfiguration? customPaymentMethodConfiguration,  bool? opensCardScannerAutomatically, @JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson)  Map<String, TermsDisplay>? termsDisplay)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool customFlow,  String? customerId,  String? primaryButtonLabel,  String? customerEphemeralKeySecret,  String? customerSessionClientSecret,  String? paymentIntentClientSecret,  String? setupIntentClientSecret,  IntentConfiguration? intentConfiguration,  String? merchantDisplayName,  PaymentSheetApplePay? applePay, @JsonKey(toJson: UserInterfaceStyleKey.toJson)  ThemeMode? style,  PaymentSheetGooglePay? googlePay, @JsonKey(name: 'link')  LinkDisplayParams? linkDisplayParams,  bool allowsDelayedPaymentMethods,  PaymentSheetAppearance? appearance, @JsonKey(name: 'defaultBillingDetails')  BillingDetails? billingDetails,  bool? allowsRemovalOfLastSavedPaymentMethod,  List<String>? paymentMethodOrder,  String? returnURL,  BillingDetailsCollectionConfiguration? billingDetailsCollectionConfiguration,  String? removeSavedPaymentMethodMessage, @JsonKey(toJson: _cardBrandListToJson)  List<CardBrand>? preferredNetworks,  CardBrandAcceptance? cardBrandAcceptance,  CardFundingFiltering? cardFundingFiltering,  CustomPaymentMethodConfiguration? customPaymentMethodConfiguration,  bool? opensCardScannerAutomatically, @JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson)  Map<String, TermsDisplay>? termsDisplay)  $default,) {final _that = this;
 switch (_that) {
 case _SetupParameters():
 return $default(_that.customFlow,_that.customerId,_that.primaryButtonLabel,_that.customerEphemeralKeySecret,_that.customerSessionClientSecret,_that.paymentIntentClientSecret,_that.setupIntentClientSecret,_that.intentConfiguration,_that.merchantDisplayName,_that.applePay,_that.style,_that.googlePay,_that.linkDisplayParams,_that.allowsDelayedPaymentMethods,_that.appearance,_that.billingDetails,_that.allowsRemovalOfLastSavedPaymentMethod,_that.paymentMethodOrder,_that.returnURL,_that.billingDetailsCollectionConfiguration,_that.removeSavedPaymentMethodMessage,_that.preferredNetworks,_that.cardBrandAcceptance,_that.cardFundingFiltering,_that.customPaymentMethodConfiguration,_that.opensCardScannerAutomatically,_that.termsDisplay);case _:
@@ -420,7 +420,7 @@ return $default(_that.customFlow,_that.customerId,_that.primaryButtonLabel,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool customFlow,  String? customerId,  String? primaryButtonLabel,  String? customerEphemeralKeySecret,  String? customerSessionClientSecret,  String? paymentIntentClientSecret,  String? setupIntentClientSecret,  IntentConfiguration? intentConfiguration,  String? merchantDisplayName,  PaymentSheetApplePay? applePay, @JsonKey(toJson: UserInterfaceStyleKey.toJson)  ThemeMode? style,  PaymentSheetGooglePay? googlePay,  LinkDisplayParams? linkDisplayParams,  bool allowsDelayedPaymentMethods,  PaymentSheetAppearance? appearance, @JsonKey(name: 'defaultBillingDetails')  BillingDetails? billingDetails,  bool? allowsRemovalOfLastSavedPaymentMethod,  List<String>? paymentMethodOrder,  String? returnURL,  BillingDetailsCollectionConfiguration? billingDetailsCollectionConfiguration,  String? removeSavedPaymentMethodMessage, @JsonKey(toJson: _cardBrandListToJson)  List<CardBrand>? preferredNetworks,  CardBrandAcceptance? cardBrandAcceptance,  CardFundingFiltering? cardFundingFiltering,  CustomPaymentMethodConfiguration? customPaymentMethodConfiguration,  bool? opensCardScannerAutomatically, @JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson)  Map<String, TermsDisplay>? termsDisplay)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool customFlow,  String? customerId,  String? primaryButtonLabel,  String? customerEphemeralKeySecret,  String? customerSessionClientSecret,  String? paymentIntentClientSecret,  String? setupIntentClientSecret,  IntentConfiguration? intentConfiguration,  String? merchantDisplayName,  PaymentSheetApplePay? applePay, @JsonKey(toJson: UserInterfaceStyleKey.toJson)  ThemeMode? style,  PaymentSheetGooglePay? googlePay, @JsonKey(name: 'link')  LinkDisplayParams? linkDisplayParams,  bool allowsDelayedPaymentMethods,  PaymentSheetAppearance? appearance, @JsonKey(name: 'defaultBillingDetails')  BillingDetails? billingDetails,  bool? allowsRemovalOfLastSavedPaymentMethod,  List<String>? paymentMethodOrder,  String? returnURL,  BillingDetailsCollectionConfiguration? billingDetailsCollectionConfiguration,  String? removeSavedPaymentMethodMessage, @JsonKey(toJson: _cardBrandListToJson)  List<CardBrand>? preferredNetworks,  CardBrandAcceptance? cardBrandAcceptance,  CardFundingFiltering? cardFundingFiltering,  CustomPaymentMethodConfiguration? customPaymentMethodConfiguration,  bool? opensCardScannerAutomatically, @JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson)  Map<String, TermsDisplay>? termsDisplay)?  $default,) {final _that = this;
 switch (_that) {
 case _SetupParameters() when $default != null:
 return $default(_that.customFlow,_that.customerId,_that.primaryButtonLabel,_that.customerEphemeralKeySecret,_that.customerSessionClientSecret,_that.paymentIntentClientSecret,_that.setupIntentClientSecret,_that.intentConfiguration,_that.merchantDisplayName,_that.applePay,_that.style,_that.googlePay,_that.linkDisplayParams,_that.allowsDelayedPaymentMethods,_that.appearance,_that.billingDetails,_that.allowsRemovalOfLastSavedPaymentMethod,_that.paymentMethodOrder,_that.returnURL,_that.billingDetailsCollectionConfiguration,_that.removeSavedPaymentMethodMessage,_that.preferredNetworks,_that.cardBrandAcceptance,_that.cardFundingFiltering,_that.customPaymentMethodConfiguration,_that.opensCardScannerAutomatically,_that.termsDisplay);case _:
@@ -435,7 +435,7 @@ return $default(_that.customFlow,_that.customerId,_that.primaryButtonLabel,_that
 
 @JsonSerializable(explicitToJson: true)
 class _SetupParameters implements SetupPaymentSheetParameters {
-  const _SetupParameters({this.customFlow = false, this.customerId, this.primaryButtonLabel, this.customerEphemeralKeySecret, this.customerSessionClientSecret, this.paymentIntentClientSecret, this.setupIntentClientSecret, this.intentConfiguration, this.merchantDisplayName, this.applePay, @JsonKey(toJson: UserInterfaceStyleKey.toJson) this.style, this.googlePay, this.linkDisplayParams, this.allowsDelayedPaymentMethods = false, this.appearance, @JsonKey(name: 'defaultBillingDetails') this.billingDetails, this.allowsRemovalOfLastSavedPaymentMethod, final  List<String>? paymentMethodOrder, this.returnURL, this.billingDetailsCollectionConfiguration, this.removeSavedPaymentMethodMessage, @JsonKey(toJson: _cardBrandListToJson) final  List<CardBrand>? preferredNetworks, this.cardBrandAcceptance, this.cardFundingFiltering, this.customPaymentMethodConfiguration, this.opensCardScannerAutomatically, @JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson) final  Map<String, TermsDisplay>? termsDisplay}): _paymentMethodOrder = paymentMethodOrder,_preferredNetworks = preferredNetworks,_termsDisplay = termsDisplay;
+  const _SetupParameters({this.customFlow = false, this.customerId, this.primaryButtonLabel, this.customerEphemeralKeySecret, this.customerSessionClientSecret, this.paymentIntentClientSecret, this.setupIntentClientSecret, this.intentConfiguration, this.merchantDisplayName, this.applePay, @JsonKey(toJson: UserInterfaceStyleKey.toJson) this.style, this.googlePay, @JsonKey(name: 'link') this.linkDisplayParams, this.allowsDelayedPaymentMethods = false, this.appearance, @JsonKey(name: 'defaultBillingDetails') this.billingDetails, this.allowsRemovalOfLastSavedPaymentMethod, final  List<String>? paymentMethodOrder, this.returnURL, this.billingDetailsCollectionConfiguration, this.removeSavedPaymentMethodMessage, @JsonKey(toJson: _cardBrandListToJson) final  List<CardBrand>? preferredNetworks, this.cardBrandAcceptance, this.cardFundingFiltering, this.customPaymentMethodConfiguration, this.opensCardScannerAutomatically, @JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson) final  Map<String, TermsDisplay>? termsDisplay}): _paymentMethodOrder = paymentMethodOrder,_preferredNetworks = preferredNetworks,_termsDisplay = termsDisplay;
   factory _SetupParameters.fromJson(Map<String, dynamic> json) => _$SetupParametersFromJson(json);
 
 /// Whether or not to use a custom flow.
@@ -478,7 +478,7 @@ class _SetupParameters implements SetupPaymentSheetParameters {
 /// If set, PaymentSheet displays Google Pay as a payment option
 @override final  PaymentSheetGooglePay? googlePay;
 /// Configuration related to Link
-@override final  LinkDisplayParams? linkDisplayParams;
+@override@JsonKey(name: 'link') final  LinkDisplayParams? linkDisplayParams;
 /// Flag that allows payment methods that do not move money at the send of the checkout.
 ///
 /// Defaul value is false.
@@ -609,7 +609,7 @@ abstract mixin class _$SetupParametersCopyWith<$Res> implements $SetupPaymentShe
   factory _$SetupParametersCopyWith(_SetupParameters value, $Res Function(_SetupParameters) _then) = __$SetupParametersCopyWithImpl;
 @override @useResult
 $Res call({
- bool customFlow, String? customerId, String? primaryButtonLabel, String? customerEphemeralKeySecret, String? customerSessionClientSecret, String? paymentIntentClientSecret, String? setupIntentClientSecret, IntentConfiguration? intentConfiguration, String? merchantDisplayName, PaymentSheetApplePay? applePay,@JsonKey(toJson: UserInterfaceStyleKey.toJson) ThemeMode? style, PaymentSheetGooglePay? googlePay, LinkDisplayParams? linkDisplayParams, bool allowsDelayedPaymentMethods, PaymentSheetAppearance? appearance,@JsonKey(name: 'defaultBillingDetails') BillingDetails? billingDetails, bool? allowsRemovalOfLastSavedPaymentMethod, List<String>? paymentMethodOrder, String? returnURL, BillingDetailsCollectionConfiguration? billingDetailsCollectionConfiguration, String? removeSavedPaymentMethodMessage,@JsonKey(toJson: _cardBrandListToJson) List<CardBrand>? preferredNetworks, CardBrandAcceptance? cardBrandAcceptance, CardFundingFiltering? cardFundingFiltering, CustomPaymentMethodConfiguration? customPaymentMethodConfiguration, bool? opensCardScannerAutomatically,@JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson) Map<String, TermsDisplay>? termsDisplay
+ bool customFlow, String? customerId, String? primaryButtonLabel, String? customerEphemeralKeySecret, String? customerSessionClientSecret, String? paymentIntentClientSecret, String? setupIntentClientSecret, IntentConfiguration? intentConfiguration, String? merchantDisplayName, PaymentSheetApplePay? applePay,@JsonKey(toJson: UserInterfaceStyleKey.toJson) ThemeMode? style, PaymentSheetGooglePay? googlePay,@JsonKey(name: 'link') LinkDisplayParams? linkDisplayParams, bool allowsDelayedPaymentMethods, PaymentSheetAppearance? appearance,@JsonKey(name: 'defaultBillingDetails') BillingDetails? billingDetails, bool? allowsRemovalOfLastSavedPaymentMethod, List<String>? paymentMethodOrder, String? returnURL, BillingDetailsCollectionConfiguration? billingDetailsCollectionConfiguration, String? removeSavedPaymentMethodMessage,@JsonKey(toJson: _cardBrandListToJson) List<CardBrand>? preferredNetworks, CardBrandAcceptance? cardBrandAcceptance, CardFundingFiltering? cardFundingFiltering, CustomPaymentMethodConfiguration? customPaymentMethodConfiguration, bool? opensCardScannerAutomatically,@JsonKey(toJson: _termsDisplayToJson, fromJson: _termsDisplayFromJson) Map<String, TermsDisplay>? termsDisplay
 });
 
 
@@ -6554,7 +6554,7 @@ as List<CardBrandCategory>,
 mixin _$LinkDisplayParams {
 
 /// Display configuration for Link
- LinkDisplay get linkDisplay;
+@JsonKey(name: 'display') LinkDisplay get linkDisplay;
 /// Create a copy of LinkDisplayParams
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -6587,7 +6587,7 @@ abstract mixin class $LinkDisplayParamsCopyWith<$Res>  {
   factory $LinkDisplayParamsCopyWith(LinkDisplayParams value, $Res Function(LinkDisplayParams) _then) = _$LinkDisplayParamsCopyWithImpl;
 @useResult
 $Res call({
- LinkDisplay linkDisplay
+@JsonKey(name: 'display') LinkDisplay linkDisplay
 });
 
 
@@ -6692,7 +6692,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( LinkDisplay linkDisplay)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'display')  LinkDisplay linkDisplay)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _LinkDisplayParams() when $default != null:
 return $default(_that.linkDisplay);case _:
@@ -6713,7 +6713,7 @@ return $default(_that.linkDisplay);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( LinkDisplay linkDisplay)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'display')  LinkDisplay linkDisplay)  $default,) {final _that = this;
 switch (_that) {
 case _LinkDisplayParams():
 return $default(_that.linkDisplay);case _:
@@ -6733,7 +6733,7 @@ return $default(_that.linkDisplay);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( LinkDisplay linkDisplay)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'display')  LinkDisplay linkDisplay)?  $default,) {final _that = this;
 switch (_that) {
 case _LinkDisplayParams() when $default != null:
 return $default(_that.linkDisplay);case _:
@@ -6748,11 +6748,11 @@ return $default(_that.linkDisplay);case _:
 @JsonSerializable()
 
 class _LinkDisplayParams implements LinkDisplayParams {
-  const _LinkDisplayParams({required this.linkDisplay});
+  const _LinkDisplayParams({@JsonKey(name: 'display') required this.linkDisplay});
   factory _LinkDisplayParams.fromJson(Map<String, dynamic> json) => _$LinkDisplayParamsFromJson(json);
 
 /// Display configuration for Link
-@override final  LinkDisplay linkDisplay;
+@override@JsonKey(name: 'display') final  LinkDisplay linkDisplay;
 
 /// Create a copy of LinkDisplayParams
 /// with the given fields replaced by the non-null parameter values.
@@ -6787,7 +6787,7 @@ abstract mixin class _$LinkDisplayParamsCopyWith<$Res> implements $LinkDisplayPa
   factory _$LinkDisplayParamsCopyWith(_LinkDisplayParams value, $Res Function(_LinkDisplayParams) _then) = __$LinkDisplayParamsCopyWithImpl;
 @override @useResult
 $Res call({
- LinkDisplay linkDisplay
+@JsonKey(name: 'display') LinkDisplay linkDisplay
 });
 
 

--- a/packages/stripe_platform_interface/lib/src/models/payment_sheet.g.dart
+++ b/packages/stripe_platform_interface/lib/src/models/payment_sheet.g.dart
@@ -31,11 +31,9 @@ _SetupParameters _$SetupParametersFromJson(
       : PaymentSheetGooglePay.fromJson(
           json['googlePay'] as Map<String, dynamic>,
         ),
-  linkDisplayParams: json['linkDisplayParams'] == null
+  linkDisplayParams: json['link'] == null
       ? null
-      : LinkDisplayParams.fromJson(
-          json['linkDisplayParams'] as Map<String, dynamic>,
-        ),
+      : LinkDisplayParams.fromJson(json['link'] as Map<String, dynamic>),
   allowsDelayedPaymentMethods:
       json['allowsDelayedPaymentMethods'] as bool? ?? false,
   appearance: json['appearance'] == null
@@ -102,7 +100,7 @@ Map<String, dynamic> _$SetupParametersToJson(
   'applePay': instance.applePay?.toJson(),
   'style': UserInterfaceStyleKey.toJson(instance.style),
   'googlePay': instance.googlePay?.toJson(),
-  'linkDisplayParams': instance.linkDisplayParams?.toJson(),
+  'link': instance.linkDisplayParams?.toJson(),
   'allowsDelayedPaymentMethods': instance.allowsDelayedPaymentMethods,
   'appearance': instance.appearance?.toJson(),
   'defaultBillingDetails': instance.billingDetails?.toJson(),
@@ -643,13 +641,11 @@ Map<String, dynamic> _$CardBrandAcceptanceDisallowedToJson(
 
 _LinkDisplayParams _$LinkDisplayParamsFromJson(Map<String, dynamic> json) =>
     _LinkDisplayParams(
-      linkDisplay: $enumDecode(_$LinkDisplayEnumMap, json['linkDisplay']),
+      linkDisplay: $enumDecode(_$LinkDisplayEnumMap, json['display']),
     );
 
 Map<String, dynamic> _$LinkDisplayParamsToJson(_LinkDisplayParams instance) =>
-    <String, dynamic>{
-      'linkDisplay': _$LinkDisplayEnumMap[instance.linkDisplay]!,
-    };
+    <String, dynamic>{'display': _$LinkDisplayEnumMap[instance.linkDisplay]!};
 
 const _$LinkDisplayEnumMap = {
   LinkDisplay.automatic: 'automatic',

--- a/packages/stripe_platform_interface/test/method_channel_stripe_test.dart
+++ b/packages/stripe_platform_interface/test/method_channel_stripe_test.dart
@@ -327,21 +327,26 @@ void main() {
 
     group('initPaymentSheet', () {
       late Completer<void> completer;
+      late MethodChannelMock methodChannelMock;
       setUp(() async {
         completer = Completer();
+        methodChannelMock = MethodChannelMock(
+          channelName: methodChannelName,
+          method: 'initPaymentSheet',
+          result: {},
+        );
         sut = MethodChannelStripe(
           platformIsIos: false,
           platformIsAndroid: true,
-          methodChannel: MethodChannelMock(
-            channelName: methodChannelName,
-            method: 'initPaymentSheet',
-            result: {},
-          ).methodChannel,
+          methodChannel: methodChannelMock.methodChannel,
         );
         await sut
             .initPaymentSheet(
               const SetupPaymentSheetParameters(
                 paymentIntentClientSecret: 'paymentIntentClientSecret',
+                linkDisplayParams: LinkDisplayParams(
+                  linkDisplay: LinkDisplay.never,
+                ),
               ),
             )
             .then((_) => completer.complete());
@@ -349,6 +354,11 @@ void main() {
 
       test('It completes operation', () {
         expect(completer.isCompleted, true);
+      });
+
+      test('It serializes Link display params using native field names', () {
+        final arguments = methodChannelMock.log.single.arguments as Map;
+        expect(arguments['params'], containsPair('link', {'display': 'never'}));
       });
     });
 


### PR DESCRIPTION
LinkDisplayParams were serialized using the Dart field names `linkDisplayParams` and `linkDisplay`, while the native iOS and Android PaymentSheet implementations expect `link` and `display`.

Add JsonKey annotations to match the native payload fields.

With this change, `LinkDisplayParams` is passed to the native PaymentSheet implementations using the expected fields, for example `LinkDisplayParams(linkDisplay: LinkDisplay.never)` is serialized as `link.display = "never"` and is correctly applied. `automatic` is the default behavior, so it continues to behave the same as before.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. This will ensure for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/flutter-stripe/flutter_stripe/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/flutter-stripe/flutter_stripe/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you developed the feature on the latest stable version of Flutter?
- [ ] Do all checks pass?

`melos run format`:
I ran `melos run format`, but it reformatted unrelated sections in existing files. I did not include those unrelated formatting changes in this PR.

`melos run analyze`:
Warnings are reported in `flutter_stripe` and `flutter_stripe_web`, but there are no issues in `stripe_platform_interface`, which is the package modified in this PR.

`melos run unittest`:
The modified package, `stripe_platform_interface`, passed all tests, including the added `initPaymentSheet` serialization test.

The overall Melos command did not fully pass because other packages do not have runnable Flutter tests:
- `stripe_android`: `Test directory "test" not found.`
- `flutter_stripe`: `No tests were found.`
- `stripe_ios`: `No tests were found.`

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Codex to investigate the bug. I also ran `build_runner` and the relevant Melos commands myself, and manually reviewed the results.

The only code change was adding annotations, which I fully understand.

I ran my app with the corrected version included and manually verified all three cases myself: unset `linkDisplayParams`, using `LinkDisplay.automatic`, and using `LinkDisplay.never`.

To add to that, I am not an English speaker, so I use AI translation for translating and proofreading my texts.

-----


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSON serialization for Link payment configuration parameters to ensure proper transmission of payment sheet settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->