### PR TITLE
fix(android,ios): forward phone, carrier, trackingNumber when mapping ShippingDetails for confirm

### DIFF
--- a/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/utils/Mappers.kt
+++ b/packages/stripe_android/android/src/main/kotlin/com/reactnativestripesdk/utils/Mappers.kt
@@ -711,6 +711,9 @@ internal fun mapToShippingDetails(shippingDetails: ReadableMap?): ConfirmPayment
   return ConfirmPaymentIntentParams.Shipping(
     name = getValOr(shippingDetails, "name") ?: "",
     address = address,
+    phone = getValOr(shippingDetails, "phone"),
+    carrier = getValOr(shippingDetails, "carrier"),
+    trackingNumber = getValOr(shippingDetails, "trackingNumber"),
   )
 }
 

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/Mappers.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/Mappers.swift
@@ -560,6 +560,9 @@ class Mappers {
         }
 
         let shipping = STPPaymentIntentShippingDetailsParams(address: shippingAddress, name: shippingDetails["name"] as? String ?? "")
+        shipping.phone = shippingDetails["phone"] as? String
+        shipping.carrier = shippingDetails["carrier"] as? String
+        shipping.trackingNumber = shippingDetails["trackingNumber"] as? String
 
         return shipping
     }


### PR DESCRIPTION
## Summary

The shipping-details mappers in both `stripe_android` and `stripe_ios` silently dropped `phone`, `carrier`, and `trackingNumber` when converting the Dart `ShippingDetails` map into the underlying SDK shipping params used by `confirmPayment` / `confirmSetupIntent`. Only `address` and `name` were forwarded — the other three fields, which the underlying native SDKs fully support, were never copied over.

This PR wires them through. The Stripe Android `ConfirmPaymentIntentParams.Shipping` constructor already accepts these fields ([API ref](https://stripe.dev/stripe-android/payments-core/com.stripe.android.model/-confirm-payment-intent-params/-shipping/index.html)), and the iOS `STPPaymentIntentShippingDetailsParams` exposes them as settable properties.

## Where this hurts in practice

The most visible symptom is on Android with Google Pay's two-step flow (`createPlatformPayPaymentMethod` followed by `confirmPayment`) — the only path that lets you collect a shipping address through the GPay sheet via `shippingAddressConfig`.

1. The user fills in shipping in the GPay sheet, including a phone number.
2. The phone arrives in Dart on `pmResult.shippingContact.phoneNumber`.
3. The caller passes a `ShippingDetails(phone: ...)` to `confirmPayment`.
4. The mapper drops the field on the floor → `paymentIntent.shipping.phone` ends up `null`.
5. Backend webhook handlers reading `paymentIntent.shipping.phone` (e.g. for delivery contact) get nothing.

The address and name show up server-side; the phone doesn't. Same shape on iOS for any caller passing `phone`/`carrier`/`trackingNumber` through `confirmPayment`.

## Changes

**`packages/stripe_android/.../utils/Mappers.kt`** — `mapToShippingDetails` now forwards `phone`, `carrier`, `trackingNumber`:

```kotlin
return ConfirmPaymentIntentParams.Shipping(
  name = getValOr(shippingDetails, "name") ?: "",
  address = address,
  phone = getValOr(shippingDetails, "phone"),
  carrier = getValOr(shippingDetails, "carrier"),
  trackingNumber = getValOr(shippingDetails, "trackingNumber"),
)
```

**`packages/stripe_ios/.../Mappers.swift`** — `mapToShippingDetails` sets the same fields on `STPPaymentIntentShippingDetailsParams`:

```swift
let shipping = STPPaymentIntentShippingDetailsParams(address: shippingAddress, name: shippingDetails["name"] as? String ?? "")
shipping.phone = shippingDetails["phone"] as? String
shipping.carrier = shippingDetails["carrier"] as? String
shipping.trackingNumber = shippingDetails["trackingNumber"] as? String
```

JSON keys (`phone`, `carrier`, `trackingNumber`) match what `ShippingDetails.toJson()` emits in `stripe_platform_interface` — verified against the generated `payment_intents.g.dart`.

## Test plan

- [ ] Android: Google Pay sheet with `shippingAddressConfig: isRequired = true` and a `phoneNumberRequired` row. Pass the resulting `pmResult.shippingContact` into `confirmPayment(shippingDetails: ...)`. Inspect the resulting `paymentIntent.shipping.phone` (and the request body Stripe receives) — phone is now present.
- [ ] iOS: pass a `ShippingDetails(phone: ...)` to `confirmPayment`. Check `paymentIntent.shipping.phone` is set.
- [ ] Existing flows that don't supply phone/carrier/trackingNumber: unchanged (the new fields default to `null`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shipping details now capture phone number, carrier, and tracking number information across Android and iOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->