### PR TITLE
fix(stripe_ios): allow confirmPayment without params (possible regression)

### DIFF
--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl.swift
@@ -880,7 +880,7 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
     @objc(confirmPayment:data:options:resolver:rejecter:)
     public func confirmPayment(
         paymentIntentClientSecret: String,
-        params: NSDictionary,
+        params: NSDictionary?,
         options: NSDictionary,
         resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
@@ -888,10 +888,8 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
         self.confirmPaymentResolver = resolve
         self.confirmPaymentClientSecret = paymentIntentClientSecret
 
-        // Handle React Native null values - when null is passed from JS, it becomes NSNull
-        let actualParams = (params == NSNull()) ? nil : params
-        let paymentMethodData = actualParams?["paymentMethodData"] as? NSDictionary
-        let (missingPaymentMethodError, paymentMethodType) = getPaymentMethodType(params: actualParams)
+        let paymentMethodData = params?["paymentMethodData"] as? NSDictionary
+        let (missingPaymentMethodError, paymentMethodType) = getPaymentMethodType(params: params)
         if missingPaymentMethodError != nil {
             resolve(missingPaymentMethodError)
             return

--- a/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift
@@ -637,11 +637,11 @@ extension  StripePlugin {
     func confirmPayment(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let arguments = call.arguments as? FlutterMap,
               let paymentIntentClientSecret = arguments["paymentIntentClientSecret"] as? String,
-              let options = arguments["options"] as? NSDictionary,
-              let params = arguments["params"] as? NSDictionary else {
+              let options = arguments["options"] as? NSDictionary else {
             result(FlutterError.invalidParams)
             return
         }
+        let params = arguments["params"] as? NSDictionary
         
         confirmPayment(
             paymentIntentClientSecret: paymentIntentClientSecret,

--- a/packages/stripe_ios/test/stripe_ios_test.dart
+++ b/packages/stripe_ios/test/stripe_ios_test.dart
@@ -1,1 +1,41 @@
-void main() {}
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('confirmPayment handler accepts omitted params', () {
+    final source = File(
+      'ios/stripe_ios/Sources/stripe_ios/StripePlugin.swift',
+    ).readAsStringSync();
+
+    final handlerStart = source.indexOf(
+      'func confirmPayment(_ call: FlutterMethodCall',
+    );
+    final nextHandlerStart = source.indexOf(
+      'func retrievePaymentIntent',
+      handlerStart,
+    );
+    final handler = source.substring(handlerStart, nextHandlerStart);
+
+    expect(
+      handler,
+      isNot(contains('let params = arguments["params"] as? NSDictionary else')),
+    );
+    expect(
+      handler,
+      contains('let params = arguments["params"] as? NSDictionary'),
+    );
+  });
+
+  test('confirmPayment implementation keeps params nullable', () {
+    final source = File(
+      'ios/stripe_ios/Sources/stripe_ios/Stripe Sdk/StripeSdkImpl.swift',
+    ).readAsStringSync();
+
+    final methodStart = source.indexOf('public func confirmPayment(');
+    final methodBodyStart = source.indexOf(') {', methodStart);
+    final signature = source.substring(methodStart, methodBodyStart);
+
+    expect(signature, contains('params: NSDictionary?'));
+  });
+}


### PR DESCRIPTION
## Summary

This restores the iOS `confirmPayment` behavior where `params` can be omitted when the PaymentIntent already has a payment method attached server-side.

`PaymentMethodParams?` is still nullable in the Dart platform interface, and `MethodChannelStripe.confirmPayment` still sends `params: null` when `Stripe.instance.confirmPayment(...)` is called without `data`. In `stripe_ios` 12.x, the iOS method-channel handler rejects that call before the existing native server-attached-payment-method path can run.

Related to #2282, #2287, and the older #1246.

## Reproduction

This fails on iOS with `flutter_stripe >= 12.x` when confirming a PaymentIntent whose payment method is attached by the backend.

```dart
final paymentMethod = await Stripe.instance.createPlatformPayPaymentMethod(
  params: PlatformPayPaymentMethodParams.applePay(
    applePayParams: ApplePayParams(
      merchantCountryCode: 'IT',
      currencyCode: 'EUR',
      cartItems: [
        ApplePayCartSummaryItem.immediate(
          label: 'Test purchase',
          amount: '10.90',
        ),
      ],
    ),
  ),
);

// Send paymentMethod.id to the backend.
// Backend creates a PaymentIntent with this payment method attached
// and returns the PaymentIntent client secret.
await Stripe.instance.confirmPayment(
  paymentIntentClientSecret: clientSecret,
);
```

Actual result:

```txt
PlatformException(Invalid Params, , , null)
```

Expected result:

`confirmPayment` should continue into the native Stripe confirmation flow because this flow is valid when the payment method was attached server-side.

## Regression Cause

The native iOS method-channel handler currently requires `params`:

```swift
let params = arguments["params"] as? NSDictionary
```

inside the `guard`, so a Dart call with `params: null` fails immediately with `FlutterError.invalidParams`.

Older `11.x` behavior treated `params` as optional. `StripeSdkImpl.getPaymentMethodType(params: nil)` already supports this case and leads to:

```swift
STPPaymentIntentParams(clientSecret: paymentIntentClientSecret)
```

This PR restores that optionality at the Flutter method-channel boundary and in the native `confirmPayment` signature.

## Testing

- Added regression coverage in `packages/stripe_ios/test/stripe_ios_test.dart`.
- Verified in a consuming Flutter app with saved card and Apple Pay test-mode purchases.
- Ran `flutter test test/stripe_ios_test.dart` in `packages/stripe_ios`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Stripe iOS SDK's payment confirmation method now allows optional payment parameters, providing greater flexibility in payment processing workflows.

* **Tests**
  * Added test coverage to validate optional parameter handling and method signature behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flutter-stripe/flutter_stripe/pull/2415)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->