### PR TITLE
test: lock down PaymentSheet wire-format contract for @JsonKey renames

### DIFF
--- a/packages/stripe_platform_interface/test/method_channel_stripe_test.dart
+++ b/packages/stripe_platform_interface/test/method_channel_stripe_test.dart
@@ -389,6 +389,7 @@ void main() {
         );
         expect(params.containsKey('defaultBillingDetails'), isTrue);
         expect(params.containsKey('billingDetails'), isFalse);
+        expect((params['defaultBillingDetails'] as Map)['email'], 'a@b.com');
       });
 
       test(
@@ -409,6 +410,9 @@ void main() {
               params['customPaymentMethodConfiguration']
                   as Map<dynamic, dynamic>;
           expect(config.containsKey('customPaymentMethods'), isTrue);
+          final methods = config['customPaymentMethods'] as List;
+          expect(methods, isNotEmpty);
+          expect((methods.first as Map)['id'], 'cpmt_test');
         },
       );
     });

--- a/packages/stripe_platform_interface/test/method_channel_stripe_test.dart
+++ b/packages/stripe_platform_interface/test/method_channel_stripe_test.dart
@@ -362,6 +362,53 @@ void main() {
       });
     });
 
+    group('initPaymentSheet wire-format contract', () {
+      Future<Map<dynamic, dynamic>> serialize(
+        SetupPaymentSheetParameters params,
+      ) async {
+        final methodChannelMock = MethodChannelMock(
+          channelName: methodChannelName,
+          method: 'initPaymentSheet',
+          result: {},
+        );
+        final localSut = MethodChannelStripe(
+          platformIsIos: false,
+          platformIsAndroid: true,
+          methodChannel: methodChannelMock.methodChannel,
+        );
+        await localSut.initPaymentSheet(params);
+        return (methodChannelMock.log.single.arguments as Map)['params'] as Map;
+      }
+
+      test('billingDetails is sent as "defaultBillingDetails"', () async {
+        final params = await serialize(
+          const SetupPaymentSheetParameters(
+            paymentIntentClientSecret: 'pi_test',
+            billingDetails: BillingDetails(email: 'a@b.com'),
+          ),
+        );
+        expect(params.containsKey('defaultBillingDetails'), isTrue);
+        expect(params.containsKey('billingDetails'), isFalse);
+      });
+
+      test(
+        'customPaymentMethodConfiguration nests customPaymentMethods array',
+        () async {
+          final params = await serialize(
+            const SetupPaymentSheetParameters(
+              paymentIntentClientSecret: 'pi_test',
+              customPaymentMethodConfiguration: CustomPaymentMethodConfiguration(
+                customPaymentMethods: [CustomPaymentMethod(id: 'cpmt_test')],
+              ),
+            ),
+          );
+          final config =
+              params['customPaymentMethodConfiguration'] as Map<dynamic, dynamic>;
+          expect(config.containsKey('customPaymentMethods'), isTrue);
+        },
+      );
+    });
+
     group('Reset payment sheet', () {
       late Completer<void> completer;
 

--- a/packages/stripe_platform_interface/test/method_channel_stripe_test.dart
+++ b/packages/stripe_platform_interface/test/method_channel_stripe_test.dart
@@ -397,13 +397,17 @@ void main() {
           final params = await serialize(
             const SetupPaymentSheetParameters(
               paymentIntentClientSecret: 'pi_test',
-              customPaymentMethodConfiguration: CustomPaymentMethodConfiguration(
-                customPaymentMethods: [CustomPaymentMethod(id: 'cpmt_test')],
-              ),
+              customPaymentMethodConfiguration:
+                  CustomPaymentMethodConfiguration(
+                    customPaymentMethods: [
+                      CustomPaymentMethod(id: 'cpmt_test'),
+                    ],
+                  ),
             ),
           );
           final config =
-              params['customPaymentMethodConfiguration'] as Map<dynamic, dynamic>;
+              params['customPaymentMethodConfiguration']
+                  as Map<dynamic, dynamic>;
           expect(config.containsKey('customPaymentMethods'), isTrue);
         },
       );


### PR DESCRIPTION
## Summary

Add contract tests asserting that `SetupPaymentSheetParameters.toJson()` emits the JSON field names the native iOS and Android handlers actually read. Complements the regression test added in #2407.

## Why

Per `CONTRIBUTING.md`, the native folders (`packages/stripe_ios/ios/.../Stripe Sdk/`, `packages/stripe_android/.../reactnativestripesdk/`) are kept in sync with `stripe-react-native` and are not editable here. That means the Dart side is the only place to enforce the bridge field-name contract — but there is no type-level link between Dart `@JsonKey(name: …)` annotations and the RN-derived native readers, so drift goes silent.

Issue #2398 (`linkDisplayParams` silently ignored) was the third Link-display-class fix in five months (d76710c3, #2313, #2407). #2407 added an inline contract test for `link.display`. This PR extends that approach to the other two `@JsonKey(name: …)` renames in `SetupPaymentSheetParameters`:

- `billingDetails` → `defaultBillingDetails`
  Read by `StripeSdkImpl+PaymentSheet.swift:74`, `StripeSdkImpl+Embedded.swift:354`, `PaymentSheetManager.kt:311`, `EmbeddedPaymentElementViewManager.kt:95`.
- `customPaymentMethodConfiguration.customPaymentMethods`
  Read by `Mappers.kt:1044`.

The tests assert by field name (not full snapshot), so they won't trip on unrelated additions to the params struct.

## Test plan

- [x] `flutter test packages/stripe_platform_interface/test/method_channel_stripe_test.dart` — all 28 tests pass, including the 2 new ones
- [x] `dart format` clean
- [x] `flutter analyze` clean
- [ ] CI re-runs on PR

## AI/LLM disclosure

Per `CONTRIBUTING.md`: this PR was drafted with Claude Code (Anthropic Claude Opus 4.7). The author reviewed all generated code, the tests were run locally, and the author will own all follow-up review comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation tests for payment sheet initialization to ensure billing details are serialized to the expected native key.
  * Added tests confirming custom payment method configuration nests custom payment methods correctly.
  * Improves confidence that payment sheet parameters are formatted consistently across platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flutter-stripe/flutter_stripe/pull/2418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->