### PR TITLE
Add FlutterFramework SwiftPM dep

### DIFF
--- a/packages/stripe_ios/ios/stripe_ios/Package.swift
+++ b/packages/stripe_ios/ios/stripe_ios/Package.swift
@@ -12,12 +12,14 @@ let package = Package(
         .library(name: "stripe-ios", targets: ["stripe_ios"])
     ],
     dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework"),
         .package(url: "https://github.com/stripe/stripe-ios-spm", exact: "25.9.0")
     ],
     targets: [
         .target(
             name: "stripe_ios",
             dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework"),
                 .product(name: "Stripe", package: "stripe-ios-spm"),
                 .product(name: "StripePayments", package: "stripe-ios-spm"),
                 .product(name: "StripePaymentsUI", package: "stripe-ios-spm"),


### PR DESCRIPTION
### DESCRIPTION

- There's a new section into the [migration guide](https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-plugin-authors#how-to-add-swift-package-manager-support-to-an-existing-flutter-plugin). Now, adding `FlutterFramework` dependency is required to avoid a new warning.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. This will ensure for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/flutter-stripe/flutter_stripe/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/flutter-stripe/flutter_stripe/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Do all checks pass?
- [x] Have you developed the feature on the latest stable version of Flutter?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. 
-----

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies and build configuration to incorporate local framework integration for the iOS Stripe module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flutter-stripe/flutter_stripe/pull/2420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->