### PR TITLE
Fix web PaymentElement scrolling in constrained layouts

### DIFF
--- a/packages/stripe_web/lib/src/widgets/payment_element.dart
+++ b/packages/stripe_web/lib/src/widgets/payment_element.dart
@@ -19,11 +19,14 @@ export 'package:stripe_js/stripe_api.dart'
 
 typedef PaymentElementTheme = js.ElementTheme;
 
+const _defaultPaymentElementHeight = 300.0;
+
 class PaymentElement extends StatefulWidget {
   final String clientSecret;
   final String? customerSessionClientSecret;
   final double? width;
   final double? height;
+  final double? maxHeight;
   final CardStyle? style;
   final CardPlaceholder? placeholder;
   final bool enablePostalCode;
@@ -48,6 +51,7 @@ class PaymentElement extends StatefulWidget {
     this.customerSessionClientSecret,
     this.width,
     this.height,
+    this.maxHeight,
     this.style,
     this.placeholder,
     this.enablePostalCode = false,
@@ -65,7 +69,7 @@ class PaymentElement extends StatefulWidget {
     this.terms,
     this.wallets,
     this.applePay,
-  });
+  }) : assert(maxHeight == null || maxHeight > 0);
 
   @override
   State<PaymentElement> createState() => PaymentElementState();
@@ -76,7 +80,8 @@ class PaymentElementState extends State<PaymentElement> {
   final String _viewType = 'stripe_payment_element_${_nextId++}';
 
   web.HTMLDivElement _divElement = web.HTMLDivElement();
-  double height = 300.0;
+  double _effectiveHeight = _defaultPaymentElementHeight;
+  double _measuredContentHeight = _defaultPaymentElementHeight;
   bool _isReady = false;
 
   late final js.JsElementsCreateOptions _cachedCreateOptions;
@@ -84,12 +89,12 @@ class PaymentElementState extends State<PaymentElement> {
 
   late final resizeObserver = web.ResizeObserver(
     ((JSArray<web.ResizeObserverEntry> entries, web.ResizeObserver observer) {
-      if (widget.height == null) {
-        for (final entry in entries.toDart) {
-          final cr = entry.contentRect;
+      for (final entry in entries.toDart) {
+        final stripeElement = entry.target as web.HTMLElement;
+        if (mounted) {
           setState(() {
-            height = cr.height.toDouble();
-            _divElement.style.height = '${height}px';
+            _measuredContentHeight = stripeElement.scrollHeight.toDouble();
+            _applyHostHeight();
           });
         }
       }
@@ -98,14 +103,14 @@ class PaymentElementState extends State<PaymentElement> {
 
   @override
   void initState() {
-    height = widget.height ?? height;
+    _measuredContentHeight = widget.height ?? _defaultPaymentElementHeight;
+    _effectiveHeight = _resolvedHeight;
 
     _divElement = web.HTMLDivElement()
       ..id = 'payment-element'
       ..style.border = 'none'
-      ..style.width = '100%'
-      ..style.height = '${height}px'
-      ..style.minHeight = '${height}px';
+      ..style.width = '100%';
+    _applyHostHeight();
 
     _cachedCreateOptions = _createOptionsOnce();
     _cachedElementOptions = _elementOptionsOnce();
@@ -133,7 +138,10 @@ class PaymentElementState extends State<PaymentElement> {
         ..onReady((_) {
           final stripeEl = _divElement.firstElementChild;
           if (stripeEl != null) {
-            resizeObserver.observe(stripeEl as web.HTMLElement);
+            final stripeElement = stripeEl as web.HTMLElement;
+            resizeObserver.observe(stripeElement);
+            _measuredContentHeight = stripeElement.scrollHeight.toDouble();
+            _applyHostHeight();
           }
           if (mounted) {
             setState(() {
@@ -149,6 +157,34 @@ class PaymentElementState extends State<PaymentElement> {
         (_) => _mountWhenConnected(),
       );
     }
+  }
+
+  double get _resolvedHeight {
+    if (widget.height != null) {
+      return widget.height!;
+    }
+    if (widget.maxHeight != null &&
+        _measuredContentHeight > widget.maxHeight!) {
+      return widget.maxHeight!;
+    }
+    return _measuredContentHeight;
+  }
+
+  bool get _isHeightCapped {
+    return widget.height == null &&
+        widget.maxHeight != null &&
+        _measuredContentHeight > widget.maxHeight!;
+  }
+
+  void _applyHostHeight() {
+    _effectiveHeight = _resolvedHeight;
+    final heightCss = '${_effectiveHeight}px';
+
+    _divElement.style
+      ..height = heightCss
+      ..minHeight = heightCss
+      ..maxHeight = _isHeightCapped ? heightCss : ''
+      ..overflowY = _isHeightCapped ? 'auto' : '';
   }
 
   js.PaymentElement? get element => WebStripe.element as js.PaymentElement?;
@@ -175,7 +211,7 @@ class PaymentElementState extends State<PaymentElement> {
       child: ConstrainedBox(
         constraints: BoxConstraints(
           maxWidth: double.infinity,
-          maxHeight: height,
+          maxHeight: _effectiveHeight,
         ),
         child: Stack(
           children: [
@@ -223,6 +259,11 @@ class PaymentElementState extends State<PaymentElement> {
     if (widget.enablePostalCode != oldWidget.enablePostalCode ||
         widget.placeholder != oldWidget.placeholder ||
         widget.style != oldWidget.style) {}
+    if (widget.height != oldWidget.height ||
+        widget.maxHeight != oldWidget.maxHeight) {
+      _measuredContentHeight = widget.height ?? _measuredContentHeight;
+      setState(_applyHostHeight);
+    }
     super.didUpdateWidget(oldWidget);
   }
 


### PR DESCRIPTION
Fixes `PaymentElement` on web when it is placed inside a constrained layout. Fix #2045

Add an optional `maxHeight`. If Stripe reports content taller than that, the host div is capped and scrolls instead of growing past its parent.

Also adds the missing web stub for `setConfirmHandler` to make the package compile.

I tested the changes on our project, it is running on the old Flutter version (3.32.8), haven't verify on stable Flutter yet.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. This will ensure for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/flutter-stripe/flutter_stripe/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/flutter-stripe/flutter_stripe/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Do all checks pass?
- [ ] Have you developed the feature on the latest stable version of Flutter?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*. 

AI was used to help inspect the existing web implementation and draft the change. I manually reviewed the changes, tested the patched package in a Flutter web app using a constrained payment sheet, and ran package-level analysis/tests locally.

-----

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional maximum height setting for the Payment Element.
  * Payment content now adapts to its rendered size and can scroll when it exceeds the configured maximum height.

* **Bug Fixes**
  * Improved height handling when payment content loads or widget sizing settings change.
  * Added validation to prevent invalid maximum height values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->