### PR TITLE
fix(web): stop mirroring the Stripe iframe's focus into the Flutter focus tree; honour CardField.autofocus

### DIFF
--- a/packages/stripe_web/lib/src/widgets/card_field.dart
+++ b/packages/stripe_web/lib/src/widgets/card_field.dart
@@ -103,8 +103,6 @@ class WebStripeCardState extends State<WebCardField> with CardFieldContext {
               .elements(createElementOptions())
               .createCard(createOptions())
             ..mount(_divElement)
-            ..onBlur((_) => _effectiveNode.unfocus())
-            ..onFocus((_) => _effectiveNode.requestFocus())
             ..onChange(onCardChanged);
     } else {
       WidgetsBinding.instance.addPostFrameCallback(
@@ -140,6 +138,14 @@ class WebStripeCardState extends State<WebCardField> with CardFieldContext {
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Focus(
         focusNode: _effectiveNode,
+        // The Stripe iframe owns its own DOM focus; it must never be mirrored
+        // into the framework. When semantics are enabled (screen readers, or
+        // SemanticsBinding.ensureSemantics), focusing this node makes the
+        // engine move DOM focus to the node's flt-semantics element, which
+        // blurs the iframe the moment it is tapped and makes the field
+        // untypeable.
+        canRequestFocus: false,
+        skipTraversal: true,
         child: ConstrainedBox(
           constraints: constraints,
           child: HtmlElementView(viewType: _viewType),

--- a/packages/stripe_web/lib/src/widgets/card_field.dart
+++ b/packages/stripe_web/lib/src/widgets/card_field.dart
@@ -103,7 +103,15 @@ class WebStripeCardState extends State<WebCardField> with CardFieldContext {
               .elements(createElementOptions())
               .createCard(createOptions())
             ..mount(_divElement)
-            ..onChange(onCardChanged);
+            ..onChange(onCardChanged)
+            // Upstream declares [autofocus] but never acts on it. The iframe
+            // cannot take focus until Stripe reports it ready, so honour the
+            // flag from the ready event rather than straight after mount.
+            // Mobile browsers still refuse to raise the keyboard without a
+            // user gesture, so this places the caret and nothing more.
+            ..onReady((_) {
+              if (widget.autofocus) element?.focus();
+            });
     } else {
       WidgetsBinding.instance.addPostFrameCallback(
         (_) => _mountWhenConnected(),

--- a/packages/stripe_web/lib/src/widgets/card_field.dart
+++ b/packages/stripe_web/lib/src/widgets/card_field.dart
@@ -98,20 +98,24 @@ class WebStripeCardState extends State<WebCardField> with CardFieldContext {
   void _mountWhenConnected() {
     if (!mounted) return;
     if (_divElement.isConnected) {
-      element =
-          WebStripe.js
-              .elements(createElementOptions())
-              .createCard(createOptions())
-            ..mount(_divElement)
-            ..onChange(onCardChanged)
-            // Upstream declares [autofocus] but never acts on it. The iframe
-            // cannot take focus until Stripe reports it ready, so honour the
-            // flag from the ready event rather than straight after mount.
-            // Mobile browsers still refuse to raise the keyboard without a
-            // user gesture, so this places the caret and nothing more.
-            ..onReady((_) {
-              if (widget.autofocus) element?.focus();
-            });
+      // Keep a handle on the element THIS widget created: [element] is the
+      // shared WebStripe.element, which another Stripe widget mounted or
+      // disposed later may have replaced by the time the ready event fires.
+      final card = WebStripe.js
+          .elements(createElementOptions())
+          .createCard(createOptions());
+      card
+        ..mount(_divElement)
+        ..onChange(onCardChanged)
+        // Upstream declares [autofocus] but never acts on it. The iframe
+        // cannot take focus until Stripe reports it ready, so honour the
+        // flag from the ready event rather than straight after mount.
+        // Mobile browsers still refuse to raise the keyboard without a
+        // user gesture, so this places the caret and nothing more.
+        ..onReady((_) {
+          if (mounted && widget.autofocus) card.focus();
+        });
+      element = card;
     } else {
       WidgetsBinding.instance.addPostFrameCallback(
         (_) => _mountWhenConnected(),

--- a/packages/stripe_web/lib/src/widgets/express_checkout_element.dart
+++ b/packages/stripe_web/lib/src/widgets/express_checkout_element.dart
@@ -102,8 +102,6 @@ class ExpressCheckoutElementState extends State<ExpressCheckoutElement> {
             });
           }
         })
-        ..onBlur((_) => _effectiveNode.unfocus())
-        ..onFocus((_) => _effectiveNode.requestFocus())
         ..onConfirm(confirm);
     } else {
       WidgetsBinding.instance.addPostFrameCallback(
@@ -141,6 +139,11 @@ class ExpressCheckoutElementState extends State<ExpressCheckoutElement> {
   Widget build(BuildContext context) {
     return Focus(
       focusNode: _effectiveNode,
+      // Never take framework focus for the Stripe iframe: with semantics
+      // enabled the engine would move DOM focus to the flt-semantics element,
+      // blurring the iframe as soon as it is tapped (see card_field.dart).
+      canRequestFocus: false,
+      skipTraversal: true,
       child: ConstrainedBox(
         constraints: BoxConstraints(
           maxWidth: double.infinity,

--- a/packages/stripe_web/lib/src/widgets/payment_element.dart
+++ b/packages/stripe_web/lib/src/widgets/payment_element.dart
@@ -149,8 +149,6 @@ class PaymentElementState extends State<PaymentElement> {
             });
           }
         })
-        ..onBlur((_) => _effectiveNode.unfocus())
-        ..onFocus((_) => _effectiveNode.requestFocus())
         ..onChange(onCardChanged);
     } else {
       WidgetsBinding.instance.addPostFrameCallback(
@@ -206,8 +204,12 @@ class PaymentElementState extends State<PaymentElement> {
   @override
   Widget build(BuildContext context) {
     return Focus(
-      autofocus: true,
       focusNode: _effectiveNode,
+      // Never take framework focus for the Stripe iframe: with semantics
+      // enabled the engine would move DOM focus to the flt-semantics element,
+      // blurring the iframe as soon as it is tapped (see card_field.dart).
+      canRequestFocus: false,
+      skipTraversal: true,
       child: ConstrainedBox(
         constraints: BoxConstraints(
           maxWidth: double.infinity,

--- a/packages/stripe_web/lib/src/widgets/payment_element.dart
+++ b/packages/stripe_web/lib/src/widgets/payment_element.dart
@@ -133,7 +133,10 @@ class PaymentElementState extends State<PaymentElement> {
     if (!mounted) return;
     if (_divElement.isConnected) {
       elements = WebStripe.js.elements(_cachedCreateOptions);
-      element = elements!.createPayment(_cachedElementOptions)
+      // Same instance discipline as CardField: focus/measure the element this
+      // widget created, not whatever WebStripe.element points at later.
+      final payment = elements!.createPayment(_cachedElementOptions);
+      payment
         ..mount(_divElement)
         ..onReady((_) {
           final stripeEl = _divElement.firstElementChild;
@@ -147,9 +150,13 @@ class PaymentElementState extends State<PaymentElement> {
             setState(() {
               _isReady = true;
             });
+            // [autofocus] used to be a no-op here as well; honour it once
+            // Stripe reports the iframe ready (see card_field.dart).
+            if (widget.autofocus) payment.focus();
           }
         })
         ..onChange(onCardChanged);
+      element = payment;
     } else {
       WidgetsBinding.instance.addPostFrameCallback(
         (_) => _mountWhenConnected(),


### PR DESCRIPTION
-----
- [x] Have you followed the guidelines in our [Contributing](https://github.com/flutter-stripe/flutter_stripe/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/flutter-stripe/flutter_stripe/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Do all checks pass?
- [x] Have you developed the feature on the latest stable version of Flutter?
-----
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
-----

## Two web `CardField` fixes

### 1. `fix(web)`: stop mirroring the Stripe iframe's focus into the Flutter focus tree

`CardField`, `PaymentElement` and `ExpressCheckoutElement` on web wire the Stripe element's `onFocus`/`onBlur` to `FocusNode.requestFocus()` / `unfocus()`. Whenever the semantics tree is active — `SemanticsBinding.ensureSemantics()`, a screen reader, or any app that enables semantics for testing — focusing that node makes the engine move **DOM focus** onto the node's `flt-semantics` element, which blurs the Stripe iframe ~10 ms after every tap. The card field becomes untypeable: the caret flashes and disappears.

The fix removes the mirror and marks the wrapping `Focus` `canRequestFocus: false, skipTraversal: true`. The iframe owns its own DOM focus; the framework should never contend for it. Traversal was not meaningful for a cross-origin iframe in the first place.

### 2. `feat(web)`: honour `CardField.autofocus`

The web `CardField` declares `autofocus` and never acts on it. It now calls `element.focus()` from the element's `ready` event (the iframe cannot take focus before it reports ready), the same way `payment_element.dart` and `express_checkout_element.dart` already hang their post-mount work off `onReady`. Mobile browsers still refuse to raise the soft keyboard without a user gesture, so on phones this places the caret only; desktop focuses fully.

## Verification

Manually, on a production app built against this branch (Flutter 3.44.0):
- Chrome desktop and Android Chrome, iOS Safari — card entry with semantics **enabled** (`ENABLE_SEMANTICS` dart-define calling `ensureSemantics`): typing works in number, expiry and CVC; previously untypeable.
- Same with semantics disabled: unchanged.
- `autofocus: true`: desktop Chrome focuses the number field on load; iOS Safari places the caret; Android Chrome places the caret and Chrome retracts the keyboard (browser gesture policy, expected).
- `flutter analyze` clean for `stripe_web`.

## AI disclosure

The diagnosis and patches were developed with an AI coding assistant (Claude Code). All behaviour above was verified by hand on real devices and browsers by the author; the semantics-focus failure was reproduced and confirmed fixed on device before and after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QapcPohD4yibyfT5reG9jM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved focus behavior for Stripe card, express checkout, and payment elements.
  - Prevented framework focus traversal from disrupting interaction with embedded payment fields.
  - Preserved card field autofocus by applying focus after the embedded field is ready.
  - Restored autofocus for payment elements when enabled.
  - Prevented focus from being applied to outdated or replaced embedded elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->